### PR TITLE
feat: add Claude Code plugin marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,143 @@
+{
+  "name": "fcakyon-claude-plugins",
+  "owner": {
+    "name": "Fatih Akyon",
+    "email": "[email protected]"
+  },
+  "metadata": {
+    "description": "Battle-tested Claude Code plugin collection: auto-formatting, Git workflow agents, pattern analysis, productivity commands, and 100+ MCP tools.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "code-quality-hooks",
+      "source": "./",
+      "description": "Auto-formatting system for Python, JavaScript, TypeScript, CSS, JSON, YAML, HTML, Markdown, and Shell scripts. Eliminates formatting debates and reduces CI failures.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#code-quality-hooks",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "MIT",
+      "keywords": [
+        "formatting",
+        "linting",
+        "python-ruff",
+        "prettier",
+        "markdown",
+        "code-style",
+        "auto-fix",
+        "pre-commit"
+      ],
+      "category": "productivity",
+      "tags": ["formatting", "automation", "quality"],
+      "hooks": "./.claude/hooks/hooks.json"
+    },
+    {
+      "name": "git-workflow-agents",
+      "source": "./",
+      "description": "Intelligent Git automation agents: commit-manager analyzes staged changes across multiple commits, pr-manager creates PRs with README sync and proper formatting.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#agents",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "MIT",
+      "keywords": [
+        "git",
+        "commit",
+        "pull-request",
+        "pr",
+        "github",
+        "workflow",
+        "changelog",
+        "semantic-versioning"
+      ],
+      "category": "development",
+      "tags": ["git", "automation", "workflow"],
+      "agents": [
+        "./.claude/agents/commit-manager.md",
+        "./.claude/agents/pr-manager.md"
+      ]
+    },
+    {
+      "name": "code-simplifier-agent",
+      "source": "./",
+      "description": "Auto-triggers after TodoWrite to ensure new code follows existing project patterns for imports, naming, function signatures, and base classes. Maintains codebase consistency.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#agents",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "MIT",
+      "keywords": [
+        "code-patterns",
+        "consistency",
+        "refactoring",
+        "imports",
+        "naming-conventions",
+        "best-practices",
+        "code-review"
+      ],
+      "category": "development",
+      "tags": ["analysis", "patterns", "quality"],
+      "agents": ["./.claude/agents/code-simplifier.md"]
+    },
+    {
+      "name": "productivity-commands",
+      "source": "./",
+      "description": "Custom slash commands: /pr-summary for changelog generation, /commit for automated commits, /arch for pattern explanations, /think for enhanced reasoning.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#commands",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "MIT",
+      "keywords": [
+        "commands",
+        "shortcuts",
+        "slash-commands",
+        "productivity",
+        "cli",
+        "automation",
+        "templates"
+      ],
+      "category": "productivity",
+      "tags": ["commands", "productivity", "shortcuts"],
+      "commands": ["./.claude/commands/"]
+    },
+    {
+      "name": "mcp-server-configs",
+      "source": "./",
+      "description": "Pre-configured MCP servers: Azure (100+ tools), Context7 (20K+ library docs), GitHub, Linear, MongoDB, Playwright, Slack, Supabase, Tavily (web search).",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#mcp-servers",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "MIT",
+      "keywords": [
+        "mcp",
+        "servers",
+        "integration",
+        "azure",
+        "github",
+        "mongodb",
+        "playwright",
+        "slack",
+        "supabase",
+        "tavily",
+        "context7",
+        "linear"
+      ],
+      "category": "tools",
+      "tags": ["mcp", "integration", "tools"],
+      "mcpServers": "./mcp.json"
+    }
+  ]
+}

--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -1,0 +1,67 @@
+{
+  "PreToolUse": [
+    {
+      "matcher": "WebFetch",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/hook_webfetch_to_tavily_extract.py"
+        }
+      ]
+    },
+    {
+      "matcher": "mcp__tavily__tavily-extract",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/hook_tavily_extract_to_advanced.py"
+        }
+      ]
+    },
+    {
+      "matcher": "WebSearch",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/hook_websearch_to_tavily_search.py"
+        }
+      ]
+    },
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/hook_enforce_rg_over_grep.py"
+        }
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "Edit|MultiEdit|Write|Task",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); if [[ -n \"$file_path\" && -f \"$file_path\" ]]; then case \"$file_path\" in *.py|*.js|*.jsx|*.ts|*.tsx) if [[ \"$OSTYPE\" == \"darwin\"* ]]; then sed -i '' 's/^[[:space:]]*$//g' \"$file_path\" 2>/dev/null || true; else sed -i 's/^[[:space:]]*$//g' \"$file_path\" 2>/dev/null || true; fi ;; esac; fi"
+        },
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/hook_python_code_quality.py"
+        },
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/hook_prettier_formatting.py"
+        },
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/hook_markdown_formatting.py"
+        },
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/hook_bash_formatting.py"
+        }
+      ]
+    }
+  ]
+}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,8 @@
 # Installation Guide
 
