### PR TITLE
Fix subagent references and bump websearch-tools version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -100,12 +100,12 @@
     },
     {
       "name": "plugin-dev",
+      "source": "./plugins/plugin-dev",
       "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 7 expert skills covering hooks, MCP integration, commands, agents, and best practices. AI-assisted plugin creation and validation.",
       "version": "1.2.1",
       "author": {
         "name": "Fatih Akyon"
       },
-      "source": "./plugins/plugin-dev",
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugin-dev",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
       "license": "Apache-2.0",

--- a/plugins/general-dev/agents/code-simplifier.md
+++ b/plugins/general-dev/agents/code-simplifier.md
@@ -9,7 +9,7 @@ You are a **Contextual Pattern Analyzer** that ensures new code follows existing
 
 ## **TRIGGER CONDITIONS**
 
-Dont activate if the commit-manager agent is currently working
+Dont activate if the `commit-manager` agent is currently working
 
 ## **SEMANTIC ANALYSIS APPROACH**
 

--- a/plugins/github-dev/agents/pr-manager.md
+++ b/plugins/github-dev/agents/pr-manager.md
@@ -20,7 +20,7 @@ You are a Git and GitHub PR workflow automation specialist. Your role is to orch
    - Never commit directly to main
 
 3. **Commit Staged Changes**:
-   - Use `commit-manager` subagent to handle if any staged changes, skip this step if no staged changes exist, ignore unstaged changes
+   - Use `github-dev:commit-manager` subagent to handle if any staged changes, skip this step if no staged changes exist, ignore unstaged changes
    - Ensure commits follow project conventions
 
 4. **Documentation Updates**:
@@ -90,7 +90,7 @@ You are a Git and GitHub PR workflow automation specialist. Your role is to orch
 
 - Use `gh` CLI for all PR operations
 - Use `mcp__tavily__tavily-search` for web verification
-- Use `/commit-manager` for commit creation
+- Use `github-dev:commit-manager` subagent for commit creation
 - Use git commands for branch operations
 
 ## Output:

--- a/plugins/github-dev/skills/pr-workflow/SKILL.md
+++ b/plugins/github-dev/skills/pr-workflow/SKILL.md
@@ -13,7 +13,7 @@ Complete workflow for creating pull requests following project standards.
 
 2. **Branch setup**
    - If on main/master, create feature branch first: `feature/brief-description` or `fix/brief-description`
-   - Use `/commit-manager` to handle staged changes if needed
+   - Use `github-dev:commit-manager` subagent to handle staged changes if needed
 
 3. **Documentation check**
    - Update README.md or docs based on changes compared to target branch

--- a/plugins/websearch-tools/.claude-plugin/plugin.json
+++ b/plugins/websearch-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "websearch-tools",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Smart web tool routing via hooks that redirect WebFetch/WebSearch to Tavily. Includes context7 MCP for library docs and a skill for tool selection.",
   "author": {
     "name": "Fatih Akyon"


### PR DESCRIPTION
- Update commit-manager references to use `github-dev:commit-manager` subagent format in [pr-manager.md](plugins/github-dev/agents/pr-manager.md) and [pr-workflow/SKILL.md](plugins/github-dev/skills/pr-workflow/SKILL.md)
- Bump websearch-tools plugin version to 1.2.1 in [plugin.json](plugins/websearch-tools/.claude-plugin/plugin.json)
- Format agent name with backticks in [code-simplifier.md](plugins/general-dev/agents/code-simplifier.md)
- Reorder source field in [marketplace.json](.claude-plugin/marketplace.json)