### PR TITLE
Add tree command to bash allowlist

### DIFF
--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -24,6 +24,7 @@
       "Bash(cat:*)",
       "Bash(sed:*)",
       "Bash(source:*)",
+      "Bash(tree:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr diff:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,7 @@
       "Bash(cat:*)",
       "Bash(sed:*)",
       "Bash(source:*)",
+      "Bash(tree:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr diff:*)",


### PR DESCRIPTION
Add `Bash(tree:*)` to the allowlist for directory structure visualization.

- Add `tree` command to [.claude/settings.json](.claude/settings.json#L25)
- Add `tree` command to [.claude/settings-zai.json](.claude/settings-zai.json#L27)