### PR TITLE
docs: add Context7 and plugin badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # claude-codex-settings
 
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blue)](#available-plugins)
+[![Context7 MCP](https://img.shields.io/badge/Context7%20MCP-Indexed-blue)](https://context7.com/fcakyon/claude-codex-settings)
+[![llms.txt](https://img.shields.io/badge/llms.txt-✓-brightgreen)](https://context7.com/fcakyon/claude-codex-settings/llms.txt)
+
 My personal Claude [Code](https://github.com/anthropics/claude-code)/[Desktop](https://claude.ai/download) and [OpenAI Codex](https://developers.openai.com/codex) setup with battle-tested commands and MCP servers that I use daily.
 
 [Installation](INSTALL.md) • [Configuration](#configuration) • [MCP Servers](#mcp-servers) • [Agents](#agents) • [Hooks](#hooks) • [Commands](#commands) • [Statusline](#statusline)


### PR DESCRIPTION
Add visibility badges for Context7 integration and Claude Code plugin marketplace.

- Add Claude Code Plugin badge linking to [Available Plugins](#available-plugins) section
- Add Context7 MCP Indexed badge linking to [Context7 repository page](https://context7.com/fcakyon/claude-codex-settings)
- Add llms.txt badge for [llms.txt file](https://context7.com/fcakyon/claude-codex-settings/llms.txt)