-Complete setup instructions for Claude Code, OpenAI Codex, and all dependencies.
+Complete installation guide for Claude Code, dependencies, and this configuration.
+
+> **Prefer easier setup?** Use the [plugin marketplace](README.md#installation) to install agents/commands/hooks/MCP. You'll still need to complete prerequisites and create the AGENTS.md symlink.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,91 @@ My personal Claude [Code](https://github.com/anthropics/claude-code)/[Desktop](h
 
 ## Installation
 
-For complete installation instructions, see [INSTALL.md](INSTALL.md).
+### 1. Prerequisites (Required)
+
+Install Claude Code and dependencies:
+
+```bash
+# Install Node.js
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+nvm install 22
+
+# Install Claude Code
+npm install -g @anthropic-ai/claude-code
+
+# Install required tools
+brew install jq gh # macOS
+# OR apt-get install jq gh  # Ubuntu
+
+# Install code quality tools (required for hooks to work)
+pip install ruff docformatter
+npm install -g prettier@3.6.2 prettier-plugin-sh
+```
+
+See [INSTALL.md](INSTALL.md#prerequisites) for detailed prerequisite setup.
+
+---
+
+### 2. Install Configuration
+
+**Option A: Plugin Marketplace**
+
+Install agents, commands, hooks, and MCP servers via plugin system:
+
+```bash
+# Add marketplace
+/plugin marketplace add fcakyon/claude-codex-settings
+
+# Install plugins
+/plugin install code-quality-hooks@fcakyon-claude-plugins
+/plugin install git-workflow-agents@fcakyon-claude-plugins
+/plugin install code-simplifier-agent@fcakyon-claude-plugins
+/plugin install productivity-commands@fcakyon-claude-plugins
+/plugin install mcp-server-configs@fcakyon-claude-plugins
+```
+
+Then create symlink for cross-tool compatibility:
+
+```bash
+ln -s ~/.claude/CLAUDE.md ~/.claude/AGENTS.md
+```
+
+Restart Claude Code to activate.
+
+**Option B: Manual Clone**
+
+<details>
+<summary>Click to expand manual installation</summary>
+
+```bash
+# Clone repository
+git clone https://github.com/fcakyon/claude-settings.git ~/.claude-settings
+
+# Copy configuration files
+cp -r ~/.claude-settings/.claude/* ~/.claude/
+
+# Create symlink
+ln -s ~/.claude/CLAUDE.md ~/.claude/AGENTS.md
+
+# Make hooks executable
+chmod +x ~/.claude/hooks/*.py
+```
+
+See [INSTALL.md](INSTALL.md) for complete manual setup guide.
+
+</details>
+
+## Available Plugins
+
+| Plugin                    | Description                        | Installation                                                   |
+| ------------------------- | ---------------------------------- | -------------------------------------------------------------- |
+| **code-quality-hooks**    | Auto-formatting for 8+ languages   | `/plugin install code-quality-hooks@fcakyon-claude-plugins`    |
+| **git-workflow-agents**   | commit-manager + pr-manager agents | `/plugin install git-workflow-agents@fcakyon-claude-plugins`   |
+| **code-simplifier-agent** | Pattern consistency enforcer       | `/plugin install code-simplifier-agent@fcakyon-claude-plugins` |
+| **productivity-commands** | Custom slash commands              | `/plugin install productivity-commands@fcakyon-claude-plugins` |
+| **mcp-server-configs**    | 9 pre-configured MCP servers       | `/plugin install mcp-server-configs@fcakyon-claude-plugins`    |
+
+---
 
 ## Configuration
 
@@ -30,7 +114,28 @@ VSCode settings are stored in [`.vscode/settings.json`](./.vscode/settings.json)
 
 ## MCP Servers
 
-The MCP (Model Context Protocol) configuration lives in [`mcp.json`](./mcp.json). These are some solid MCP server repos worth checking out:
+The MCP (Model Context Protocol) configuration lives in [`mcp.json`](./mcp.json).
+
+### Installation
+
+**Plugin-based:**
+
+```bash
+/plugin install mcp-server-configs@fcakyon-claude-plugins
+```
+
+<details>
+<summary><b>Manual Installation</b></summary>
+
+Copy [`mcp.json`](./mcp.json) to your project root named as `.mcp.json` and adjust MCP servers.
+
+</details>
+
+---
+
+### Available MCP Servers
+
+These are some solid MCP server repos worth checking out:
 
 - [Azure MCP](https://github.com/Azure/azure-mcp) - 40+ Azure tools (100% free)
 - [Context7](https://github.com/upstash/context7) - Up-to-date documentation context for 20K+ libraries (100% free)
@@ -49,6 +154,24 @@ OpenAI Codex compatible version of MCP server configurations can be found in [`~
 
 Specialized agents that run automatically to enhance code quality, stored in [`.claude/agents/`](./.claude/agents/):
 
+### Installation
+
+**Plugin-based:**
+
+```bash
+/plugin install git-workflow-agents@fcakyon-claude-plugins
+/plugin install code-simplifier-agent@fcakyon-claude-plugins
+```
+
+<details>
+<summary><b>Manual Installation</b></summary>
+
+Copy agents from [`.claude/agents/`](./.claude/agents/) to your project's `.claude/agents/` directory.
+
+</details>
+
+---
+
 - [`code-simplifier.md`](./.claude/agents/code-simplifier.md) - Contextual pattern analyzer that ensures new code follows existing project conventions (imports, naming, function signatures, class patterns). Auto-triggers after TodoWrite to maintain codebase consistency.
 
 - [`commit-manager.md`](./.claude/agents/commit-manager.md) - Git commit expert that analyzes staged changes, creates optimal commit strategies, and executes commits with meaningful messages. Handles documentation updates and multi-commit scenarios.
@@ -60,6 +183,28 @@ For more details, see the [Claude Code sub-agents documentation](https://docs.an
 ## Hooks
 
 Custom hooks that enhance tool usage, configured in [`.claude/settings.json`](./.claude/settings.json):
+
+### Installation
+
+**Plugin-based:**
+
+```bash
+/plugin install code-quality-hooks@fcakyon-claude-plugins
+```
+
+<details>
+<summary><b>Manual Installation</b></summary>
+
+1. Copy hooks from [`.claude/hooks/`](./.claude/hooks/) to your project
+2. Copy hook configuration from [`.claude/settings.json`](./.claude/settings.json)
+3. Make scripts executable:
+   ```bash
+   chmod +x ./.claude/hooks/*.py
+   ```
+
+</details>
+
+---
 
 ### Setup
 
@@ -121,6 +266,23 @@ For more details, see the [Claude Code hooks documentation](https://docs.anthrop
 ## Commands
 
 Custom Claude Code slash commands that make life easier, stored in [`.claude/commands/`](./.claude/commands/):
+
+### Installation
+
+**Plugin-based:**
+
+```bash
+/plugin install productivity-commands@fcakyon-claude-plugins
+```
+
+<details>
+<summary><b>Manual Installation</b></summary>
+
+Copy commands from [`.claude/commands/`](./.claude/commands/) to your project's `.claude/commands/` directory.
+
+</details>
+
+---
 
 - [`/commit-staged`](./.claude/commands/commit-staged.md) - Commit staged changes using the commit-manager agent with optional context
 - [`/create-pr`](./.claude/commands/create-pr.md) - Create pull request using the pr-manager agent with optional context


### PR DESCRIPTION
Add plugin marketplace configuration to enable one-command installation of agents, commands, hooks, and MCP servers.

- Add [.claude-plugin/marketplace.json](.claude-plugin/marketplace.json) with 5 curated plugins:
  - `code-quality-hooks`: Auto-formatting for 8+ languages
  - `git-workflow-agents`: commit-manager + pr-manager agents
  - `code-simplifier-agent`: Pattern consistency enforcer
  - `productivity-commands`: Custom slash commands
  - `mcp-server-configs`: 9 pre-configured MCP servers
- Create centralized [.claude/hooks/hooks.json](.claude/hooks/hooks.json) for hook configurations (referenced by all plugins)
- Update [README.md](README.md) with 2-step installation flow:
  - Step 1: Prerequisites (Claude Code, Node.js, tools)
  - Step 2: Plugin marketplace (Option A) or Manual clone (Option B)
- Add "Available Plugins" reference table with quick install commands
- Reorganize MCP Servers, Agents, Hooks, Commands sections with plugin-based installation
- Update [INSTALL.md](INSTALL.md#L1-L5) header to clarify plugin marketplace scope

**Installation Example:**

```bash
# Add marketplace
/plugin marketplace add fcakyon/claude-codex-settings

# Install all plugins
/plugin install code-quality-hooks@fcakyon-claude-plugins
/plugin install git-workflow-agents@fcakyon-claude-plugins
/plugin install code-simplifier-agent@fcakyon-claude-plugins
/plugin install productivity-commands@fcakyon-claude-plugins
/plugin install mcp-server-configs@fcakyon-claude-plugins
```