### PR TITLE
Remove obsolete docformatter confirmation rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,8 +42,6 @@
       "Bash(git worktree list:*)",
       "Bash(ruff:*)",
       "Bash(uv run ruff:*)",
-      "Bash(docformatter:*)",
-      "Bash(uv run docformatter:*)",
       "Bash(python --version:*)",
       "WebFetch(domain:docs.litellm.ai)",
       "WebFetch(domain:openai.com)",


### PR DESCRIPTION
Clean up confirmation rules after docformatter removal.

- Remove `docformatter` and `uv run docformatter` confirmation rules from [.claude/settings.json](.claude/settings.json#L45-L46)
- Aligns with recent removal of docformatter tool in favor of ruff for docstring formatting