### PR TITLE
Improve PR reviewer selection with fallback logic

### DIFF
--- a/.claude/agents/pr-manager.md
+++ b/.claude/agents/pr-manager.md
@@ -41,7 +41,11 @@ You are a Git and GitHub PR workflow automation specialist. Your role is to orch
      - `-t` or `--title`: Concise title (max 72 chars)
      - `-b` or `--body`: Description with brief summary (few words or 1 sentence) + few bullet points of changes
      - `-a @me`: Self-assign (confirmation hook will show actual username)
-     - `-r <reviewer>`: Add reviewer (find from recent merged PRs of the assignee/self)
+     - `-r <reviewer>`: Add reviewer by finding most probable reviewer from recent PRs:
+       - Get current repo: `gh repo view --json nameWithOwner -q .nameWithOwner`
+       - First try: `gh pr list --repo <owner>/<repo> --author @me --limit 5` to find PRs by current author
+       - If no PRs by author, fallback: `gh pr list --repo <owner>/<repo> --limit 5` to get any recent PRs
+       - Extract reviewer username from the PR list
    - Title should start with capital letter and verb and should not start with conventional commit prefixes (e.g. "fix:", "feat:")
    - Never include test plans in PR messages
    - For significant changes, include before/after code examples in PR body

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ This file provides guidance to Claude Code (claude.ai/code), OpenAI Codex and ot
 - **IMPORTANT**: Analyze ALL committed changes in the branch using `git diff <base-branch>...HEAD`
   - PR message must describe the complete changeset across all commits, not just the latest commit
   - Focus on what changed from the perspective of someone reviewing the entire branch
-- Create PR with `gh pr create` using `-t` (title), `-b` (summary + bullet points), `-a @me` (self-assign), `-r <reviewer>` (from recent PRs)
+- Create PR with `gh pr create` using `-t` (title), `-b` (summary + bullet points), `-a @me` (self-assign), `-r <reviewer>` (find reviewer by: first try `gh pr list --repo <owner>/<repo> --author @me --limit 5`, if no results retry without `--author @me`)
 - Title should start with capital letter and verb and should not start with conventional commit prefixes (e.g. "fix:", "feat:")
 - PR should contain brief summary (few words or 1 sentence) and few bullet points of changes (with inline md links to sources when relevant)
 - For significant changes, include before/after code examples in PR body


### PR DESCRIPTION
Add fallback workflow for finding reviewers from recent PRs

- Update [`.claude/agents/pr-manager.md:44-48`](.claude/agents/pr-manager.md#L44-L48) with detailed reviewer selection instructions
- Update [`CLAUDE.md:87`](CLAUDE.md#L87) to match pr-manager workflow
- Add `gh repo view` to dynamically get current repo
- First try `gh pr list --author @me --limit 5` to find author's PRs
- Fallback to `gh pr list --limit 5` if no author PRs found