### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -244,6 +244,22 @@
       "tags": ["research", "academic", "latex"]
     },
     {
+      "name": "mmx-cli",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/MiniMax-AI/cli.git",
+        "path": "skill"
+      },
+      "description": "MiniMax AI CLI skill for generating text, images, video, speech, and music, plus web search via the MiniMax platform.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/MiniMax-AI/cli",
+      "repository": "https://github.com/MiniMax-AI/cli",
+      "license": "MIT",
+      "keywords": ["minimax", "ai", "image", "video", "speech", "music", "text-generation", "web-search"],
+      "category": "ai",
+      "tags": ["ai", "generation"]
+    },
+    {
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to the Claude Code marketplace via `git-subdir` source so the mmx-cli skill is discoverable out of the box
- Users can install via `/plugin install mmx-cli@claude-settings` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**1 file changed, 16 lines added.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard.

## Test plan

- `/plugin install mmx-cli@claude-settings` installs successfully
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal