### PR TITLE
Allow gh issue view bash command

### DIFF
--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -30,6 +30,7 @@
       "Bash(gh pr diff:*)",
       "Bash(gh api user:*)",
       "Bash(gh repo view:*)",
+      "Bash(gh issue view:*)",
       "Bash(git branch --show-current:*)",
       "Bash(git diff:*)",
       "Bash(git status:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,7 @@
       "Bash(gh pr diff:*)",
       "Bash(gh api user:*)",
       "Bash(gh repo view:*)",
+      "Bash(gh issue view:*)",
       "Bash(git branch --show-current:*)",
       "Bash(git diff:*)",
       "Bash(git status:*)",


### PR DESCRIPTION
## Summary
Add support for `gh issue view` bash command in Claude Code settings.

## Changes
- Add `Bash(gh issue view:*)` to allowed commands in [.claude/settings-zai.json](.claude/settings-zai.json)
- Add `Bash(gh issue view:*)` to allowed commands in [.claude/settings.json](.claude/settings.json)

This enables users to view GitHub issues directly from the command line within Claude Code.