### PR TITLE
Add intelligent-compact plugin for higher-fidelity auto-compact

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,6 +5,18 @@
   },
   "plugins": [
     {
+      "name": "intelligent-compact",
+      "source": {
+        "source": "local",
+        "path": "./plugins/intelligent-compact"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "development"
+    },
+    {
       "name": "anthropic-office-skills",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,21 @@
   },
   "plugins": [
     {
+      "name": "intelligent-compact",
+      "source": "./plugins/intelligent-compact",
+      "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["precompact", "compact", "summary", "context", "hooks"],
+      "category": "development",
+      "tags": ["context", "hooks"]
+    },
+    {
       "name": "anthropic-office-skills",
       "source": "./plugins/anthropic-office-skills",
       "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -3,6 +3,12 @@
   "displayName": "Claude & Cursor Settings",
   "plugins": [
     {
+      "name": "intelligent-compact",
+      "source": "./plugins/intelligent-compact",
+      "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings.",
+      "version": "1.0.0"
+    },
+    {
       "name": "anthropic-office-skills",
       "source": "./plugins/anthropic-office-skills",
       "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing.",

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ ln -sfn CLAUDE.md GEMINI.md
 ## Plugins
 
 <details>
+<summary><strong>intelligent-compact</strong> - PreCompact hook that preserves high-signal context in auto-compact summaries</summary>
+
+| Claude Code                                           | Codex CLI                                                                     | Gemini CLI                                                       |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `/plugin install intelligent-compact@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `intelligent-compact` | `gemini extensions install --path ./plugins/intelligent-compact` |
+
+Claude Code's auto-compact summarizes long sessions to fit the context window, but the default summary routinely drops the highest-signal facts: file paths under investigation, confirmed root causes, remaining tasks, unanswered questions, metrics and IDs, and findings from expensive subagent runs. This plugin ships a single PreCompact hook that injects A-F fidelity requirements on top of the 9-section default compact prompt, so those categories survive every `/compact` (manual) and every auto compaction. Active on Claude Code only; Codex, Cursor, and Gemini CLI do not yet expose a PreCompact hook.
+
+**Hooks:**
+
+- [`precompact_priorities.sh`](./plugins/intelligent-compact/hooks/scripts/precompact_priorities.sh) - Priority-preservation instructions for the compaction summarizer
+
+</details>
+
+<details>
 <summary><strong>anthropic-office-skills</strong> - Official Anthropic PDF, Word, PowerPoint, Excel skills</summary>
 
 | Claude Code                                               | Codex CLI                                                                         | Gemini CLI                                                           |

--- a/plugins/intelligent-compact/.claude-plugin/plugin.json
+++ b/plugins/intelligent-compact/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "intelligent-compact",
+  "version": "1.0.0",
+  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings."
+}

--- a/plugins/intelligent-compact/.codex-plugin/plugin.json
+++ b/plugins/intelligent-compact/.codex-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "intelligent-compact",
+  "version": "1.0.0",
+  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings."
+}

--- a/plugins/intelligent-compact/.cursor-plugin/plugin.json
+++ b/plugins/intelligent-compact/.cursor-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "intelligent-compact",
+  "version": "1.0.0",
+  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings."
+}

--- a/plugins/intelligent-compact/gemini-extension.json
+++ b/plugins/intelligent-compact/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "intelligent-compact",
+  "version": "1.0.0",
+  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings."
+}

--- a/plugins/intelligent-compact/hooks/hooks.json
+++ b/plugins/intelligent-compact/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "PreCompact hook that injects priority-preservation instructions into the conversation summary",
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/precompact_priorities.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/intelligent-compact/hooks/scripts/precompact_priorities.sh
+++ b/plugins/intelligent-compact/hooks/scripts/precompact_priorities.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# precompact_priorities.sh
+#
+# Claude Code fires PreCompact before each /compact (manual) and each
+# auto compaction. This script's trimmed stdout becomes the
+# "Additional Instructions:" block appended after the default 9-section
+# compact prompt.
+#
+# Each rule below is a fidelity requirement layered onto one of the
+# existing default sections (1-9) rather than a parallel taxonomy, so
+# the summarizer has one coherent shape to fill.
+#
+# The quoted heredoc delimiter ('PRIORITY_BLOCK') disables every form of
+# shell expansion, so apostrophes, em-dashes, and backticks in the block
+# pass through untouched with zero escaping.
+
+cat << 'PRIORITY_BLOCK'
+<priority-preservation-instructions>
+These requirements augment the 9 required sections. They do not replace
+any section — they raise the fidelity bar for content categories that
+the default prompt leaves under-specified.
+
+A. UNANSWERED QUESTIONS (patches §6 and §7)
+   The default §6 says to list ALL user messages but does not ask you
+   to flag which ones went unanswered. For each §6 message, mark it as
+   answered, partially answered, or unanswered. In §7, add a
+   sub-heading "Pending Questions" at the top and list every
+   unanswered or partially answered user question verbatim.
+
+B. ROOT CAUSES, NOT SYMPTOMS (patches §4 and §5)
+   The default §4 asks for "errors and fixes" but does not distinguish
+   confirmed root causes from ruled-out hypotheses. In §5, record
+   every confirmed root cause with its file path and line number
+   (pattern: `path/to/file.py:42`). In §4, keep ruled-out hypotheses
+   so they don't get re-tried. Never paraphrase an error message,
+   error code, or stack frame — preserve them verbatim.
+
+C. EXACT NUMBERS AND IDS (patches §3, §4, §5)
+   The default prompt nowhere tells you to preserve exact digits. Do
+   so everywhere they appear: benchmark results, profiling output,
+   error rates, latencies, token counts, costs, PR numbers, issue
+   numbers, commit SHAs, run IDs, dataset names, and model IDs. Never
+   round, never paraphrase a quantitative value.
+
+D. FILE PATH IMPORTANCE TIERS (patches §3)
+   The default §3 lists files flat. Group them by importance instead:
+   critical (caused or fixed the issue), referenced (read for
+   context), mentioned (appeared in discussion only). Use the pattern
+   `path/to/file.py:42` whenever a specific line matters.
+
+E. SUBAGENT FINDINGS ARE PRIMARY EVIDENCE (patches §3 and §5)
+   The default prompt does not call out Task / Agent tool results.
+   For every such tool result in the transcript, preserve the agent's
+   final report in full in §3 or §5 as appropriate — file paths, code
+   references, citations, and quantitative findings it returned.
+   Subagent runs are expensive to redo; treat their reports as
+   primary evidence, not as compressible chatter.
+
+F. A-VS-B COMPARISONS (patches §1)
+   The default §1 asks for explicit requests and intents but says
+   nothing about alternatives under evaluation. When the user was
+   weighing option A vs option B (tool X vs tool Y, approach 1 vs
+   approach 2), preserve both sides and the decision criteria. If a
+   decision was reached, record which side won and the reasoning.
+
+Priority when cutting for length: if A–F would otherwise be dropped
+to fit within a section's length, drop conversational filler,
+repeated tool output, and intermediate reasoning first.
+</priority-preservation-instructions>
+PRIORITY_BLOCK


### PR DESCRIPTION
Adds a new plugin that makes Claude Code's auto-compact preserve the high-signal bits it usually paraphrases away. It appends six rules to the built-in compact prompt via a PreCompact hook, covering pending user questions, confirmed vs ruled-out root causes with `file:line`, exact digits (PR numbers, SHAs, metrics, model IDs), file importance tiers, full subagent reports, and A-vs-B decision criteria.

- PreCompact hook only activates in Claude Code; manifests ship for Codex, Cursor, and Gemini for format parity
- Listed first in all three marketplace files and the README plugin table

`/plugin install intelligent-compact@claude-settings`