### PR TITLE
Add PR title formatting guidelines and clarify workflow

### DIFF
--- a/.claude/agents/pr-manager.md
+++ b/.claude/agents/pr-manager.md
@@ -1,7 +1,7 @@
 ---
 name: pr-manager
 description: Use this agent when you need to create a complete pull request workflow including branch creation, committing staged changes, and PR submission. This agent handles the entire end-to-end process from checking the current branch to creating a properly formatted PR with documentation updates. Examples:\n\n<example>\nContext: User has made code changes and wants to create a PR\nuser: "I've finished implementing the new feature. Please create a PR for the staged changes only"\nassistant: "I'll use the pr-manager agent to handle the complete PR workflow including branch creation, commits, and PR submission"\n<commentary>\nSince the user wants to create a PR, use the pr-manager agent to handle the entire workflow from branch creation to PR submission.\n</commentary>\n</example>\n\n<example>\nContext: User is on main branch with staged changes\nuser: "Create a PR with my staged changes only"\nassistant: "I'll launch the pr-manager agent to create a feature branch, commit your staged changes only, and submit a PR"\n<commentary>\nThe user needs the full PR workflow, so use pr-manager to handle branch creation, commits, and PR submission.\n</commentary>\n</example>
-tools: Bash, BashOutput, Glob, Grep, Read, WebSearch, WebFetch, TodoWrite, SlashCommand, ListMcpResourcesTool, ReadMcpResourceTool, mcp__github__list_pull_requests, mcp__tavily__tavily-search, mcp__tavily__tavily-extract
+tools: Bash, BashOutput, Glob, Grep, Read, WebSearch, WebFetch, TodoWrite, SlashCommand, ListMcpResourcesTool, ReadMcpResourceTool, mcp__tavily__tavily-search, mcp__tavily__tavily-extract
 model: claude-sonnet-4-5-20250929
 color: cyan
 ---
@@ -21,7 +21,7 @@ You are a Git and GitHub PR workflow automation specialist. Your role is to orch
    - Never commit directly to main
 
 3. **Commit Staged Changes**:
-   - Use `/commit-manager` slash command to handle if any staged changes, skip this step if no staged changes exist, for unstaged changes skip committing
+   - Use `/commit-manager` slash command to handle if any staged changes, skip this step if no staged changes exist, ignore unstaged changes
    - Ensure commits follow project conventions
 
 4. **Documentation Updates**:
@@ -41,7 +41,8 @@ You are a Git and GitHub PR workflow automation specialist. Your role is to orch
      - `-t` or `--title`: Concise title (max 72 chars)
      - `-b` or `--body`: Description with brief summary (few words or 1 sentence) + few bullet points of changes
      - `-a @me`: Self-assign (confirmation hook will show actual username)
-     - `-r <reviewer>`: Add reviewer (find from recent PRs of the assignee if needed)
+     - `-r <reviewer>`: Add reviewer (find from recent merged PRs of the assignee/self)
+   - Title should start with capital letter and verb and should not start with conventional commit prefixes (e.g. "fix:", "feat:")
    - Never include test plans in PR messages
    - For significant changes, include before/after code examples in PR body
    - Include inline markdown links to relevant code lines when helpful (format: `[src/auth.py:42](src/auth.py#L42)`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ This file provides guidance to Claude Code (claude.ai/code), OpenAI Codex and ot
   - PR message must describe the complete changeset across all commits, not just the latest commit
   - Focus on what changed from the perspective of someone reviewing the entire branch
 - Create PR with `gh pr create` using `-t` (title), `-b` (summary + bullet points), `-a @me` (self-assign), `-r <reviewer>` (from recent PRs)
+- Title should start with capital letter and verb and should not start with conventional commit prefixes (e.g. "fix:", "feat:")
 - PR should contain brief summary (few words or 1 sentence) and few bullet points of changes (with inline md links to sources when relevant)
 - For significant changes, include before/after code examples in PR body
 - Include inline markdown links to relevant code lines when helpful (format: `[src/auth.py:42](src/auth.py#L42)`)


### PR DESCRIPTION
Add formatting requirements for PR titles and clarify commit workflow handling.

- Add requirement for PR titles to start with capital letter and verb in [CLAUDE.md:87](CLAUDE.md#L87) and [.claude/agents/pr-manager.md:45](/.claude/agents/pr-manager.md#L45)
- Remove conventional commit prefixes (fix:, feat:, etc.) from PR titles
- Clarify handling of unstaged changes in commit workflow in [.claude/agents/pr-manager.md:24](/.claude/agents/pr-manager.md#L24)
- Update reviewer selection to reference recent merged PRs in [.claude/agents/pr-manager.md:44](/.claude/agents/pr-manager.md#L44)
- Remove unused mcp__github__list_pull_requests tool from pr-manager in [.claude/agents/pr-manager.md:4](/.claude/agents/pr-manager.md#L4)