### PR TITLE
Add VS Code editor and diff configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,6 +68,8 @@
     },
     "telemetry.telemetryLevel": "off",
     "git.autofetch": true,
+    "diffEditor.ignoreTrimWhitespace": false,
+    "diffEditor.renderSideBySide": false,
     "files.autoSave": "afterDelay",
     "editor.formatOnSave": true,
     "python.analysis.typeCheckingMode": "basic",
@@ -93,7 +95,12 @@
             "path": "/bin/bash"
         }
     },
-    
+    "debug.console.fontSize": 10,
+    "terminal.integrated.fontSize": 11,
+    "editor.fontSize": 11,
+    "workbench.editor.autoLockGroups": {
+        "workbench.editor.chatSession": false
+    },
     "workbench.iconTheme": "vscode-icons",
     "workbench.colorTheme": "GitHub Dark",
     "accessibility.signals.terminalBell": {


### PR DESCRIPTION
Adds VS Code workspace settings for improved editor experience.

- Font sizes: editor (11pt), terminal (11pt), debug console (10pt)
- Diff editor: disable trim whitespace, use inline view instead of side-by-side
- Chat sessions: prevent auto-locking of editor groups