### PR TITLE
Add Claude Code VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
+    "claudeCode.initialPermissionMode": "plan",
+    "claudeCode.respectGitIgnore": false,
     "github.copilot.chat.commitMessageGeneration.instructions": [
         {
             "text": "Use conventional commit message format."


### PR DESCRIPTION
Configure Claude Code behavior in VS Code

- Add `claudeCode.initialPermissionMode: plan` for safer operations requiring explicit approval ([source](https://docs.claude.com/en/docs/claude-code/sdk/sdk-permissions))
- Add `claudeCode.respectGitIgnore: false` to allow access to gitignored files for local development ([source](https://github.com/anthropics/claude-code/issues/2305))

These settings provide better control over Claude Code's file access and execution permissions while enabling access to local documentation and configuration files that may be gitignored.