### PR TITLE
fix: add missing frontmatter to 10 supabase-cli reference skill docs

### DIFF
--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/functions.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/functions.md
@@ -1,3 +1,8 @@
+---
+name: supabase-functions
+description: Reference for Supabase Edge Functions CLI commands.
+---
+
 ## supabase-functions
 
 Manage Supabase Edge Functions.

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/gen.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/gen.md
@@ -1,3 +1,8 @@
+---
+name: supabase-gen
+description: Reference for Supabase type generation CLI commands.
+---
+
 ## supabase-gen
 
 Automatically generates type definitions based on your Postgres database schema.

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/init.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/init.md
@@ -1,3 +1,8 @@
+---
+name: supabase-init
+description: Reference for Supabase project initialization CLI commands.
+---
+
 ## supabase-init
 
 Initialize configurations for Supabase local development.

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/link.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/link.md
@@ -1,3 +1,8 @@
+---
+name: supabase-link
+description: Reference for Supabase project linking CLI commands.
+---
+
 ## supabase-link
 
 Link your local development project to a hosted Supabase project.

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/login.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/login.md
@@ -1,3 +1,8 @@
+---
+name: supabase-login
+description: Reference for Supabase CLI authentication commands.
+---
+
 ## supabase-login
 
 Connect the Supabase CLI to your Supabase account by logging in with your [personal access token](https://supabase.com/dashboard/account/tokens).

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/projects.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/projects.md
@@ -1,3 +1,8 @@
+---
+name: supabase-projects
+description: Reference for Supabase project management CLI commands.
+---
+
 ## supabase-projects
 
 Provides tools for creating and managing your Supabase projects.

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/secrets.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/secrets.md
@@ -1,3 +1,8 @@
+---
+name: supabase-secrets
+description: Reference for Supabase secrets management CLI commands.
+---
+
 ## supabase-secrets
 
 Provides tools for managing environment variables and secrets for your Supabase project.

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/start.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/start.md
@@ -1,3 +1,8 @@
+---
+name: supabase-start
+description: Reference for Supabase local development stack start commands.
+---
+
 ## supabase-start
 
 Starts the Supabase local development stack.

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/status.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/status.md
@@ -1,3 +1,8 @@
+---
+name: supabase-status
+description: Reference for Supabase local development stack status commands.
+---
+
 ## supabase-status
 
 Shows status of the Supabase local development stack.

--- a/plugins/supabase-skills/skills/supabase-cli/references/commands/stop.md
+++ b/plugins/supabase-skills/skills/supabase-cli/references/commands/stop.md
@@ -1,3 +1,8 @@
+---
+name: supabase-stop
+description: Reference for Supabase local development stack stop commands.
+---
+
 ## supabase-stop
 
 Stops the Supabase local development stack.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

Ten skill reference docs under `supabase-cli/references/commands/` are missing the required SKILL.md frontmatter block (`name` and `description`). Without frontmatter, these files score 50/100 on the NL quality scale and may not be loaded correctly as skills. The fix prepends a minimal frontmatter block to each file without modifying any existing content.

Files updated: `functions.md`, `gen.md`, `init.md`, `link.md`, `login.md`, `projects.md`, `secrets.md`, `start.md`, `status.md`, `stop.md`