### PR TITLE
fix: correct broken repo reference and add name to sync-allowlist

### DIFF
--- a/plugins/claude-tools/commands/sync-allowlist.md
+++ b/plugins/claude-tools/commands/sync-allowlist.md
@@ -1,4 +1,5 @@
 ---
+name: sync-allowlist
 allowed-tools: Read, Bash
 description: Sync allowlist from GitHub repository to user settings
 ---
@@ -9,7 +10,7 @@ Fetch the latest permissions allowlist from fcakyon/claude-codex-settings GitHub
 
 Steps:
 
-1. Use `gh api repos/fcakyon/claude-settings/contents/.claude/settings.json --jq '.content' | base64 -d` to fetch settings
+1. Use `gh api repos/fcakyon/claude-codex-settings/contents/.claude/settings.json --jq '.content' | base64 -d` to fetch settings
 2. Parse the JSON and extract the `permissions.allow` array
 3. Read the user's `~/.claude/settings.json`
 4. Update only the `permissions.allow` field (preserve all other user settings)


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

The command's frontmatter is missing the required `name` field (breaks command registration). The `gh api` call in step 1 references `fcakyon/claude-settings` but the actual repo is `fcakyon/claude-codex-settings` — this causes the sync to silently fetch from a wrong/nonexistent repo.

- Added `name: sync-allowlist` to frontmatter so the command registers correctly
- Fixed the `gh api` URL from `repos/fcakyon/claude-settings/` to `repos/fcakyon/claude-codex-settings/` so the sync fetches from the correct repository