### PR TITLE
style: remove trailing whitespace from hook files

### DIFF
--- a/.claude/hooks/hook_bash_formatting.py
+++ b/.claude/hooks/hook_bash_formatting.py
@@ -12,31 +12,31 @@ def main():
     try:
         data = json.load(sys.stdin)
         file_path = data.get("tool_input", {}).get("file_path", "")
-        
+
         if not file_path.endswith(('.sh', '.bash')):
             sys.exit(0)
-            
+
         sh_file = Path(file_path)
         if not sh_file.exists():
             sys.exit(0)
-            
+
         # Check if npx is available
         if not shutil.which('npx'):
             sys.exit(0)
-            
+
         # Try prettier with prettier-plugin-sh, handle any failure gracefully
         try:
             subprocess.run([
                 'npx', 'prettier', '--write', 
-                f'--plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs',
+                '--plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs',
                 str(sh_file)
             ], shell=True, capture_output=True, check=False, cwd=sh_file.parent, timeout=10)
         except:
             pass  # Silently handle any failure (missing plugin, timeout, etc.)
-        
+
     except Exception:
         pass
-    
+
     sys.exit(0)
 
 if __name__ == "__main__":

--- a/.claude/hooks/hook_prettier_formatting.py
+++ b/.claude/hooks/hook_prettier_formatting.py
@@ -16,31 +16,31 @@ def main():
     try:
         data = json.load(sys.stdin)
         file_path = data.get("tool_input", {}).get("file_path", "")
-        
+
         if not file_path:
             sys.exit(0)
-            
+
         py_file = Path(file_path)
         if not py_file.exists() or py_file.suffix not in PRETTIER_EXTENSIONS:
             sys.exit(0)
-            
+
         # Skip lock files and model.json
         if ('lock' in py_file.name.lower() or 
             py_file.name == 'model.json'):
             sys.exit(0)
-            
+
         # Check if prettier is available
         if not shutil.which('npx'):
             sys.exit(0)
-            
+
         # Run prettier
         subprocess.run([
             'npx', 'prettier', '--write', str(py_file)
         ], capture_output=True, check=False, cwd=py_file.parent)
-        
+
     except Exception:
         pass
-    
+
     sys.exit(0)
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Clean up trailing spaces in hook_bash_formatting.py
- Clean up trailing spaces in hook_prettier_formatting.py