### PR TITLE
Fix infinite loop in Python docstring formatter hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,4 @@ __marimo__/
 
 # other
 .DS_Store
+pyproject.toml


### PR DESCRIPTION
Fix critical bug where the hook was causing infinite recursion by processing the entire repository.

- Replace directory traversal with stdin-based single file processing in [.claude/hooks/format_python_docstrings.py](.claude/hooks/format_python_docstrings.py#L219-L240)
- Remove CLI mode to simplify hook to hook-only operation
- Add path validation to skip virtual environments and package directories
- Add pyproject.toml to .gitignore

Before:
```python
def main(paths: list[str] | None = None) -> None:
    if not paths:
        paths = ['.']
    for path_str in paths:
        path = Path(path_str)
        files = sorted(path.rglob('*.py')) if path.is_dir() else []
        # Process all files...
```

After:
```python
def main() -> None:
    python_file = read_python_path()  # Read single file from stdin
    if python_file:
        # Process only the edited file
```