### PR TITLE
Fix Codex startup and move MiniMax to a recipe file

### DIFF
--- a/.codex/config-minimax.toml
+++ b/.codex/config-minimax.toml
@@ -1,0 +1,25 @@
+# MiniMax recipe for Codex CLI.
+# Copy the blocks below into ~/.codex/config.toml to activate.
+# This file is NOT auto-loaded; Codex only reads config.toml.
+#
+# Compatibility note (as of 2026-04):
+#   Codex CLI no longer accepts wire_api = "chat" (openai/codex PR #10157,
+#   merged 2026-02-03). MiniMax's OpenAI-compatible endpoint exposes only
+#   /v1/chat/completions, so pointing base_url at api.minimax.io directly
+#   will fail at either parse time or runtime.
+#
+#   Workaround: run a Responses API translation proxy locally (LiteLLM,
+#   LM Studio, or llama.cpp server) that forwards to MiniMax, then set
+#   base_url to the proxy URL below.
+#
+# Claude Code users: MiniMax's Anthropic-compatible endpoint works directly
+# without a proxy. See .claude/settings-minimax.json and README.md.
+
+model = "MiniMax-M2.7"
+model_provider = "minimax"
+
+[model_providers.minimax]
+name = "MiniMax"
+base_url = "http://localhost:4000/v1"   # local Responses API proxy, not api.minimax.io
+env_key = "MINIMAX_API_KEY"
+wire_api = "responses"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -17,11 +17,3 @@ name = "Azure OpenAI"
 base_url = "https://YOUR-AZURE-OPENAI.openai.azure.com/openai/v1"
 env_key = "AZURE_OPENAI_API_KEY"
 wire_api = "responses"
-
-# MiniMax (OpenAI-compatible, 204K context)
-# To use: set model_provider = "minimax" and model = "MiniMax-M2.7"
-[model_providers.minimax]
-name = "MiniMax"
-base_url = "https://api.minimax.io/v1"
-env_key = "MINIMAX_API_KEY"
-wire_api = "chat"

--- a/README.md
+++ b/README.md
@@ -788,6 +788,8 @@ export ENABLE_TOOL_SEARCH=false
 
 Or use the settings file: [`.claude/settings-minimax.json`](./.claude/settings-minimax.json)
 
+For Codex CLI, see the recipe at [`.codex/config-minimax.toml`](./.codex/config-minimax.toml). Note that Codex requires a local Responses API proxy since MiniMax only exposes chat completions.
+
 </details>
 
 <details>


### PR DESCRIPTION
Codex CLI was failing to start because the inactive MiniMax provider block in `.codex/config.toml` used `wire_api = "chat"`, which Codex dropped in [openai/codex#10157](https://github.com/openai/codex/pull/10157). Codex validates every provider block on load, so one invalid entry killed launch even when Azure was the active provider.

- Removed the MiniMax block from `.codex/config.toml` so Codex starts cleanly with just Azure
- Added `.codex/config-minimax.toml` as a copy-paste recipe (same pattern as `.claude/settings-minimax.json`), with a note that MiniMax only exposes `/v1/chat/completions` and needs a local Responses-API proxy
- README points Codex users at the new recipe file

Codex users who want MiniMax now copy `.codex/config-minimax.toml` into `~/.codex/config.toml` and run a local proxy (LiteLLM, LM Studio, or llama.cpp server).