### PR TITLE
Add ccproxy-tools plugin for LLM provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Install agents, commands, hooks, skills, and MCP servers via [Claude Code Plugin
 /plugin install notification-tools@fcakyon-claude-plugins # OS notifications
 /plugin install plugin-dev@fcakyon-claude-plugins         # Plugin development toolkit
 /plugin install claude-tools@fcakyon-claude-plugins       # Sync CLAUDE.md + allowlist
+/plugin install ccproxy-tools@fcakyon-claude-plugins      # Use any LLM via ccproxy/LiteLLM
 ```
 
 After installing MCP plugins, run `/plugin-name:setup` for configuration (e.g., `/slack-tools:setup`).
@@ -316,6 +317,21 @@ Commands for syncing CLAUDE.md and permissions allowlist from repository, plus c
 - [`/load-frontend-skill`](./plugins/claude-tools/commands/load-frontend-skill.md) - Load frontend design skill from Anthropic
 - [`/sync-claude-md`](./plugins/claude-tools/commands/sync-claude-md.md) - Sync CLAUDE.md from GitHub
 - [`/sync-allowlist`](./plugins/claude-tools/commands/sync-allowlist.md) - Sync permissions allowlist
+
+</details>
+
+<details>
+<summary><strong>ccproxy-tools</strong> - Use Claude Code with any LLM</summary>
+
+Configure Claude Code to use ccproxy/LiteLLM with Claude Pro/Max subscription, GitHub Copilot, or other providers. Run `/ccproxy-tools:setup` after install.
+
+**Commands:**
+
+- [`/ccproxy-tools:setup`](./plugins/ccproxy-tools/commands/setup.md) - Configure ccproxy/LiteLLM
+
+**Skills:**
+
+- [`setup`](./plugins/ccproxy-tools/skills/setup/SKILL.md) - Troubleshooting guide
 
 </details>
 

--- a/plugins/ccproxy-tools/.claude-plugin/plugin.json
+++ b/plugins/ccproxy-tools/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "ccproxy-tools",
+  "version": "1.0.0",
+  "description": "Configure Claude Code to use ccproxy/LiteLLM with Claude Pro/Max, GitHub Copilot, or any LLM.",
+  "author": {
+    "name": "Fatih Akyon"
+  },
+  "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+  "repository": "https://github.com/fcakyon/claude-codex-settings",
+  "license": "Apache-2.0"
+}

--- a/plugins/ccproxy-tools/commands/setup.md
+++ b/plugins/ccproxy-tools/commands/setup.md
@@ -1,0 +1,282 @@
+---
+description: Configure ccproxy/LiteLLM to use Claude Code with any LLM provider
+---
+
+# ccproxy-tools Setup
+
+Configure Claude Code to use ccproxy/LiteLLM with Claude Pro/Max subscription, GitHub Copilot, or other LLM providers.
+
+## Step 1: Check Prerequisites
+
+Check if required tools are installed:
+
+```bash
+which uv
+uv tool list | grep -E "litellm|ccproxy" || echo "Not installed"
+```
+
+If not installed, show:
+
+```
+Install ccproxy and LiteLLM:
+uv tool install 'litellm[proxy]' 'ccproxy'
+```
+
+## Step 2: Ask Provider Choice
+
+Use AskUserQuestion:
+
+- question: "Which LLM provider do you want to use with Claude Code?"
+- header: "Provider"
+- options:
+  - label: "Claude Pro/Max (ccproxy)"
+    description: "Use your Claude subscription via OAuth - no API keys needed"
+  - label: "GitHub Copilot (LiteLLM)"
+    description: "Use GitHub Copilot subscription via LiteLLM proxy"
+  - label: "OpenAI API (LiteLLM)"
+    description: "Use OpenAI models via LiteLLM proxy"
+  - label: "Gemini API (LiteLLM)"
+    description: "Use Google Gemini models via LiteLLM proxy"
+
+## Step 3: Provider-Specific Setup
+
+### If Claude Pro/Max (ccproxy)
+
+Tell the user:
+
+```
+Claude Pro/Max Setup via ccproxy:
+
+1. Initialize ccproxy config:
+   ccproxy init
+
+2. Start the proxy server:
+   ccproxy start
+
+   The proxy runs on http://localhost:4000
+
+3. When prompted, authenticate via browser with your Claude subscription.
+
+4. I'll update your .claude/settings.json with:
+   - ANTHROPIC_BASE_URL: http://localhost:4000
+
+5. Restart Claude Code to apply changes.
+
+Note: Keep ccproxy running in a terminal or use tmux:
+tmux new-session -d -s ccproxy 'ccproxy start'
+```
+
+Update `.claude/settings.json` env section with:
+
+```json
+{
+  "ANTHROPIC_BASE_URL": "http://localhost:4000"
+}
+```
+
+### If GitHub Copilot (LiteLLM)
+
+Tell the user:
+
+```
+GitHub Copilot Setup via LiteLLM:
+
+1. Create LiteLLM config at ~/.litellm/config.yaml with the content I'll provide.
+
+2. Start LiteLLM proxy:
+   litellm --config ~/.litellm/config.yaml
+
+   The proxy runs on http://localhost:4000
+
+3. When you see "Please visit ... and enter code XXXX-XXXX to authenticate"
+   Open the link and authenticate with your GitHub Copilot account.
+
+4. I'll update your .claude/settings.json with:
+   - ANTHROPIC_BASE_URL: http://localhost:4000
+   - ANTHROPIC_AUTH_TOKEN: sk-dummy
+   - Model mappings for opus/sonnet/haiku
+
+5. Restart Claude Code to apply changes.
+
+Note: Keep LiteLLM running in a terminal or use tmux:
+tmux new-session -d -s litellm 'litellm --config ~/.litellm/config.yaml'
+```
+
+Create `~/.litellm/config.yaml`:
+
+```yaml
+general_settings:
+  master_key: sk-dummy
+litellm_settings:
+  drop_params: true
+model_list:
+  - model_name: claude-opus-4
+    litellm_params:
+      model: github_copilot/claude-opus-4
+      extra_headers:
+        editor-version: "vscode/1.104.3"
+        editor-plugin-version: "copilot-chat/0.26.7"
+        Copilot-Integration-Id: "vscode-chat"
+        user-agent: "GitHubCopilotChat/0.26.7"
+        x-github-api-version: "2025-04-01"
+  - model_name: claude-sonnet-4.5
+    litellm_params:
+      model: github_copilot/claude-sonnet-4.5
+      extra_headers:
+        editor-version: "vscode/1.104.3"
+        editor-plugin-version: "copilot-chat/0.26.7"
+        Copilot-Integration-Id: "vscode-chat"
+        user-agent: "GitHubCopilotChat/0.26.7"
+        x-github-api-version: "2025-04-01"
+  - model_name: gpt-5-mini
+    litellm_params:
+      model: github_copilot/gpt-5-mini
+      extra_headers:
+        editor-version: "vscode/1.104.3"
+        editor-plugin-version: "copilot-chat/0.26.7"
+        Copilot-Integration-Id: "vscode-chat"
+        user-agent: "GitHubCopilotChat/0.26.7"
+        x-github-api-version: "2025-04-01"
+  - model_name: "*"
+    litellm_params:
+      model: "github_copilot/*"
+      extra_headers:
+        editor-version: "vscode/1.104.3"
+        editor-plugin-version: "copilot-chat/0.26.7"
+        Copilot-Integration-Id: "vscode-chat"
+        user-agent: "GitHubCopilotChat/0.26.7"
+        x-github-api-version: "2025-04-01"
+```
+
+Update `.claude/settings.json` env section with:
+
+```json
+{
+  "ANTHROPIC_BASE_URL": "http://localhost:4000",
+  "ANTHROPIC_AUTH_TOKEN": "sk-dummy",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4.5",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5-mini"
+}
+```
+
+### If OpenAI API (LiteLLM)
+
+Ask for OpenAI API key using AskUserQuestion:
+
+- question: "Enter your OpenAI API key (starts with sk-):"
+- header: "OpenAI Key"
+- options:
+  - label: "I have it ready"
+    description: "I'll paste my OpenAI API key"
+  - label: "Skip for now"
+    description: "I'll configure it later"
+
+Create `~/.litellm/config.yaml`:
+
+```yaml
+general_settings:
+  master_key: sk-dummy
+litellm_settings:
+  drop_params: true
+model_list:
+  - model_name: claude-opus-4
+    litellm_params:
+      model: openai/gpt-5
+      api_key: YOUR_OPENAI_KEY
+  - model_name: claude-sonnet-4.5
+    litellm_params:
+      model: openai/gpt-5
+      api_key: YOUR_OPENAI_KEY
+  - model_name: "*"
+    litellm_params:
+      model: openai/gpt-5-mini
+      api_key: YOUR_OPENAI_KEY
+```
+
+Update `.claude/settings.json` env section with:
+
+```json
+{
+  "ANTHROPIC_BASE_URL": "http://localhost:4000",
+  "ANTHROPIC_AUTH_TOKEN": "sk-dummy",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4.5",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5-mini"
+}
+```
+
+### If Gemini API (LiteLLM)
+
+Ask for Gemini API key using AskUserQuestion:
+
+- question: "Enter your Gemini API key:"
+- header: "Gemini Key"
+- options:
+  - label: "I have it ready"
+    description: "I'll paste my Gemini API key"
+  - label: "Skip for now"
+    description: "I'll configure it later"
+
+Create `~/.litellm/config.yaml`:
+
+```yaml
+general_settings:
+  master_key: sk-dummy
+litellm_settings:
+  drop_params: true
+model_list:
+  - model_name: claude-opus-4
+    litellm_params:
+      model: gemini/gemini-2.5-pro
+      api_key: YOUR_GEMINI_KEY
+  - model_name: claude-sonnet-4.5
+    litellm_params:
+      model: gemini/gemini-2.5-flash
+      api_key: YOUR_GEMINI_KEY
+  - model_name: "*"
+    litellm_params:
+      model: gemini/gemini-2.5-flash
+      api_key: YOUR_GEMINI_KEY
+```
+
+Update `.claude/settings.json` env section with:
+
+```json
+{
+  "ANTHROPIC_BASE_URL": "http://localhost:4000",
+  "ANTHROPIC_AUTH_TOKEN": "sk-dummy",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4.5",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5-mini"
+}
+```
+
+## Step 4: Update Settings
+
+1. Read current `.claude/settings.json`
+2. Create backup at `.claude/settings.json.backup`
+3. Merge the provider-specific env variables into the existing env section
+4. Write updated settings back
+
+## Step 5: Confirm Success
+
+Tell the user:
+
+```
+Configuration complete!
+
+IMPORTANT: Restart Claude Code for changes to take effect.
+- Exit Claude Code
+- Start the proxy (ccproxy start OR litellm --config ~/.litellm/config.yaml)
+- Run `claude` again
+
+To verify after restart:
+- Claude Code should connect to the proxy at localhost:4000
+- Check proxy terminal for request logs
+
+Troubleshooting:
+- Run /ccproxy-tools:setup again if issues occur
+- Check proxy is running: curl http://localhost:4000/health
+- See ccproxy docs: https://github.com/starbased-co/ccproxy
+```

--- a/plugins/ccproxy-tools/skills/setup/SKILL.md
+++ b/plugins/ccproxy-tools/skills/setup/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: setup
+description: This skill should be used when user encounters "ccproxy not found", "LiteLLM connection failed", "localhost:4000 refused", "OAuth failed", "proxy not running", or needs help configuring ccproxy/LiteLLM integration.
+---
+
+# ccproxy-tools Setup
+
+Run `/ccproxy-tools:setup` to configure ccproxy/LiteLLM.
+
+## Quick Fixes
+
+- **ccproxy/litellm not found** - Install with `uv tool install 'litellm[proxy]' 'ccproxy'`
+- **Connection refused localhost:4000** - Start proxy: `ccproxy start` or `litellm --config ~/.litellm/config.yaml`
+- **OAuth failed** - Re-run `ccproxy init` and authenticate via browser
+- **Invalid model name** - Check model names in `.claude/settings.json` match LiteLLM config
+- **Changes not applied** - Restart Claude Code after updating settings
+
+## Environment Variables
+
+Key settings in `.claude/settings.json` → `env`:
+
+| Variable                         | Purpose                                |
+| -------------------------------- | -------------------------------------- |
+| `ANTHROPIC_BASE_URL`             | Proxy endpoint (http://localhost:4000) |
+| `ANTHROPIC_AUTH_TOKEN`           | Auth token for proxy                   |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL`   | Opus model name                        |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Sonnet model name                      |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL`  | Haiku model name                       |
+
+## Check Proxy Health
+
+```bash
+curl http://localhost:4000/health
+```
+
+## Resources
+
+- ccproxy: https://github.com/starbased-co/ccproxy
+- LiteLLM: https://docs.litellm.ai


### PR DESCRIPTION
Add plugin to configure Claude Code with ccproxy/LiteLLM for using alternative LLM providers.

- Interactive setup command with 4 provider options: Claude Pro/Max (ccproxy), GitHub Copilot, OpenAI, Gemini
- LiteLLM config.yaml templates for each provider
- Environment variable configuration for [.claude/settings.json](plugins/ccproxy-tools/commands/setup.md#L260-L276)
- Troubleshooting skill for common errors ([SKILL.md](plugins/ccproxy-tools/skills/setup/SKILL.md))