### PR TITLE
refactor: pin ccusage to latest version in statusline

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -155,7 +155,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "npx -y ccusage statusline",
+    "command": "npx -y ccusage@latest statusline",
     "padding": 0
   }
 }


### PR DESCRIPTION
Use `@latest` version specifier for ccusage package in statusline command

- Update statusline command: `npx -y ccusage statusline` → `npx -y ccusage@latest statusline` in [.claude/settings.json:158](.claude/settings.json#L158)
- Ensures statusline always uses the most recent ccusage version