### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ My daily battle-tested Claude [Code](https://github.com/anthropics/claude-code)/
 
 ## Installation
 
+[![Run in Smithery](https://smithery.ai/badge/skills/fcakyon)](https://smithery.ai/skills?ns=fcakyon&utm_source=github&utm_medium=badge)
+
+
 > **Prerequisites:** Before installing, ensure you have Claude Code and required tools installed. See [INSTALL.md](INSTALL.md) for complete prerequisites.
 
 Install agents, commands, hooks, skills, and MCP servers via [Claude Code Plugins](https://docs.claude.com/en/docs/claude-code/plugins) system:


### PR DESCRIPTION
## Add skill discoverability badge

Your 12 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/fcakyon)](https://smithery.ai/skills?ns=fcakyon&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.