### PR TITLE
Fix hook script compatibility for Python 3.9 and remove PyYAML dependency

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Battle-tested Claude Code plugin collection: auto-formatting, Git workflow agents, pattern analysis, productivity commands, and 100+ MCP tools.",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "plugins": [
     {
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Ultralytics-specific development tools: Python/JavaScript/Markdown/Bash formatting hooks, Slack/MongoDB/Linear MCP integration, plus skills for optimal MCP usage.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Fatih Akyon"
       },
@@ -102,7 +102,7 @@
       "name": "plugin-dev",
       "source": "./plugins/plugin-dev",
       "description": "Comprehensive toolkit for developing Claude Code plugins. Includes 7 expert skills covering hooks, MCP integration, commands, agents, and best practices. AI-assisted plugin creation and validation.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/plugins/plugin-dev/.claude-plugin/plugin.json
+++ b/plugins/plugin-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-dev",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Toolkit for developing Claude Code plugins with skills for hooks, MCP integration, commands, agents, and best practices.",
   "author": {
     "name": "Fatih Akyon"

--- a/plugins/plugin-dev/hooks/scripts/validate_skill.py
+++ b/plugins/plugin-dev/hooks/scripts/validate_skill.py
@@ -7,7 +7,15 @@ import re
 import sys
 from pathlib import Path
 
-import yaml
+
+def parse_simple_yaml(text):
+    """Parse simple key-value YAML frontmatter."""
+    result = {}
+    for line in text.strip().split("\n"):
+        if ":" in line:
+            key, _, value = line.partition(":")
+            result[key.strip()] = value.strip().strip('"').strip("'")
+    return result
 
 
 def get_edited_file_path():
@@ -65,8 +73,8 @@ def validate_skill():
 
         # Parse YAML
         try:
-            frontmatter = yaml.safe_load(parts[1])
-        except yaml.YAMLError as e:
+            frontmatter = parse_simple_yaml(parts[1])
+        except Exception as e:
             errors.append(f"{prefix}: Invalid YAML - {e}")
             continue
 

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash. Includes MCP servers for Slack message search, MongoDB queries, and Linear tracking, with usage skills.",
   "author": {
     "name": "Fatih Akyon"

--- a/plugins/ultralytics-dev/hooks/scripts/format_python_docstrings.py
+++ b/plugins/ultralytics-dev/hooks/scripts/format_python_docstrings.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Format Python docstrings in Google style without external dependencies."""
 
+from __future__ import annotations
+
 import ast
 import json
 import re


### PR DESCRIPTION
## Summary

Fix two compatibility issues in plugin hook scripts that caused runtime errors.

- Add `from __future__ import annotations` to [format_python_docstrings.py](plugins/ultralytics-dev/hooks/scripts/format_python_docstrings.py#L4) for Python 3.9 compatibility with union type syntax (`Path | None`)
- Replace PyYAML with inline YAML parser in [validate_skill.py](plugins/plugin-dev/hooks/scripts/validate_skill.py#L11-L17) to eliminate external dependency
- Bump plugin versions to 1.2.2