### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Battle-tested Claude Code plugin collection: auto-formatting, Git workflow agents, pattern analysis, productivity commands, and 100+ MCP tools.",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "code-quality-hooks",
       "source": "./",
       "description": "Auto-formatting system for Python, JavaScript, TypeScript, CSS, JSON, YAML, HTML, Markdown, and Shell scripts. Eliminates formatting debates and reduces CI failures.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Fatih Akyon"
       },
@@ -37,7 +37,7 @@
       "name": "git-workflow-agents",
       "source": "./",
       "description": "Intelligent Git automation agents: commit-manager analyzes staged changes across multiple commits, pr-manager creates PRs with README sync and proper formatting.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Fatih Akyon"
       },
@@ -65,7 +65,7 @@
       "name": "code-simplifier-agent",
       "source": "./",
       "description": "Auto-triggers after TodoWrite to ensure new code follows existing project patterns for imports, naming, function signatures, and base classes. Maintains codebase consistency.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Fatih Akyon"
       },
@@ -89,7 +89,7 @@
       "name": "productivity-commands",
       "source": "./",
       "description": "Custom slash commands: /pr-summary for changelog generation, /commit for automated commits, /arch for pattern explanations, /think for enhanced reasoning.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Fatih Akyon"
       },
@@ -113,7 +113,7 @@
       "name": "mcp-server-configs",
       "source": "./",
       "description": "Pre-configured MCP servers: Azure (100+ tools), Context7 (20K+ library docs), GitHub, Linear, MongoDB, Playwright, Slack, Supabase, Tavily (web search).",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Fatih Akyon"
       },


### PR DESCRIPTION
Update marketplace and all plugin versions to 1.1.0

- Update marketplace metadata version in [.claude-plugin/marketplace.json:8](.claude-plugin/marketplace.json#L8)
- Update all plugin versions to 1.1.0:
  - code-quality-hooks ([L15](.claude-plugin/marketplace.json#L15))
  - git-workflow-agents ([L40](.claude-plugin/marketplace.json#L40))
  - code-simplifier-agent ([L68](.claude-plugin/marketplace.json#L68))
  - productivity-commands ([L92](.claude-plugin/marketplace.json#L92))
  - mcp-server-configs ([L116](.claude-plugin/marketplace.json#L116))