### PR TITLE
Add confirmation and docstring formatting hooks

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/load_claude_md.py"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "WebFetch",
@@ -34,6 +45,14 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/enforce_rg_over_grep.py"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/git_commit_confirm.py"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/gh_pr_create_confirm.py"
           }
         ]
       }
@@ -45,6 +64,10 @@
           {
             "type": "command",
             "command": "file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); if [[ -n \"$file_path\" && -f \"$file_path\" ]]; then case \"$file_path\" in *.py|*.js|*.jsx|*.ts|*.tsx) if [[ \"$OSTYPE\" == \"darwin\"* ]]; then sed -i '' 's/^[[:space:]]*$//g' \"$file_path\" 2>/dev/null || true; else sed -i 's/^[[:space:]]*$//g' \"$file_path\" 2>/dev/null || true; fi ;; esac; fi"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/format_python_docstrings.py"
           },
           {
             "type": "command",


### PR DESCRIPTION
Register hooks for improved workflow safety and code quality.

- Add [UserPromptSubmit](./.claude/hooks/hooks.json#L3-L14) hook to load CLAUDE.md on each prompt ([load_claude_md.py](./.claude/hooks/load_claude_md.py))
- Add [PreToolUse](./.claude/hooks/hooks.json#L48-L54) confirmation hooks for git commit ([git_commit_confirm.py](./.claude/hooks/git_commit_confirm.py)) and PR creation ([gh_pr_create_confirm.py](./.claude/hooks/gh_pr_create_confirm.py))
- Add [PostToolUse](./.claude/hooks/hooks.json#L68-L71) hook for Python docstring formatting ([format_python_docstrings.py](./.claude/hooks/format_python_docstrings.py))