### PR TITLE
Make statusline plugin cross-platform without extra dependency

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins featuring skills, slash commands, autonomous subagents, hooks, and MCP server integrations for Git workflow, code review, and plugin development.",
-    "version": "2.0.6"
+    "version": "2.0.7"
   },
   "plugins": [
     {
@@ -42,7 +42,7 @@
       "name": "statusline-tools",
       "source": "./plugins/statusline-tools",
       "description": "Cross-platform statusline showing session context, cost, and account-wide 5H usage with time until reset.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/plugins/statusline-tools/.claude-plugin/plugin.json
+++ b/plugins/statusline-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "statusline-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cross-platform statusline showing session context, cost, and account-wide 5H usage with time until reset.",
   "author": {
     "name": "Fatih Akyon"


### PR DESCRIPTION
Remove jq dependency from statusline script for native shell compatibility.

- Replace jq JSON parsing with sed-based extraction in [plugins/statusline-tools/scripts/statusline.sh](plugins/statusline-tools/scripts/statusline.sh)
- Reduce script from 115 to 72 lines while maintaining functionality
- Bump version to 1.0.1 in plugin.json and marketplace.json