### PR TITLE
Remove redundant staging verification step from commit workflow

### DIFF
--- a/.claude/agents/commit-manager.md
+++ b/.claude/agents/commit-manager.md
@@ -44,7 +44,6 @@ When activated, follow this precise workflow:
      - Create a temporary list of all staged files using `git diff --cached --name-only`
      - For each commit, use `git reset HEAD <file>` to unstage specific files not meant for current commit
      - Use `git add <file>` to stage only the files intended for the current commit
-     - Verify staging area with `git status --porcelain` before each commit
      - After each commit, re-stage remaining files for subsequent commits
    - **CRITICAL**: Always verify the exact files in staging area before each `git commit` command
    - After committing, push changes to the remote repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,6 @@ This file provides guidance to Claude Code (claude.ai/code), OpenAI Codex and ot
 - **ONLY analyze staged files** - completely ignore unstaged changes and files
 - Check all currently staged files using `git diff --cached --name-only`
 - Read the actual code diffs using `git diff --cached` to understand the nature and scope of changes
-- Verify staging area with `git status --porcelain` before each commit
 - Create concise, descriptive commit messages following this format:
   - First line: `{task-type}: brief description of the big picture change`
   - Task types: feat, fix, refactor, docs, style, test, build


### PR DESCRIPTION
Simplify commit workflow documentation by removing duplicate verification instruction.

- Remove `git status --porcelain` verification step from [.claude/agents/commit-manager.md](.claude/agents/commit-manager.md#L47)
- Remove same verification step from [CLAUDE.md](CLAUDE.md#L132)
- Keep the CRITICAL note that already covers verification: "Always verify the exact files in staging area before each git commit command"