### PR TITLE
Update plugin skills and main readme to include source repositories of the MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ Install agents, commands, hooks, skills, and MCP servers via [Claude Code Plugin
 # Install plugins (pick what you need)
 /plugin install ultralytics-dev@fcakyon-claude-plugins    # Auto-formatting hooks
 /plugin install github-dev@fcakyon-claude-plugins         # Git workflow + GitHub MCP
-/plugin install tavily-tools@fcakyon-claude-plugins       # Tavily MCP
-/plugin install paper-search-tools@fcakyon-claude-plugins # Academic paper search MCP
-/plugin install supabase-tools@fcakyon-claude-plugins     # Supabase MCP
-/plugin install slack-tools@fcakyon-claude-plugins        # Slack MCP
-/plugin install mongodb-tools@fcakyon-claude-plugins      # MongoDB MCP (read-only)
-/plugin install gcloud-tools@fcakyon-claude-plugins       # GCloud Observability MCP
-/plugin install linear-tools@fcakyon-claude-plugins       # Linear MCP
-/plugin install azure-tools@fcakyon-claude-plugins        # Azure MCP (40+ services)
-/plugin install playwright-tools@fcakyon-claude-plugins   # E2E testing skill
+/plugin install tavily-tools@fcakyon-claude-plugins       # Tavily MCP & Skills
+/plugin install paper-search-tools@fcakyon-claude-plugins # Paper Search MCP & Skills
+/plugin install supabase-tools@fcakyon-claude-plugins     # Supabase MCP & Skills
+/plugin install slack-tools@fcakyon-claude-plugins        # Slack MCP & Skills
+/plugin install mongodb-tools@fcakyon-claude-plugins      # MongoDB MCP & Skills (read-only)
+/plugin install gcloud-tools@fcakyon-claude-plugins       # GCloud MCP & Skills
+/plugin install linear-tools@fcakyon-claude-plugins       # Linear MCP & Skills
+/plugin install azure-tools@fcakyon-claude-plugins        # Azure MCP & Skills (40+ services)
+/plugin install playwright-tools@fcakyon-claude-plugins   # Playwright MCP + E2E skill
 /plugin install general-dev@fcakyon-claude-plugins        # Code simplifier + utilities
 /plugin install notification-tools@fcakyon-claude-plugins # OS notifications
 /plugin install plugin-dev@fcakyon-claude-plugins         # Plugin development toolkit
@@ -68,7 +68,7 @@ Auto-formatting hooks for Python, JavaScript, Markdown, and Bash.
 </details>
 
 <details>
-<summary><strong>slack-tools</strong> - Slack MCP</summary>
+<summary><strong>slack-tools</strong> - Slack MCP & Skills</summary>
 
 Message search and channel history. Run `/slack-tools:setup` after install.
 
@@ -81,12 +81,12 @@ Message search and channel history. Run `/slack-tools:setup` after install.
 
 - [`/slack-tools:setup`](./plugins/slack-tools/commands/setup.md) - Configure Slack MCP
 
-**MCP:** [`.mcp.json`](./plugins/slack-tools/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/slack-tools/.mcp.json) | [ubie-oss/slack-mcp-server](https://github.com/ubie-oss/slack-mcp-server)
 
 </details>
 
 <details>
-<summary><strong>mongodb-tools</strong> - MongoDB MCP</summary>
+<summary><strong>mongodb-tools</strong> - MongoDB MCP & Skills</summary>
 
 Database exploration (read-only). Run `/mongodb-tools:setup` after install.
 
@@ -99,12 +99,12 @@ Database exploration (read-only). Run `/mongodb-tools:setup` after install.
 
 - [`/mongodb-tools:setup`](./plugins/mongodb-tools/commands/setup.md) - Configure MongoDB MCP
 
-**MCP:** [`.mcp.json`](./plugins/mongodb-tools/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/mongodb-tools/.mcp.json) | [mongodb-js/mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server)
 
 </details>
 
 <details>
-<summary><strong>gcloud-tools</strong> - GCloud Observability MCP</summary>
+<summary><strong>gcloud-tools</strong> - GCloud MCP & Skills</summary>
 
 Logs, metrics, and traces. Run `/gcloud-tools:setup` after install.
 
@@ -117,12 +117,12 @@ Logs, metrics, and traces. Run `/gcloud-tools:setup` after install.
 
 - [`/gcloud-tools:setup`](./plugins/gcloud-tools/commands/setup.md) - Configure GCloud MCP
 
-**MCP:** [`.mcp.json`](./plugins/gcloud-tools/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/gcloud-tools/.mcp.json) | [googleapis/gcloud-mcp](https://github.com/googleapis/gcloud-mcp)
 
 </details>
 
 <details>
-<summary><strong>linear-tools</strong> - Linear MCP</summary>
+<summary><strong>linear-tools</strong> - Linear MCP & Skills</summary>
 
 Issue tracking with OAuth. Run `/linear-tools:setup` after install.
 
@@ -135,12 +135,12 @@ Issue tracking with OAuth. Run `/linear-tools:setup` after install.
 
 - [`/linear-tools:setup`](./plugins/linear-tools/commands/setup.md) - Configure Linear MCP
 
-**MCP:** [`.mcp.json`](./plugins/linear-tools/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/linear-tools/.mcp.json) | [Linear MCP Docs](https://linear.app/docs/mcp)
 
 </details>
 
 <details>
-<summary><strong>azure-tools</strong> - Azure MCP</summary>
+<summary><strong>azure-tools</strong> - Azure MCP & Skills</summary>
 
 40+ Azure services with Azure CLI authentication. Run `/azure-tools:setup` after install.
 
@@ -153,18 +153,24 @@ Issue tracking with OAuth. Run `/linear-tools:setup` after install.
 
 - [`/azure-tools:setup`](./plugins/azure-tools/commands/setup.md) - Configure Azure MCP
 
-**MCP:** [`.mcp.json`](./plugins/azure-tools/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/azure-tools/.mcp.json) | [microsoft/mcp/Azure.Mcp.Server](https://github.com/microsoft/mcp/tree/main/servers/Azure.Mcp.Server)
 
 </details>
 
 <details>
-<summary><strong>playwright-tools</strong> - E2E testing skill</summary>
+<summary><strong>playwright-tools</strong> - Playwright MCP & Skills</summary>
 
-Playwright testing best practices (no MCP, no setup needed).
+Browser automation via MCP. Run `/playwright-tools:setup` after install. May require `npx playwright install` for browser binaries.
 
 **Skills:**
 
-- [`playwright-usage`](./plugins/playwright-tools/skills/playwright-usage/SKILL.md) - E2E testing best practices
+- [`playwright-testing`](./plugins/playwright-tools/skills/playwright-testing/SKILL.md) - E2E testing best practices
+
+**Commands:**
+
+- [`/playwright-tools:setup`](./plugins/playwright-tools/commands/setup.md) - Configure Playwright MCP
+
+**MCP:** [`.mcp.json`](./plugins/playwright-tools/.mcp.json) | [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp)
 
 </details>
 
@@ -186,12 +192,12 @@ Git and GitHub automation. Run `/github-dev:setup` after install.
 - [`/review-pr`](./plugins/github-dev/commands/review-pr.md) - Review pull request
 - [`/clean-gone-branches`](./plugins/github-dev/commands/clean-gone-branches.md) - Clean deleted branches
 
-**MCP:** [`.mcp.json`](./plugins/github-dev/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/github-dev/.mcp.json) | [github/github-mcp-server](https://github.com/github/github-mcp-server)
 
 </details>
 
 <details>
-<summary><strong>tavily-tools</strong> - Tavily MCP</summary>
+<summary><strong>tavily-tools</strong> - Tavily MCP & Skills</summary>
 
 Web search and content extraction. Run `/tavily-tools:setup` after install.
 
@@ -204,12 +210,12 @@ Web search and content extraction. Run `/tavily-tools:setup` after install.
 
 - [`/tavily-tools:setup`](./plugins/tavily-tools/commands/setup.md) - Configure Tavily MCP
 
-**MCP:** [`.mcp.json`](./plugins/tavily-tools/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/tavily-tools/.mcp.json) | [tavily-ai/tavily-mcp](https://github.com/tavily-ai/tavily-mcp)
 
 </details>
 
 <details>
-<summary><strong>paper-search-tools</strong> - Academic Paper Search MCP</summary>
+<summary><strong>paper-search-tools</strong> - Paper Search MCP & Skills</summary>
 
 Search papers across arXiv, PubMed, IEEE, Scopus, ACM. Run `/paper-search-tools:setup` after install. Requires Docker.
 
@@ -222,12 +228,12 @@ Search papers across arXiv, PubMed, IEEE, Scopus, ACM. Run `/paper-search-tools:
 
 - [`/paper-search-tools:setup`](./plugins/paper-search-tools/commands/setup.md) - Configure Paper Search MCP
 
-**MCP:** [`.mcp.json`](./plugins/paper-search-tools/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/paper-search-tools/.mcp.json) | [mcp/paper-search](https://hub.docker.com/r/mcp/paper-search)
 
 </details>
 
 <details>
-<summary><strong>supabase-tools</strong> - Supabase MCP</summary>
+<summary><strong>supabase-tools</strong> - Supabase MCP & Skills</summary>
 
 Database management with OAuth. Run `/supabase-tools:setup` after install.
 
@@ -240,7 +246,7 @@ Database management with OAuth. Run `/supabase-tools:setup` after install.
 
 - [`/supabase-tools:setup`](./plugins/supabase-tools/commands/setup.md) - Configure Supabase MCP
 
-**MCP:** [`.mcp.json`](./plugins/supabase-tools/.mcp.json)
+**MCP:** [`.mcp.json`](./plugins/supabase-tools/.mcp.json) | [supabase-community/supabase-mcp](https://github.com/supabase-community/supabase-mcp)
 
 </details>
 

--- a/plugins/gcloud-tools/commands/setup.md
+++ b/plugins/gcloud-tools/commands/setup.md
@@ -4,6 +4,8 @@ description: Configure GCloud CLI authentication
 
 # GCloud Tools Setup
 
+**Source:** [googleapis/gcloud-mcp](https://github.com/googleapis/gcloud-mcp)
+
 Check GCloud MCP status and configure CLI authentication if needed.
 
 ## Step 1: Check gcloud CLI

--- a/plugins/github-dev/.mcp.json
+++ b/plugins/github-dev/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "github": {
-    "type": "http",
-    "url": "https://api.githubcopilot.com/mcp",
-    "headers": {
-      "Authorization": "Bearer ${GITHUB_TOKEN}"
-    }
-  }
-}

--- a/plugins/github-dev/agents/commit-creator.md
+++ b/plugins/github-dev/agents/commit-creator.md
@@ -1,7 +1,7 @@
 ---
 name: commit-creator
 description: Use this agent when you have staged files ready for commit and need intelligent commit planning and execution. Examples: <example>Context: User has staged multiple files with different types of changes and wants to commit them properly. user: 'I've staged several files with bug fixes and new features. Can you help me commit these?' assistant: 'I'll use the commit-creator agent to analyze your staged files, create an optimal commit plan, and handle the commit process.' <commentary>The user has staged files and needs commit assistance, so use the commit-creator agent to handle the entire commit workflow.</commentary></example> <example>Context: User has made changes and wants to ensure proper commit organization. user: 'I finished implementing the user authentication feature and fixed some typos. Everything is staged.' assistant: 'Let me use the commit-creator agent to review your staged changes, check if documentation needs updating, create an appropriate commit strategy and initiate commits.' <commentary>User has completed work and staged files, perfect time to use commit-creator for proper commit planning.</commentary></example>
-tools: Bash, BashOutput, Glob, Grep, Read, WebSearch, WebFetch, TodoWrite, ListMcpResourcesTool, ReadMcpResourceTool, mcp__tavily__tavily_search, mcp__tavily__tavily_extract
+tools: Bash, BashOutput, Glob, Grep, Read, WebSearch, WebFetch, TodoWrite, mcp__tavily__tavily_search, mcp__tavily__tavily_extract
 color: blue
 skills: commit-workflow
 model: inherit

--- a/plugins/github-dev/agents/pr-creator.md
+++ b/plugins/github-dev/agents/pr-creator.md
@@ -1,7 +1,7 @@
 ---
 name: pr-creator
 description: Use this agent when you need to create a complete pull request workflow including branch creation, committing staged changes, and PR submission. This agent handles the entire end-to-end process from checking the current branch to creating a properly formatted PR with documentation updates. Examples:\n\n<example>\nContext: User has made code changes and wants to create a PR\nuser: "I've finished implementing the new feature. Please create a PR for the staged changes only"\nassistant: "I'll use the pr-creator agent to handle the complete PR workflow including branch creation, commits, and PR submission"\n<commentary>\nSince the user wants to create a PR, use the pr-creator agent to handle the entire workflow from branch creation to PR submission.\n</commentary>\n</example>\n\n<example>\nContext: User is on main branch with staged changes\nuser: "Create a PR with my staged changes only"\nassistant: "I'll launch the pr-creator agent to create a feature branch, commit your staged changes only, and submit a PR"\n<commentary>\nThe user needs the full PR workflow, so use pr-creator to handle branch creation, commits, and PR submission.\n</commentary>\n</example>
-tools: Bash, BashOutput, Glob, Grep, Read, WebSearch, WebFetch, TodoWrite, SlashCommand, ListMcpResourcesTool, ReadMcpResourceTool, mcp__tavily__tavily_search, mcp__tavily__tavily_extract
+tools: Bash, BashOutput, Glob, Grep, Read, WebSearch, WebFetch, TodoWrite, SlashCommand, mcp__tavily__tavily_search, mcp__tavily__tavily_extract
 color: cyan
 skills: pr-workflow, commit-workflow
 model: inherit

--- a/plugins/github-dev/commands/setup.md
+++ b/plugins/github-dev/commands/setup.md
@@ -4,6 +4,8 @@ description: Configure GitHub CLI authentication
 
 # GitHub CLI Setup
 
+**Source:** [github/github-mcp-server](https://github.com/github/github-mcp-server)
+
 Configure `gh` CLI for GitHub access.
 
 ## Step 1: Check Current Status

--- a/plugins/linear-tools/commands/setup.md
+++ b/plugins/linear-tools/commands/setup.md
@@ -4,6 +4,8 @@ description: Configure Linear OAuth authentication
 
 # Linear Tools Setup
 
+**Source:** [Linear MCP Docs](https://linear.app/docs/mcp)
+
 Check Linear MCP status and configure OAuth if needed.
 
 ## Step 1: Test Current Setup

--- a/plugins/mongodb-tools/commands/setup.md
+++ b/plugins/mongodb-tools/commands/setup.md
@@ -4,6 +4,8 @@ description: Configure MongoDB MCP connection
 
 # MongoDB Tools Setup
 
+**Source:** [mongodb-js/mongodb-mcp-server](https://github.com/mongodb-js/mongodb-mcp-server)
+
 Check MongoDB MCP status and configure connection if needed.
 
 ## Step 1: Test Current Setup

--- a/plugins/paper-search-tools/commands/setup.md
+++ b/plugins/paper-search-tools/commands/setup.md
@@ -4,6 +4,8 @@ description: Configure Paper Search MCP (requires Docker)
 
 # Paper Search Tools Setup
 
+**Source:** [mcp/paper-search](https://hub.docker.com/r/mcp/paper-search)
+
 Configure the Paper Search MCP server. Requires Docker.
 
 ## Step 1: Check Docker Installation

--- a/plugins/playwright-tools/.claude-plugin/plugin.json
+++ b/plugins/playwright-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-tools",
-  "version": "2.0.0",
-  "description": "Playwright E2E testing best practices skill covering auth, file uploads, and flaky test fixes.",
+  "version": "2.1.0",
+  "description": "Playwright MCP server for browser automation plus E2E testing best practices skill.",
   "author": {
     "name": "Fatih Akyon"
   },

--- a/plugins/playwright-tools/.mcp.json
+++ b/plugins/playwright-tools/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "playwright": {
+    "command": "npx",
+    "args": ["@playwright/mcp@latest"]
+  }
+}

--- a/plugins/playwright-tools/commands/setup.md
+++ b/plugins/playwright-tools/commands/setup.md
@@ -1,0 +1,104 @@
+---
+description: Configure Playwright MCP
+---
+
+# Playwright Tools Setup
+
+**Source:** [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp)
+
+Check Playwright MCP status and configure browser dependencies if needed.
+
+## Step 1: Test Current Setup
+
+Run `/mcp` command to check if playwright server is listed and connected.
+
+If playwright server shows as connected: Tell user Playwright is configured and working.
+
+If playwright server is missing or shows connection error: Continue to Step 2.
+
+## Step 2: Browser Installation
+
+Tell the user:
+
+```
+Playwright MCP requires browser binaries. Install them with:
+
+npx playwright install
+
+This installs Chromium, Firefox, and WebKit browsers.
+
+For a specific browser only:
+npx playwright install chromium
+npx playwright install firefox
+npx playwright install webkit
+```
+
+## Step 3: Browser Options
+
+The MCP server supports these browsers via the `--browser` flag in `.mcp.json`:
+
+- `chrome` (default)
+- `firefox`
+- `webkit`
+- `msedge`
+
+Example `.mcp.json` for Firefox:
+
+```json
+{
+  "playwright": {
+    "command": "npx",
+    "args": ["@playwright/mcp@latest", "--browser", "firefox"]
+  }
+}
+```
+
+## Step 4: Headless Mode
+
+For headless operation (no visible browser), add `--headless`:
+
+```json
+{
+  "playwright": {
+    "command": "npx",
+    "args": ["@playwright/mcp@latest", "--headless"]
+  }
+}
+```
+
+## Step 5: Restart
+
+Tell the user:
+
+```
+After making changes:
+1. Exit Claude Code
+2. Run `claude` again
+
+Changes take effect after restart.
+```
+
+## Troubleshooting
+
+If Playwright MCP fails:
+
+```
+Common fixes:
+1. Browser not found - Run `npx playwright install`
+2. Permission denied - Check file permissions on browser binaries
+3. Display issues - Use `--headless` flag for headless mode
+4. Timeout errors - Increase timeout with `--timeout-navigation 120000`
+```
+
+## Alternative: Disable Plugin
+
+If user doesn't need browser automation:
+
+```
+To disable this plugin:
+1. Run /mcp command
+2. Find the playwright server
+3. Disable it
+
+This prevents errors from missing browser binaries.
+```

--- a/plugins/slack-tools/commands/setup.md
+++ b/plugins/slack-tools/commands/setup.md
@@ -4,6 +4,8 @@ description: Configure Slack MCP tokens
 
 # Slack Tools Setup
 
+**Source:** [ubie-oss/slack-mcp-server](https://github.com/ubie-oss/slack-mcp-server)
+
 Check Slack MCP status and configure tokens if needed.
 
 ## Step 1: Test Current Setup

--- a/plugins/supabase-tools/commands/setup.md
+++ b/plugins/supabase-tools/commands/setup.md
@@ -4,6 +4,8 @@ description: Configure Supabase MCP with OAuth authentication
 
 # Supabase Tools Setup
 
+**Source:** [supabase-community/supabase-mcp](https://github.com/supabase-community/supabase-mcp)
+
 Configure the official Supabase MCP server with OAuth.
 
 ## Step 1: Check Current Status

--- a/plugins/tavily-tools/commands/setup.md
+++ b/plugins/tavily-tools/commands/setup.md
@@ -4,6 +4,8 @@ description: Configure Tavily MCP server credentials
 
 # Tavily Tools Setup
 
+**Source:** [tavily-ai/tavily-mcp](https://github.com/tavily-ai/tavily-mcp)
+
 Configure the Tavily MCP server with your API key.
 
 ## Step 1: Check Current Status


### PR DESCRIPTION
- Enhanced README.md with detailed plugin descriptions and sources.
- Added source links to setup documentation for GCloud, GitHub, Linear, MongoDB, Paper Search, Playwright, Slack, Supabase, and Tavily tools.
- Updated Playwright plugin version and added setup instructions.
- Removed deprecated GitHub MCP configuration file.