### PR TITLE
Add UserPromptSubmit hook for auto-loading project instructions

### DIFF
--- a/.claude/hooks/hook_load_claude_md.py
+++ b/.claude/hooks/hook_load_claude_md.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: Read CLAUDE.md or AGENTS.md from project directory and inject as context at each prompt.
+"""
+import json
+import sys
+import os
+from pathlib import Path
+
+def find_claude_md(project_dir):
+    """Find CLAUDE.md or AGENTS.md in the project directory."""
+    claude_md = Path(project_dir) / "CLAUDE.md"
+    agents_md = Path(project_dir) / "AGENTS.md"
+
+    if claude_md.exists():
+        return claude_md
+    elif agents_md.exists():
+        return agents_md
+    return None
+
+try:
+    input_data = json.load(sys.stdin)
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", input_data.get("cwd", ""))
+
+    if not project_dir:
+        sys.exit(0)
+
+    claude_md_path = find_claude_md(project_dir)
+
+    if not claude_md_path:
+        sys.exit(0)
+
+    # Read CLAUDE.md content
+    try:
+        with open(claude_md_path, 'r', encoding='utf-8') as f:
+            content = f.read().strip()
+
+        if not content:
+            sys.exit(0)
+
+        # Output the content to be added as context
+        print(f"Project instructions from {claude_md_path.name}:\n\n{content}")
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"Error reading {claude_md_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+except Exception as e:
+    print(f"hook-error: {e}", file=sys.stderr)
+    sys.exit(1)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "model": "opusplan",
   "includeCoAuthoredBy": false,
   "env": {
@@ -6,7 +7,7 @@
     "DISABLE_BUG_COMMAND": "1",
     "DISABLE_ERROR_REPORTING": "1",
     "DISABLE_TELEMETRY": "1",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-1-20250805",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-sonnet-4-5-20250929",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-5-20250929",
     "MAX_MCP_OUTPUT_TOKENS": "40000"
   },
@@ -124,6 +125,16 @@
           {
             "type": "command",
             "command": ".claude/hooks/hook_bash_formatting.py"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/hook_load_claude_md.py"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -206,5 +206,5 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
-# claude-memory
-CLAUDE-*
+# other
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ OpenAI Codex compatible version of MCP server configurations can be found in [`~
 
 Claude Code configuration is stored in [`.claude/settings.json`](./.claude/settings.json) and includes:
 
-- Model selection (currently using OpusPlan with claude-opus-4-1-20250805 and Sonnet with claude-sonnet-4-5-20250929 - see [model configuration docs](https://docs.anthropic.com/en/docs/claude-code/model-config#opusplan-model-setting))
+- Model selection (currently using OpusPlan with claude-sonnet-4-5-20250929 - see [model configuration docs](https://docs.anthropic.com/en/docs/claude-code/model-config#opusplan-model-setting))
 - Environment variables for optimal Claude Code behavior
 - Settings for disabling telemetry and non-essential features
 - Custom hooks for enhancing tool functionality
@@ -142,6 +142,12 @@ Make hook scripts executable after cloning:
 ```bash
 chmod +x ./.claude/hooks/*.py
 ```
+
+### Context Management Hooks
+
+These hooks ensure Claude always has access to project-specific instructions by automatically loading them on each prompt.
+
+- **[hook_load_claude_md.py](./.claude/hooks/hook_load_claude_md.py)**: Auto-loads CLAUDE.md or AGENTS.md from the project directory on every user prompt. Prevents AI from forgetting main instructions by re-injecting them at every prompt submission.
 
 ### Web Content Enhancement Hooks
 


### PR DESCRIPTION
## Summary

Implements a new UserPromptSubmit hook that automatically loads CLAUDE.md or AGENTS.md context on every user prompt, preventing AI from forgetting project instructions. Also updates OpusPlan model configuration.

## Changes

- Add [hook_load_claude_md.py](./.claude/hooks/hook_load_claude_md.py) to auto-inject project instructions at every prompt submission
- Update OpusPlan model: claude-opus-4-1-20250805 → claude-sonnet-4-5-20250929 ([source](https://www.anthropic.com/news/claude-sonnet-4-5))
- Add JSON schema reference to settings.json for better IDE support
- Update .gitignore to exclude .DS_Store files
- Document new context management hook in [README.md](./README.md#context-management-hooks)