### PR TITLE
Add colored statusline with cache hit rate display

### DIFF
--- a/plugins/claude-tools/skills/statusline-setup/SKILL.md
+++ b/plugins/claude-tools/skills/statusline-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: statusline-setup
-description: This skill should be used when user asks to "configure statusline", "setup statusline", "show context usage", "display token count", "statusline not working", or wants to change how the Claude Code status bar displays information.
+description: This skill should be used when user asks to "configure statusline", "setup statusline", "show context usage", "display token count", "cache hit rate", "statusline colors", "statusline not working", or wants to change how the Claude Code status bar displays information.
 ---
 
 # Statusline Setup
@@ -9,17 +9,29 @@ Run `/claude-tools:statusline-setup` to configure the Claude Code statusline.
 
 ## Options
 
-- **Native (session context % and cost)** - Anthropic API only
+- **Native (colored, with cache %)** - Anthropic API only, color-coded display
 - **ccusage (session/daily stats)** - works with z.ai too
 - **Disable** - Remove statusline display
 
 ## What Native Statusline Shows
 
-`[Model] Context% | $Cost`
+`Model | Context: X% | Cache: Y% | $Z.ZZ`
 
-- Model name (e.g., Opus, Sonnet)
-- Session context window usage percentage
+Example: `Opus 4.5 | Context: 26% | Cache: 85% | $0.40`
+
+**Displayed information:**
+
+- Model name (e.g., Opus 4.5, Sonnet)
+- Context window usage percentage with color coding
+- Cache hit rate (prompt caching efficiency)
 - Session cost in USD
+
+**Color scheme:**
+
+- Context % green when <50% (plenty of room)
+- Context % yellow when 50-80% (getting full)
+- Context % red when >80% (near autocompact at 95%)
+- Labels and separators are dimmed for readability
 
 **Note:** Native may not work with z.ai/third-party endpoints. Use ccusage for z.ai.
 
@@ -29,3 +41,7 @@ Native statusline requires `jq`. Install:
 
 - macOS: `brew install jq`
 - Ubuntu/Debian: `sudo apt install jq`
+
+## Docs
+
+[Claude Code statusline docs](https://code.claude.com/docs/en/statusline) for more details.


### PR DESCRIPTION
Add color-coded context usage and cache hit rate to the native statusline.

![CleanShot 2025-12-25 at 05 15 45@2x](https://github.com/user-attachments/assets/8c3da893-6335-460f-b6b9-9ed2071e6d5d)

- Add ANSI color-coded context percentage (green <50%, yellow 50-80%, red >80%) in [commands/statusline-setup.md:73-99](plugins/claude-tools/commands/statusline-setup.md#L73-L99)
- Display cache hit rate showing prompt caching efficiency
- Update statusline format: `Opus 4.5 | Context: 26% | Cache: 85% | $0.40`
- Dim labels and separators for readability
- Update skill triggers to include "cache hit rate" and "statusline colors" in [SKILL.md:3](plugins/claude-tools/skills/statusline-setup/SKILL.md#L3)