### PR TITLE
Add load-frontend-skill command to claude-tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -127,7 +127,7 @@
       "name": "claude-tools",
       "source": "./plugins/claude-tools",
       "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context from CLAUDE.md files.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Commands for syncing CLAUDE.md and permissions allowlist from repository, plus c
 **Commands:**
 
 - [`/load-claude-md`](./plugins/claude-tools/commands/load-claude-md.md) - Refresh context with CLAUDE.md instructions
+- [`/load-frontend-skill`](./plugins/claude-tools/commands/load-frontend-skill.md) - Load frontend design skill from Anthropic
 - [`/sync-claude-md`](./plugins/claude-tools/commands/sync-claude-md.md) - Sync CLAUDE.md from GitHub
 - [`/sync-allowlist`](./plugins/claude-tools/commands/sync-allowlist.md) - Sync permissions allowlist
 

--- a/plugins/claude-tools/.claude-plugin/plugin.json
+++ b/plugins/claude-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tools",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context from CLAUDE.md files.",
   "author": {
     "name": "Fatih Akyon"

--- a/plugins/claude-tools/commands/load-frontend-skill.md
+++ b/plugins/claude-tools/commands/load-frontend-skill.md
@@ -1,0 +1,19 @@
+---
+description: Load frontend design skill from Anthropic
+allowed-tools: WebFetch, mcp__github__get_file_contents
+---
+
+# Load Frontend Design Skill
+
+Load the frontend-design skill from Anthropic's official Claude Code plugins to guide creation of distinctive, production-grade frontend interfaces.
+
+Try to read the skill content using GitHub MCP if available:
+
+- owner: anthropics
+- repo: claude-code
+- path: plugins/frontend-design/skills/frontend-design/SKILL.md
+
+If GitHub MCP is not available, fetch from:
+https://raw.githubusercontent.com/anthropics/claude-code/main/plugins/frontend-design/skills/frontend-design/SKILL.md
+
+Use this guidance when building web components, pages, or applications that require high design quality and avoid generic AI aesthetics.


### PR DESCRIPTION
## Summary

Add `/load-frontend-skill` command to load Anthropic's official frontend-design skill for building high-quality web interfaces.

## Changes

- Add [plugins/claude-tools/commands/load-frontend-skill.md](plugins/claude-tools/commands/load-frontend-skill.md) - new command that loads the skill via GitHub MCP with WebFetch fallback
- Update [README.md](README.md) - document the new command in claude-tools section
- Bump claude-tools version to 1.2.2 (auto-updated by sync hooks)