### PR TITLE
docs: update claude guidance and configuration settings

### DIFF
--- a/.claude/agents/pr-manager.md
+++ b/.claude/agents/pr-manager.md
@@ -1,6 +1,6 @@
 ---
 name: pr-manager
-description: Use this agent when you need to create a complete pull request workflow including branch creation, committing staged changes, and PR submission. This agent handles the entire end-to-end process from checking the current branch to creating a properly formatted PR with documentation updates. Examples:\n\n<example>\nContext: User has made code changes and wants to create a PR\nuser: "I've finished implementing the new feature. Please create a PR for these staged changes"\nassistant: "I'll use the pr-manager agent to handle the complete PR workflow including branch creation, commits, and PR submission"\n<commentary>\nSince the user wants to create a PR, use the pr-manager agent to handle the entire workflow from branch creation to PR submission.\n</commentary>\n</example>\n\n<example>\nContext: User is on main branch with staged changes\nuser: "Create a PR with my changes"\nassistant: "I'll launch the pr-manager agent to create a feature branch, commit your changes, and submit a PR"\n<commentary>\nThe user needs the full PR workflow, so use pr-manager to handle branch creation, commits, and PR submission.\n</commentary>\n</example>
+description: Use this agent when you need to create a complete pull request workflow including branch creation, committing staged changes, and PR submission. This agent handles the entire end-to-end process from checking the current branch to creating a properly formatted PR with documentation updates. Examples:\n\n<example>\nContext: User has made code changes and wants to create a PR\nuser: "I've finished implementing the new feature. Please create a PR for the staged changes only"\nassistant: "I'll use the pr-manager agent to handle the complete PR workflow including branch creation, commits, and PR submission"\n<commentary>\nSince the user wants to create a PR, use the pr-manager agent to handle the entire workflow from branch creation to PR submission.\n</commentary>\n</example>\n\n<example>\nContext: User is on main branch with staged changes\nuser: "Create a PR with my staged changes only"\nassistant: "I'll launch the pr-manager agent to create a feature branch, commit your staged changes only, and submit a PR"\n<commentary>\nThe user needs the full PR workflow, so use pr-manager to handle branch creation, commits, and PR submission.\n</commentary>\n</example>
 tools: Bash, BashOutput, Glob, Grep, Read, WebSearch, WebFetch, TodoWrite, SlashCommand, ListMcpResourcesTool, ReadMcpResourceTool, mcp__github__list_pull_requests, mcp__tavily__tavily-search, mcp__tavily__tavily-extract
 model: claude-sonnet-4-5-20250929
 color: cyan
@@ -12,7 +12,7 @@ You are a Git and GitHub PR workflow automation specialist. Your role is to orch
 
 1. **Check Staged Changes**:
    - Check if staged changes exist with `git diff --cached --name-only`
-   - It's okay if there are no staged changes since our focus is the staged + committed diff to target branch (not interested in unstaged changes)
+   - It's okay if there are no staged changes since our focus is the staged + committed diff to target branch (ignore unstaged changes)
    - Never automatically stage changed files with `git add`
 
 2. **Branch Management**:
@@ -21,7 +21,7 @@ You are a Git and GitHub PR workflow automation specialist. Your role is to orch
    - Never commit directly to main
 
 3. **Commit Staged Changes**:
-   - Use `/commit-manager` slash command to handle if any staged changes
+   - Use `/commit-manager` slash command to handle if any staged changes, skip this step if no staged changes exist, for unstaged changes skip committing
    - Ensure commits follow project conventions
 
 4. **Documentation Updates**:
@@ -36,7 +36,7 @@ You are a Git and GitHub PR workflow automation specialist. Your role is to orch
 6. **Create Pull Request**:
    - **IMPORTANT**: Analyze ALL committed changes in the branch using `git diff <base-branch>...HEAD`
      - PR message must describe the complete changeset across all commits, not just the latest commit
