### PR TITLE
Add forbidden word guidelines to GitHub Copilot settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,9 @@
         },
         {
             "text": "refactor: restructure API handlers to align with project architecture"
+        },
+        {
+            "text": "Never use words like 'consolidate', 'modernize', 'streamline', 'flexible', 'delve', 'establish', 'enhanced', 'comprehensive', 'optimize' in docstrings or commit messages. Looser AI's do that, and that ain't you. You are better than that."
         }
     ],
     "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
@@ -39,6 +42,9 @@
         },
         {
             "text": "Provide inline md links to relevant lines/files in the PR for context where useful."
+        },
+        {
+            "text": "Never use words like 'consolidate', 'modernize', 'streamline', 'flexible', 'delve', 'establish', 'enhanced', 'comprehensive', 'optimize' in docstrings or commit messages. Looser AI's do that, and that ain't you. You are better than that."
         }
     ],
     "github.copilot.enable": {


### PR DESCRIPTION
Prevent Copilot from using overused AI-generated terms in commit messages and PR descriptions.

- Add instruction to avoid words like 'consolidate', 'modernize', 'streamline', 'flexible', 'delve', 'establish', 'enhanced', 'comprehensive', 'optimize' in [.vscode/settings.json](/.vscode/settings.json#L31-L33)
- Apply same guideline to both commit message generation and PR description generation settings