### PR TITLE
Fix telemetry hook crash on string toolUseResult

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "claude-telemetry-hooks",
       "source": "./plugins/claude-telemetry-hooks",
       "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "claude-telemetry-hooks",
       "source": "./plugins/claude-telemetry-hooks",
       "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events.",
-      "version": "1.0.0"
+      "version": "1.0.1"
     },
     {
       "name": "anthropic-office-skills",

--- a/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events."
 }

--- a/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events."
 }

--- a/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events."
 }

--- a/plugins/claude-telemetry-hooks/gemini-extension.json
+++ b/plugins/claude-telemetry-hooks/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events."
 }

--- a/plugins/claude-telemetry-hooks/hooks/scripts/user_prompt_reject_feedback.py
+++ b/plugins/claude-telemetry-hooks/hooks/scripts/user_prompt_reject_feedback.py
@@ -20,14 +20,47 @@ from pathlib import Path
 
 CATEGORIES = [
     ("profanity", re.compile(r"\b(fuck(?:ed|ing)?|shit|wtf|bullshit|dumb|idiot|stupid)\b|fuck'?s sake", re.I)),
-    ("factual_challenge", re.compile(r"\b(you (said|did|claimed|fucked|forgot|lied|missed)|lying|hallucin|made up|no such|doesn'?t exist)\b|wtf\?", re.I)),
+    (
+        "factual_challenge",
+        re.compile(
+            r"\b(you (said|did|claimed|fucked|forgot|lied|missed)|lying|hallucin|made up|no such|doesn'?t exist)\b|wtf\?",
+            re.I,
+        ),
+    ),
     ("terse_reject", re.compile(r"^(no|nope|stop|halt|wrong|revert|undo|nah)[!.\s]?$|^no[ ,!]", re.I)),
-    ("wrong_target", re.compile(r"\b(i meant|wrong (file|place|repo|branch|machine|directory)|not that|not the|same (file|place|location))\b|^no,? i\b", re.I)),
-    ("tool_steering", re.compile(r"\b(use|just use|stick to|prefer)\b.*\b(rg|grep|gh|tavily|mcp|slack|bun|uv|pytest|jq)\b|\binstead of\b", re.I)),
-    ("scope_drift", re.compile(r"\b(without breaking|only (do|fix|change|the)|don'?t (touch|change|modify|add|create|put|run)|overengin|bloated|no need (to|for))\b", re.I)),
-    ("verify_first", re.compile(r"\b(check (first|docs|code|source|the)|have you (checked|read|verified)|read (the )?(code|docs|source)|move with evidence)\b", re.I)),
+    (
+        "wrong_target",
+        re.compile(
+            r"\b(i meant|wrong (file|place|repo|branch|machine|directory)|not that|not the|same (file|place|location))\b|^no,? i\b",
+            re.I,
+        ),
+    ),
+    (
+        "tool_steering",
+        re.compile(
+            r"\b(use|just use|stick to|prefer)\b.*\b(rg|grep|gh|tavily|mcp|slack|bun|uv|pytest|jq)\b|\binstead of\b",
+            re.I,
+        ),
+    ),
+    (
+        "scope_drift",
+        re.compile(
+            r"\b(without breaking|only (do|fix|change|the)|don'?t (touch|change|modify|add|create|put|run)|overengin|bloated|no need (to|for))\b",
+            re.I,
+        ),
+    ),
+    (
+        "verify_first",
+        re.compile(
+            r"\b(check (first|docs|code|source|the)|have you (checked|read|verified)|read (the )?(code|docs|source)|move with evidence)\b",
+            re.I,
+        ),
+    ),
     ("rule_setting", re.compile(r"\b(never|always|from now|next time|remember to)\b", re.I)),
-    ("why_rhetorical", re.compile(r"\bwhy (the |are you|did you|don'?t? you|is (it|cladue|claude)|not|no)\b|\?$", re.I)),
+    (
+        "why_rhetorical",
+        re.compile(r"\bwhy (the |are you|did you|don'?t? you|is (it|cladue|claude)|not|no)\b|\?$", re.I),
+    ),
     ("retry_request", re.compile(r"\b(try again|again|once more|redo|retry)\b", re.I)),
 ]
 
@@ -70,12 +103,14 @@ def find_recent_reject(transcript_path: str) -> dict | None:
             continue
         msg = entry.get("message", entry)
         content = msg.get("content")
+        tur = entry.get("toolUseResult")
+        tur = tur if isinstance(tur, dict) else {}
         if isinstance(content, list):
             for block in content:
                 if isinstance(block, dict) and block.get("type") == "tool_result" and block.get("is_error"):
-                    return {"tool_name": entry.get("toolUseResult", {}).get("name", "")}
-        if entry.get("toolUseResult", {}).get("interrupted"):
-            return {"tool_name": entry.get("toolUseResult", {}).get("name", "")}
+                    return {"tool_name": tur.get("name", "")}
+        if tur.get("interrupted"):
+            return {"tool_name": tur.get("name", "")}
     return None
 
 


### PR DESCRIPTION
The `claude-telemetry-hooks` UserPromptSubmit hook chained `.get` on `entry["toolUseResult"]`, which Claude Code stores as a plain string (e.g. `"User rejected tool use"`, `"Error: EPERM ..."`) for rejected/errored tools. A type-guard with `isinstance(..., dict)` fixes 40 of 138 real transcripts that previously crashed and recovers reject telemetry on 37 of them. Bumps the plugin to 1.0.1.

Before: `entry.get("toolUseResult", {}).get("interrupted")` → `AttributeError: 'str' object has no attribute 'get'`
After: `tur = tur if isinstance(tur, dict) else {}` then `tur.get("interrupted")`