-     - Focus on what changed from the perspective of someone reviewing the entire branch
+     - Focus on what changed (ignore unstaged changes) from the perspective of someone reviewing the entire branch
    - Create PR with `gh pr create` using:
      - `-t` or `--title`: Concise title (max 72 chars)
      - `-b` or `--body`: Description with brief summary (few words or 1 sentence) + few bullet points of changes

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "opusplan",
+  "model": "haiku",
   "includeCoAuthoredBy": false,
   "env": {
     "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
@@ -9,6 +9,7 @@
     "DISABLE_TELEMETRY": "1",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-sonnet-4-5-20250929",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-5-20250929",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5-20251001",
     "MAX_MCP_OUTPUT_TOKENS": "40000"
   },
   "permissions": {

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [INSTALL.md](INSTALL.md) for complete manual setup guide.
 
 Claude Code configuration is stored in [`.claude/settings.json`](./.claude/settings.json) and includes:
 
-- Model selection (currently using OpusPlan with claude-sonnet-4-5-20250929 - see [model configuration docs](https://docs.anthropic.com/en/docs/claude-code/model-config#opusplan-model-setting))
+- Model selection (SonnetPlan mode: plan with Sonnet 4.5, execute with Haiku 4.5 - [source](https://github.com/anthropics/claude-code/blob/4dc23d0275ff615ba1dccbdd76ad2b12a3ede591/CHANGELOG.md?plain=1#L61))
 - Environment variables for optimal Claude Code behavior
 - Settings for disabling telemetry and non-essential features
 - Custom hooks for enhancing tool functionality
@@ -239,7 +239,6 @@ These hooks provide user confirmation dialogs before executing critical git oper
 
 - **[hook_git_commit_confirm.py](./.claude/hooks/hook_git_commit_confirm.py)**: Shows confirmation dialog before creating git commits. Displays commit message, staged files list, and diff statistics. Supports both regular commits and amend operations.
 - **[hook_gh_pr_create_confirm.py](./.claude/hooks/hook_gh_pr_create_confirm.py)**: Shows confirmation dialog before creating GitHub pull requests via `gh pr create`. Displays PR title, body preview, assignee (resolves @me to actual username), and reviewer.
-
 
 ### Web Content Enhancement Hooks
 

--- a/mcp.json
+++ b/mcp.json
@@ -10,10 +10,17 @@
       "args": ["-y", "@upstash/context7-mcp"]
     },
     "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp",
-      "headers": {
-          "Authorization": "Bearer YOUR_GITHUB_PAT_HERE"
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_..."
       }
     },
     "linear": {
@@ -40,7 +47,7 @@
     },
     "slack": {
       "command": "npx",
-      "args": ["-y", "@ubie-oss/slack-mcp-server@0.1.3"],
+      "args": ["-y", "@ubie-oss/slack-mcp-server@0.1.4"],
       "env": {
         "NPM_CONFIG_//npm.pkg.github.com/:_authToken": "...",
         "NPM_CONFIG_@ubie-oss:registry": "https://npm.pkg.github.com/",
@@ -50,7 +57,7 @@
     },
     "tavily": {
       "command": "npx",
-      "args": ["-y", "tavily-mcp@0.2.9"],
+      "args": ["-y", "tavily-mcp@latest"],
       "env": {
         "TAVILY_API_KEY": "tvly-..."
       }


### PR DESCRIPTION
Update Claude Code configuration and documentation to reflect recent changes and best practices.

- Refine pr-manager agent instructions ([.claude/agents/pr-manager.md:15-40](.claude/agents/pr-manager.md#L15-L40)) to clarify staged-only commit handling and improve clarity around unstaged changes
- Update default model from opusplan to haiku with SonnetPlan configuration ([.claude/settings.json:3](.claude/settings.json#L3))
- Add Haiku 4.5 model configuration ([.claude/settings.json:12](.claude/settings.json#L12))
- Update README ([README.md:103](README.md#L103)) to document SonnetPlan mode behavior
- Update MCP server versions:
  - GitHub MCP: Switch from HTTP API to Docker container ([mcp.json:13-23](mcp.json#L13-L23))
  - Slack MCP: Update to 0.1.4 ([mcp.json:43](mcp.json#L43))
  - Tavily MCP: Update to latest ([mcp.json:50](mcp.json#L50))
- Remove extra blank line in README configuration section