### PR TITLE
Raise auto-compact window to 400K for long sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,9 +5,9 @@
     "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY": "1",
     "DISABLE_BUG_COMMAND": "1",
     "DISABLE_ERROR_REPORTING": "1",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7[1m]",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-4-7",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6[1m]",
     "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-7",
     "MAX_MCP_OUTPUT_TOKENS": "40000",
     "CLAUDE_CODE_EFFORT_LEVEL": "xhigh",
@@ -16,7 +16,8 @@
     "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": "1",
     "CLAUDE_CODE_NEW_INIT": "1",
     "CLAUDE_CODE_NO_FLICKER": "1",
-    "ENABLE_PROMPT_CACHING_1H": "1"
+    "ENABLE_PROMPT_CACHING_1H": "1",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"
   },
   "attribution": {
     "commit": "",
@@ -146,6 +147,7 @@
   },
   "outputStyle": "Explanatory",
   "model": "opus",
+  "autoScrollEnabled": false,
   "extraKnownMarketplaces": {
     "claude-settings": {
       "source": {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -5,6 +5,7 @@ approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 web_search = "live"
 personality = "pragmatic"
+model_auto_compact_token_limit = 400000
 
 [sandbox_workspace_write]
 network_access = true


### PR DESCRIPTION
Opt Opus 4.7 and Sonnet 4.6 into their 1M context windows and raise the auto-compact trigger to 400K so long sessions on large codebases stop compacting too early. Also disables output auto-scroll so earlier content stays readable while streaming.

- Claude Code: adds `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000` and pins opus/summarizer models with `[1m]` suffix
- Codex CLI: adds `model_auto_compact_token_limit = 400000` (direct threshold, not a percentage)
- Top-level Claude Code setting: `autoScrollEnabled: false`

```toml
# .codex/config.toml
model_auto_compact_token_limit = 400000
```