### PR TITLE
Fix Python hook script execution by adding shebang line

### DIFF
--- a/.claude/hooks/format_python_docstrings.py
+++ b/.claude/hooks/format_python_docstrings.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Format Python docstrings in Google style without external dependencies."""
 
 import ast


### PR DESCRIPTION
Resolves PostToolUse:Edit hook errors.

- Add `#!/usr/bin/env python3` shebang to [.claude/hooks/format_python_docstrings.py:1](.claude/hooks/format_python_docstrings.py#L1)
- Prevents script from being executed as shell script instead of Python
- Fixes "import: command not found" errors during hook execution