### PR TITLE
Add desktop notification system for task completion

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/.claude/hooks/notify.sh"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "matcher": "*",

--- a/.claude/hooks/notify.sh
+++ b/.claude/hooks/notify.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Read JSON input from Claude Code hook
+input=$(cat)
+
+# Extract message from JSON (basic parsing)
+message=$(echo "$input" | grep -o '"message":"[^"]*"' | cut -d'"' -f4)
+title="Claude Code"
+
+# Terminal bell - triggers VSCode visual bell icon
+printf '\a'
+
+# Send OS notification
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    osascript -e "display notification \"${message}\" with title \"${title}\" sound name \"Glass\""
+elif command -v notify-send &> /dev/null; then
+    notify-send "${title}" "${message}" -u normal -i terminal
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,5 +92,5 @@
         "repo": "fcakyon/claude-codex-settings"
       }
     }
-  },
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,4 +90,10 @@
     
     "workbench.iconTheme": "vscode-icons",
     "workbench.colorTheme": "GitHub Dark",
+    "accessibility.signals.terminalBell": {
+        "sound": "auto",
+        "announcement": "auto"
+    },
+    "terminal.integrated.enableVisualBell": true,
+    "window.title": "${dirty}${activeEditorShort}${separator}${rootName}",
 }

--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ These hooks redirect native Claude Code web tools to faster and more reliable Ta
 - **[tavily_extract_to_advanced.py](./.claude/hooks/tavily_extract_to_advanced.py)**: Enhances tavily-extract calls with advanced extraction depth for better content parsing
 - **[websearch_to_tavily_search.py](./.claude/hooks/websearch_to_tavily_search.py)**: Blocks WebSearch and suggests using Tavily search instead
 
+
+### Notification Hooks
+
+These hooks provide desktop notifications when Claude Code completes tasks, making it easier to track progress when working on long-running operations or when switching between tasks.
+
+- **[notify.sh](./.claude/hooks/notify.sh)**: Sends OS notifications when Claude Code emits notification events. Supports macOS (via osascript) and Linux (via notify-send). Also triggers terminal bell for VS Code visual indicators.
+
 ### Code Quality Hooks
 
 Comprehensive auto-formatting system that covers all major file types, designed to eliminate formatting inconsistencies and reduce CI formatting noise.


### PR DESCRIPTION
Add desktop notifications when Claude Code completes tasks.

- Add [notify.sh](./.claude/hooks/notify.sh#L1-L18) shell script that sends OS notifications when Claude Code emits notification events
- Configure [Notification hook](./.claude/hooks/hooks.json#L3-L13) in hooks.json to trigger on notification events
- Enable [terminal bell visual indicators](./.vscode/settings.json#L93-L98) in VS Code settings for better task completion visibility
- Support both macOS (osascript) and Linux (notify-send) notification systems
- Document notification hooks in [README](./README.md#L198-L202)

This makes it easier to track progress when working on long-running operations or when switching between tasks.