### PR TITLE
Remove redundant Plugin-based label from installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,6 @@ Specialized agents that run automatically to enhance code quality, stored in [`.
 
 ### Installation
 
-**Plugin-based:**
-
 ```bash
 /plugin install git-workflow-agents@fcakyon-claude-plugins
 /plugin install code-simplifier-agent@fcakyon-claude-plugins


### PR DESCRIPTION
Remove unnecessary "Plugin-based:" heading from the Specialized Agents installation section.

- Remove "Plugin-based:" label that added no value since the `/plugin install` commands already indicate plugin-based installation