### PR TITLE
docs: migrate installation to Claude Code native installer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,25 +6,44 @@ Complete installation guide for Claude Code, dependencies, and this configuratio
 
 ## Prerequisites
 
-### Node.js and nvm
+### Claude Code
 
-Install nvm and Node.js (v22+ recommended):
+Install Claude Code using the native installer (no Node.js required):
 
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-\. "$HOME/.nvm/nvm.sh"
-nvm install 22
-node -v     # Should print "v22.17.1".
-nvm current # Should print "v22.17.1".
-```
-
-### Claude Code and OpenAI Codex
-
-Install Claude Code:
+**macOS/Linux/WSL:**
 
 ```bash
-npm install -g @anthropic-ai/claude-code
+# Install via native installer
+curl -fsSL https://claude.ai/install.sh | bash
+
+# Or via Homebrew
+brew install --cask claude-code
+
+# Verify installation
+claude --version
 ```
+
+**Windows PowerShell:**
+
+```powershell
+# Install via native installer
+irm https://claude.ai/install.ps1 | iex
+
+# Verify installation
+claude --version
+```
+
+**Migrate from legacy npm installation:**
+
+```bash
+claude install
+```
+
+Optionally install IDE extension:
+
+- [Claude Code VSCode extension](https://docs.claude.com/en/docs/claude-code/vs-code) for IDE integration
+
+### OpenAI Codex
 
 Install OpenAI Codex:
 
@@ -32,10 +51,9 @@ Install OpenAI Codex:
 npm install -g @openai/codex
 ```
 
-Optionally install IDE extensions:
+Optionally install IDE extension:
 
-- [Claude Code VSCode extension](https://docs.claude.com/en/docs/claude-code/vs-code) for 100% IDE integration
-- [Codex VSCode extension](https://developers.openai.com/codex/ide) for 100% IDE integration
+- [Codex VSCode extension](https://developers.openai.com/codex/ide) for IDE integration
 
 ### Required Tools
 
@@ -90,6 +108,7 @@ sudo apt-get install gh
 pip install ruff docformatter
 
 # Prettier for JS/TS/CSS/JSON/YAML/HTML/Markdown/Shell formatting (required for prettier hooks)
+# Note: npm is required for prettier even though Claude Code no longer needs it
 npm install -g prettier@3.6.2 prettier-plugin-sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,26 +12,46 @@ My personal Claude [Code](https://github.com/anthropics/claude-code)/[Desktop](h
 
 ### 1. Prerequisites (Required)
 
-Install Claude Code and dependencies:
+Install Claude Code using the native installer:
+
+**macOS/Linux/WSL:**
 
 ```bash
-# Install Node.js
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-nvm install 22
+# Install Claude Code (no Node.js required)
+curl -fsSL https://claude.ai/install.sh | bash
 
-# Install Claude Code
-npm install -g @anthropic-ai/claude-code
+# Or via Homebrew
+brew install --cask claude-code
+```
 
-# Install required tools
+**Windows PowerShell:**
+
+```powershell
+# Install Claude Code (no Node.js required)
+irm https://claude.ai/install.ps1 | iex
+```
+
+**Migrate from legacy npm installation:**
+
+```bash
+claude install
+```
+
+**Install required tools:**
+
+```bash
 brew install jq gh # macOS
 # OR apt-get install jq gh  # Ubuntu
+```
 
-# Install code quality tools (required for hooks to work)
+**Install code quality tools (required for hooks to work):**
+
+```bash
 pip install ruff docformatter
 npm install -g prettier@3.6.2 prettier-plugin-sh
 ```
 
-See [INSTALL.md](INSTALL.md#prerequisites) for detailed prerequisite setup.
+See [INSTALL.md](INSTALL.md#prerequisites) for detailed setup (note: may contain outdated npm instructions).
 
 ---
 
@@ -74,7 +94,7 @@ git clone https://github.com/fcakyon/claude-settings.git ~/.claude-settings
 cp -r ~/.claude-settings/.claude/* ~/.claude/
 
 # Create symlink
-ln -s ~/.claude/CLAUDE.md ~/.claude/AGENTS.md
+ln -s CLAUDE.md AGENTS.md
 
 # Make hooks executable
 chmod +x ~/.claude/hooks/*.py


### PR DESCRIPTION
Replace npm-based installation with Claude Code native installer across documentation.

- Add platform-specific installation commands for macOS/Linux/WSL, Windows, and Homebrew ([source](https://docs.claude.com/en/docs/claude-code/setup))
- Include migration path for users on legacy npm installation
- Update symlink command in [README.md:97](README.md#L97) to use relative paths
- Clarify npm still required for prettier in [INSTALL.md:111](INSTALL.md#L111)
- Remove Node.js/nvm installation instructions
- Reorganize installation steps for better clarity

The native installer was released in late October 2025 and no longer requires Node.js to be pre-installed.