### PR TITLE
fix: add path traversal guard in sync_marketplace_to_plugins.py

### DIFF
--- a/plugins/claude-tools/hooks/scripts/sync_marketplace_to_plugins.py
+++ b/plugins/claude-tools/hooks/scripts/sync_marketplace_to_plugins.py
@@ -47,6 +47,10 @@ def sync_marketplace_to_plugins():
 
         # Resolve plugin directory relative to marketplace root
         plugin_dir = (marketplace_dir / source).resolve()
+        # Guard against path traversal if marketplace.json is tampered
+        if not str(plugin_dir).startswith(str(marketplace_dir.resolve())):
+            print(f"⚠ Skipping {source!r}: resolved path escapes plugin root", file=sys.stderr)
+            continue
         plugin_json_dir = plugin_dir / ".claude-plugin"
         plugin_json_path = plugin_json_dir / "plugin.json"
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

The `sync_marketplace_to_plugins.py` hook script resolves the `source` field from `marketplace.json` into a file path but does not verify that the resolved path stays within the expected plugin root. A tampered `marketplace.json` could write files outside the repository. This PR adds a guard that skips any entry whose resolved path escapes the marketplace root.

- Added a check after `plugin_dir = (marketplace_dir / source).resolve()` that compares the resolved path against the marketplace root
- If the resolved path escapes the root, the entry is skipped with a warning to stderr and the loop continues