### PR TITLE
fix: add missing name and allowed-tools to tavily, azure, gcloud, paper-search setup commands

### DIFF
--- a/plugins/azure-tools/commands/setup.md
+++ b/plugins/azure-tools/commands/setup.md
@@ -1,4 +1,6 @@
 ---
+name: setup
+allowed-tools: Bash, Read
 description: Configure Azure MCP server with Azure CLI authentication
 ---
 

--- a/plugins/gcloud-tools/commands/setup.md
+++ b/plugins/gcloud-tools/commands/setup.md
@@ -1,4 +1,6 @@
 ---
+name: setup
+allowed-tools: Bash
 description: Configure GCloud CLI authentication
 ---
 

--- a/plugins/paper-search-tools/commands/setup.md
+++ b/plugins/paper-search-tools/commands/setup.md
@@ -1,4 +1,6 @@
 ---
+name: setup
+allowed-tools: Bash
 description: Configure Paper Search MCP (requires Docker)
 ---
 

--- a/plugins/tavily-tools/commands/setup.md
+++ b/plugins/tavily-tools/commands/setup.md
@@ -1,4 +1,6 @@
 ---
+name: setup
+allowed-tools: Bash, Read, Write
 description: Configure Tavily MCP server credentials
 ---
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

Four setup commands are missing the required `name` and `allowed-tools` frontmatter fields. Missing `name` prevents correct command registration. Missing `allowed-tools` means Claude won't have the necessary tool permissions when running the command.

- Added `name: setup` and `allowed-tools: Bash, Read, Write` to `tavily-tools/commands/setup.md`
- Added `name: setup` and `allowed-tools: Bash, Read` to `azure-tools/commands/setup.md`
- Added `name: setup` and `allowed-tools: Bash` to `gcloud-tools/commands/setup.md`
- Added `name: setup` and `allowed-tools: Bash` to `paper-search-tools/commands/setup.md`