### PR TITLE
Remove enabledPlugins from settings files

### DIFF
--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -91,12 +91,6 @@
     "command": "npx -y ccusage@latest statusline",
     "padding": 0
   },
-  "enabledPlugins": {
-    "git-workflow-agents@fcakyon-claude-plugins": true,
-    "code-simplifier-agent@fcakyon-claude-plugins": true,
-    "productivity-commands@fcakyon-claude-plugins": true,
-    "code-quality-hooks@fcakyon-claude-plugins": true
-  },
   "extraKnownMarketplaces": {
     "fcakyon-claude-plugins": {
       "source": {
@@ -104,5 +98,5 @@
         "repo": "fcakyon/claude-codex-settings"
       }
     }
-  },
+  }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,12 +88,6 @@
     "command": "npx -y ccusage@latest statusline",
     "padding": 0
   },
-  "enabledPlugins": {
-    "git-workflow-agents@fcakyon-claude-plugins": true,
-    "code-simplifier-agent@fcakyon-claude-plugins": true,
-    "productivity-commands@fcakyon-claude-plugins": true,
-    "code-quality-hooks@fcakyon-claude-plugins": true
-  },
   "extraKnownMarketplaces": {
     "fcakyon-claude-plugins": {
       "source": {


### PR DESCRIPTION
Remove deprecated enabledPlugins configuration from settings files.

- Remove `enabledPlugins` section from [.claude/settings.json](.claude/settings.json)
- Remove `enabledPlugins` section from [.claude/settings-zai.json](.claude/settings-zai.json)
- Preserve `extraKnownMarketplaces` configuration for marketplace source