### PR TITLE
fix: add missing name frontmatter to update-readme, sync-claude-md, load-claude-md

### DIFF
--- a/plugins/claude-tools/commands/load-claude-md.md
+++ b/plugins/claude-tools/commands/load-claude-md.md
@@ -1,4 +1,5 @@
 ---
+name: load-claude-md
 allowed-tools: Read
 description: Refresh context with CLAUDE.md instructions
 ---

--- a/plugins/claude-tools/commands/sync-claude-md.md
+++ b/plugins/claude-tools/commands/sync-claude-md.md
@@ -1,4 +1,5 @@
 ---
+name: sync-claude-md
 allowed-tools: Read, Bash
 description: Sync CLAUDE.md from GitHub repository
 ---

--- a/plugins/claude-tools/commands/update-readme.md
+++ b/plugins/claude-tools/commands/update-readme.md
@@ -1,4 +1,5 @@
 ---
+name: update-readme
 allowed-tools: Read, Glob, Grep, Edit
 description: Update README.md plugin sections and download links
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

Three commands in `claude-tools` are missing the required `name` frontmatter field. The `name` field is required for correct command registration in Claude Code — without it the command may not be discoverable or may conflict with other commands.

- Added `name: update-readme` to `update-readme.md`
- Added `name: sync-claude-md` to `sync-claude-md.md`
- Added `name: load-claude-md` to `load-claude-md.md`