### PR TITLE
Standardize exclusion lists across hook scripts

### DIFF
--- a/plugins/plugin-dev/hooks/scripts/validate_skill.py
+++ b/plugins/plugin-dev/hooks/scripts/validate_skill.py
@@ -31,6 +31,10 @@ def validate_skill():
     """Validate all SKILL.md files in skills directory."""
     edited_path = get_edited_file_path()
 
+    # Skip virtual env, cache, and .claude directories
+    if edited_path and any(p in edited_path for p in [".venv", "venv", "site-packages", "__pycache__", ".claude"]):
+        return 0
+
     # Exit early if not editing a skill-related file
     if edited_path and "/skills/" not in edited_path and not edited_path.endswith("SKILL.md"):
         return 0

--- a/plugins/ultralytics-dev/hooks/hooks.json
+++ b/plugins/ultralytics-dev/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|MultiEdit|Write|Task",
+        "matcher": "Edit|MultiEdit|Write",
         "hooks": [
           {
             "type": "command",

--- a/plugins/ultralytics-dev/hooks/scripts/bash_formatting.py
+++ b/plugins/ultralytics-dev/hooks/scripts/bash_formatting.py
@@ -35,7 +35,7 @@ def main():
             sys.exit(0)
 
         sh_file = Path(file_path)
-        if not sh_file.exists():
+        if not sh_file.exists() or any(p in sh_file.parts for p in ['.venv', 'venv', 'site-packages', '__pycache__', '.claude']):
             sys.exit(0)
 
         # Check if prettier is available
@@ -44,11 +44,8 @@ def main():
 
         # Try prettier with prettier-plugin-sh, handle any failure gracefully
         try:
-            subprocess.run([
-                'npx', 'prettier', '--write', '--list-different', '--print-width', '120',
-                '--plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs',
-                str(sh_file)
-            ], shell=True, capture_output=True, check=False, cwd=sh_file.parent, timeout=10)
+            cmd = f'npx prettier --write --list-different --print-width 120 --plugin=$(npm root -g)/prettier-plugin-sh/lib/index.cjs "{sh_file}"'
+            subprocess.run(cmd, shell=True, capture_output=True, check=False, cwd=sh_file.parent, timeout=10)
         except Exception:
             pass  # Silently handle any failure (missing plugin, timeout, etc.)
 

--- a/plugins/ultralytics-dev/hooks/scripts/format_python_docstrings.py
+++ b/plugins/ultralytics-dev/hooks/scripts/format_python_docstrings.py
@@ -232,7 +232,7 @@ def read_python_path() -> Path | None:
     path = Path(file_path) if file_path else None
     if not path or path.suffix != ".py" or not path.exists():
         return None
-    if any(p in path.parts for p in ['.venv', 'venv', 'site-packages', '__pycache__']):
+    if any(p in path.parts for p in ['.venv', 'venv', 'site-packages', '__pycache__', '.claude']):
         return None
     return path
 

--- a/plugins/ultralytics-dev/hooks/scripts/markdown_formatting.py
+++ b/plugins/ultralytics-dev/hooks/scripts/markdown_formatting.py
@@ -281,6 +281,8 @@ def read_markdown_path() -> Path | None:
     path = Path(file_path) if file_path else None
     if not path or path.suffix.lower() != ".md" or not path.exists():
         return None
+    if any(p in path.parts for p in ['.venv', 'venv', 'site-packages', '__pycache__', '.claude']):
+        return None
     return path
 
 

--- a/plugins/ultralytics-dev/hooks/scripts/prettier_formatting.py
+++ b/plugins/ultralytics-dev/hooks/scripts/prettier_formatting.py
@@ -44,8 +44,8 @@ def main():
         if not py_file.exists() or py_file.suffix not in PRETTIER_EXTENSIONS:
             sys.exit(0)
 
-        # Skip lock files and model.json
-        if LOCK_FILE_PATTERN.match(py_file.name) or py_file.name == 'model.json':
+        # Skip virtual env, cache, .claude directories, lock files, model.json, and minified assets
+        if any(p in py_file.parts for p in ['.venv', 'venv', 'site-packages', '__pycache__', '.claude']) or LOCK_FILE_PATTERN.match(py_file.name) or py_file.name == 'model.json' or py_file.name.endswith(('.min.js', '.min.css')):
             sys.exit(0)
 
         # Check if prettier is available


### PR DESCRIPTION
Add consistent directory exclusion pattern to all file-processing hooks.

- Add `.venv`, `venv`, `site-packages`, `__pycache__`, `.claude` exclusions to [validate_skill.py](plugins/plugin-dev/hooks/scripts/validate_skill.py), [markdown_formatting.py](plugins/ultralytics-dev/hooks/scripts/markdown_formatting.py), [prettier_formatting.py](plugins/ultralytics-dev/hooks/scripts/prettier_formatting.py), [bash_formatting.py](plugins/ultralytics-dev/hooks/scripts/bash_formatting.py)
- Add `.claude` to existing exclusion list in [format_python_docstrings.py](plugins/ultralytics-dev/hooks/scripts/format_python_docstrings.py)
- Fix empty error messages in [python_code_quality.py](plugins/ultralytics-dev/hooks/scripts/python_code_quality.py) when ruff fails without output
- Fix shell command syntax in [bash_formatting.py](plugins/ultralytics-dev/hooks/scripts/bash_formatting.py) for prettier plugin path
- Remove `Task` from matcher in [hooks.json](plugins/ultralytics-dev/hooks/hooks.json) to prevent hooks from triggering on Task tool