### PR TITLE
refactor: migrate from inline hooks to plugin system

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,94 +73,15 @@
       "mcp__supabase__list_tables"
     ]
   },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "WebFetch",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/webfetch_to_tavily_extract.py"
-          }
-        ]
-      },
-      {
-        "matcher": "mcp__tavily__tavily-extract",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/tavily_extract_to_advanced.py"
-          }
-        ]
-      },
-      {
-        "matcher": "WebSearch",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/websearch_to_tavily_search.py"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/enforce_rg_over_grep.py"
-          },
-          {
-            "type": "command",
-            "command": ".claude/hooks/git_commit_confirm.py"
-          },
-          {
-            "type": "command",
-            "command": ".claude/hooks/gh_pr_create_confirm.py"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Edit|MultiEdit|Write|Task",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); if [[ -n \"$file_path\" && -f \"$file_path\" ]]; then case \"$file_path\" in *.py|*.js|*.jsx|*.ts|*.tsx) if [[ \"$OSTYPE\" == \"darwin\"* ]]; then sed -i '' 's/^[[:space:]]*$//g' \"$file_path\" 2>/dev/null || true; else sed -i 's/^[[:space:]]*$//g' \"$file_path\" 2>/dev/null || true; fi ;; esac; fi"
-          },
-          {
-            "type": "command",
-            "command": ".claude/hooks/python_code_quality.py"
-          },
-          {
-            "type": "command",
-            "command": ".claude/hooks/prettier_formatting.py"
-          },
-          {
-            "type": "command",
-            "command": ".claude/hooks/markdown_formatting.py"
-          },
-          {
-            "type": "command",
-            "command": ".claude/hooks/bash_formatting.py"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/load_claude_md.py"
-          }
-        ]
-      }
-    ]
-  },
   "statusLine": {
     "type": "command",
     "command": "npx -y ccusage@latest statusline",
     "padding": 0
-  }
+  },
+  "enabledPlugins": {
+    "code-quality-hooks@fcakyon-claude-plugins": true,
+    "git-workflow-agents@fcakyon-claude-plugins": true,
+    "code-simplifier-agent@fcakyon-claude-plugins": true,
+    "productivity-commands@fcakyon-claude-plugins": true
+  },
 }


### PR DESCRIPTION
Replace inline hook definitions with plugin references.

- Remove ~80 lines of inline hook configuration from [.claude/settings.json#L76-L161](.claude/settings.json#L76-L161)
- Add `enabledPlugins` section with 4 plugin references
- Maintain all existing functionality through plugin system

Before:
```json
"hooks": {
  "PreToolUse": [...],
  "PostToolUse": [...],
  "UserPromptSubmit": [...]
}
```

After:
```json
"enabledPlugins": {
  "code-quality-hooks@fcakyon-claude-plugins": true,
  "git-workflow-agents@fcakyon-claude-plugins": true,
  "code-simplifier-agent@fcakyon-claude-plugins": true,
  "productivity-commands@fcakyon-claude-plugins": true
}
```