### PR TITLE
Align formatting hooks with ultralytics/actions configuration

### DIFF
--- a/plugins/ultralytics-dev/hooks/scripts/bash_formatting.py
+++ b/plugins/ultralytics-dev/hooks/scripts/bash_formatting.py
@@ -3,9 +3,9 @@
 PostToolUse hook: Auto-format Bash/Shell scripts with prettier-plugin-sh
 """
 import json
-import sys
-import subprocess
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -45,11 +45,11 @@ def main():
         # Try prettier with prettier-plugin-sh, handle any failure gracefully
         try:
             subprocess.run([
-                'npx', 'prettier', '--write', '--list-different',
+                'npx', 'prettier', '--write', '--list-different', '--print-width', '120',
                 '--plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs',
                 str(sh_file)
             ], shell=True, capture_output=True, check=False, cwd=sh_file.parent, timeout=10)
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass  # Silently handle any failure (missing plugin, timeout, etc.)
 
     except Exception:

--- a/plugins/ultralytics-dev/hooks/scripts/prettier_formatting.py
+++ b/plugins/ultralytics-dev/hooks/scripts/prettier_formatting.py
@@ -4,9 +4,9 @@ PostToolUse hook: Auto-format JS/TS/CSS/JSON/YAML/HTML/Vue/Svelte files with pre
 """
 import json
 import re
-import sys
-import subprocess
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 # File extensions that prettier handles
@@ -54,7 +54,7 @@ def main():
 
         # Run prettier
         subprocess.run([
-            'npx', 'prettier', '--write', '--list-different', str(py_file)
+            'npx', 'prettier', '--write', '--list-different', '--print-width', '120', str(py_file)
         ], capture_output=True, check=False, cwd=py_file.parent)
 
     except Exception:


### PR DESCRIPTION
Align local formatting hooks with the configuration used in [ultralytics/actions](https://github.com/ultralytics/actions).

- Add `--print-width 120` to prettier commands in all formatting hooks
- Extend ruff rules from `I,D,UP` to `F,I,D,UP,RUF,FA` for markdown Python code blocks
- Add `RUF001,RUF002,RUF012` to ignored ruff rules for markdown blocks
- Apply minor code style fixes (import ordering, remove unnecessary blank lines)