### PR TITLE
Add license field to plugin manifests

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,151 +6,176 @@
       "name": "intelligent-compact",
       "source": "./plugins/intelligent-compact",
       "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "claude-telemetry-hooks",
       "source": "./plugins/claude-telemetry-hooks",
       "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events.",
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "license": "Apache-2.0"
     },
     {
       "name": "anthropic-office-skills",
       "source": "./plugins/anthropic-office-skills",
       "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     {
       "name": "openai-office-skills",
       "source": "./plugins/openai-office-skills",
       "description": "Official OpenAI skills for PDF, Word, PowerPoint, and Excel document processing.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     {
       "name": "python-skills",
       "source": "./plugins/python-skills",
       "description": "Python best practices grounded in PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Effective Python by Brett Slatkin.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "react-skills",
       "source": "./plugins/react-skills",
       "description": "React, Next.js, and React Native best practices with web design guidelines.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     {
       "name": "agent-browser",
       "source": "./plugins/agent-browser",
       "description": "Browser automation CLI for AI agents. Navigate pages, fill forms, click buttons, take screenshots, and test web apps.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "frontend-design-skills",
       "source": "./plugins/frontend-design-skills",
       "description": "Frontend design skills from Anthropic and OpenAI for building visually strong landing pages, websites, and apps.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "mongodb-skills",
       "source": "./plugins/mongodb-skills",
       "description": "Official MongoDB agent skills for schema design, query tuning, search, and connections.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "supabase-skills",
       "source": "./plugins/supabase-skills",
       "description": "Supabase skills for Postgres best practices, JavaScript SDK (auth, database, storage, realtime), and CLI (migrations, edge functions, local dev).",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     {
       "name": "stripe-skills",
       "source": "./plugins/stripe-skills",
       "description": "Official Stripe payment platform skills for checkout, billing, Connect, and API upgrades.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     {
       "name": "polar-skills",
       "source": "./plugins/polar-skills",
       "description": "Official Polar payment processor skills for billing, subscriptions, and local development.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "livekit-skills",
       "source": "./plugins/livekit-skills",
       "description": "LiveKit Agents SDK skills for building voice AI agents with CLI-based workflow, supporting both Cloud and self-hosted deployments.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     {
       "name": "cloudflare-skills",
       "source": "./plugins/cloudflare-skills",
       "description": "Official Cloudflare developer platform skill for Workers, Durable Objects, R2, D1, KV, AI, and 50+ services.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "web-performance-skills",
       "source": "./plugins/web-performance-skills",
       "description": "Web performance auditing skill for Core Web Vitals, Lighthouse scores, render-blocking resources, and accessibility.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "openobserve-skills",
       "source": "./plugins/openobserve-skills",
       "description": "OpenObserve REST API skill for AI agents. Search logs/metrics/traces, manage streams, and create/edit/inspect dashboards via curl.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "hetzner-skills",
       "source": "./plugins/hetzner-skills",
       "description": "Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, volumes, and storage.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     {
       "name": "dokploy-skills",
       "source": "./plugins/dokploy-skills",
       "description": "Dokploy deployment skill for Dokploy Cloud, self-hosted dashboard, Docker Compose, databases, domains, remote servers, and Dokploy CLI workflows.",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     {
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.0"
+      "version": "2.4.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "license": "Apache-2.0"
     },
     {
       "name": "azure-tools",
       "source": "./plugins/azure-tools",
       "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "license": "Apache-2.0"
     },
     {
       "name": "claude-tools",
       "source": "./plugins/claude-tools",
       "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "license": "Apache-2.0"
     },
     {
       "name": "gcloud-tools",
       "source": "./plugins/gcloud-tools",
       "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "license": "Apache-2.0"
     },
     {
       "name": "paper-search-tools",
       "source": "./plugins/paper-search-tools",
       "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "license": "Apache-2.0"
     },
     {
       "name": "tavily-tools",
       "source": "./plugins/tavily-tools",
       "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "license": "Apache-2.0"
     }
   ]
 }

--- a/.github/scripts/sync-versions.sh
+++ b/.github/scripts/sync-versions.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Propagate each plugin's version from .claude-plugin/plugin.json (source of truth)
-# to all other manifests and marketplace entries.
+# Propagate each plugin's version and license from .claude-plugin/plugin.json
+# (source of truth) to all sibling manifests and marketplace entries.
+# Marketplace files are edited via narrow regex replacements so existing
+# hand-tuned JSON formatting (compact arrays, key order) is preserved.
 # Usage: bash .github/scripts/sync-versions.sh
 
 set -euo pipefail
@@ -9,56 +11,136 @@ REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 
 python3 - "$REPO_ROOT" << 'PYEOF'
 import json
+import re
 import sys
 from pathlib import Path
 
 repo = Path(sys.argv[1])
 changes = []
+warnings = []
 
-# Collect plugin versions from .claude-plugin/plugin.json (source of truth)
-plugin_versions = {}
+# Source of truth: .claude-plugin/plugin.json for each plugin under plugins/
+plugin_meta = {}
 for plugin_dir in sorted((repo / "plugins").iterdir()):
     claude_manifest = plugin_dir / ".claude-plugin" / "plugin.json"
     if not claude_manifest.exists():
         continue
     data = json.loads(claude_manifest.read_text())
-    version = data.get("version", "")
-    if version:
-        plugin_versions[data["name"]] = version
+    name = data.get("name") or plugin_dir.name
+    plugin_meta[name] = {
+        "version": data.get("version", ""),
+        "license": data.get("license"),
+        "dir": plugin_dir,
+    }
+    if not data.get("license"):
+        warnings.append(f"  {plugin_dir.name}: missing 'license' in .claude-plugin/plugin.json")
 
-    # Sync to other manifest files
-    for label, path in [
-        ("codex", plugin_dir / ".codex-plugin" / "plugin.json"),
-        ("cursor", plugin_dir / ".cursor-plugin" / "plugin.json"),
-        ("gemini", plugin_dir / "gemini-extension.json"),
+# Sibling plugin.json files. Gemini's manifest spec excludes 'license'.
+for name, meta in plugin_meta.items():
+    plugin_dir = meta["dir"]
+    for label, path, syncs_license in [
+        ("codex",  plugin_dir / ".codex-plugin"  / "plugin.json", True),
+        ("cursor", plugin_dir / ".cursor-plugin" / "plugin.json", True),
+        ("gemini", plugin_dir / "gemini-extension.json",          False),
     ]:
         if not path.exists():
             continue
         manifest = json.loads(path.read_text())
-        if manifest.get("version") != version:
-            manifest["version"] = version
+        before = dict(manifest)
+        if meta["version"] and manifest.get("version") != meta["version"]:
+            manifest["version"] = meta["version"]
+        if syncs_license and meta["license"] and manifest.get("license") != meta["license"]:
+            manifest["license"] = meta["license"]
+        if manifest != before:
             path.write_text(json.dumps(manifest, indent=2) + "\n")
-            changes.append(f"  {plugin_dir.name}/{label}: -> {version}")
+            diff = []
+            if before.get("version") != manifest.get("version"):
+                diff.append(f"version={manifest['version']}")
+            if before.get("license") != manifest.get("license"):
+                diff.append(f"license={manifest['license']}")
+            changes.append(f"  {plugin_dir.name}/{label}: " + ", ".join(diff))
 
-# Update marketplace files that have per-plugin version fields
+
+def find_entry_span(text, name):
+    """Return (start, end) byte offsets of the JSON object containing `"name": "<name>"`, or None."""
+    m = re.search(r'"name"\s*:\s*"' + re.escape(name) + r'"', text)
+    if not m:
+        return None
+    start = text.rfind("{", 0, m.start())
+    if start < 0:
+        return None
+    depth = 0
+    for i in range(start, len(text)):
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return start, i + 1
+    return None
+
+
+def narrow_update(text, name, field, value):
+    """Within the entry block for `name`, replace the value of `field`, or insert it after the `version` line."""
+    span = find_entry_span(text, name)
+    if span is None:
+        return text, False
+    s, e = span
+    block = text[s:e]
+    field_pat = re.compile(r'("' + re.escape(field) + r'"\s*:\s*)"[^"]*"')
+    if field_pat.search(block):
+        new_block = field_pat.sub(lambda m: m.group(1) + json.dumps(value), block, count=1)
+    else:
+        ver_pat = re.compile(r'(\n([ \t]+)"version"\s*:\s*"[^"]*")(,?)')
+        vm = ver_pat.search(block)
+        if not vm:
+            return text, False
+        indent = vm.group(2)
+        existing_comma = vm.group(3)
+        new_version_line = vm.group(1) + ","
+        new_field_line = f'\n{indent}"{field}": {json.dumps(value)}' + existing_comma
+        new_block = block[:vm.start()] + new_version_line + new_field_line + block[vm.end():]
+    if new_block == block:
+        return text, False
+    return text[:s] + new_block + text[e:], True
+
+
 for label, mkt_path in [
     ("claude", repo / ".claude-plugin" / "marketplace.json"),
     ("cursor", repo / ".cursor-plugin" / "marketplace.json"),
 ]:
     if not mkt_path.exists():
         continue
-    mkt = json.loads(mkt_path.read_text())
+    text = mkt_path.read_text()
+    original = text
+    mkt = json.loads(text)
     for entry in mkt.get("plugins", []):
         name = entry.get("name", "")
-        if name in plugin_versions and entry.get("version") != plugin_versions[name]:
-            entry["version"] = plugin_versions[name]
-            changes.append(f"  {label} marketplace/{name}: -> {plugin_versions[name]}")
-    mkt_path.write_text(json.dumps(mkt, indent=2) + "\n")
+        meta = plugin_meta.get(name)
+        if not meta:
+            continue
+        if meta["version"] and entry.get("version") != meta["version"]:
+            text, ok = narrow_update(text, name, "version", meta["version"])
+            if ok:
+                changes.append(f"  {label} marketplace/{name}: version={meta['version']}")
+        if meta["license"] and entry.get("license") != meta["license"]:
+            text, ok = narrow_update(text, name, "license", meta["license"])
+            if ok:
+                changes.append(f"  {label} marketplace/{name}: license={meta['license']}")
+    if text != original:
+        # Sanity: re-parse to make sure narrow edits left valid JSON
+        json.loads(text)
+        mkt_path.write_text(text)
 
 if changes:
-    print("Version sync changes:")
+    print("Sync changes:")
     for c in changes:
         print(c)
 else:
-    print("All versions already in sync.")
+    print("All manifests already in sync.")
+if warnings:
+    print("\nMissing fields in source-of-truth:")
+    for w in warnings:
+        print(w)
 PYEOF

--- a/plugins/agent-browser/.claude-plugin/plugin.json
+++ b/plugins/agent-browser/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "agent-browser",
   "version": "1.0.0",
-  "description": "Browser automation CLI for AI agents. Navigate pages, fill forms, click buttons, take screenshots, and test web apps."
+  "description": "Browser automation CLI for AI agents. Navigate pages, fill forms, click buttons, take screenshots, and test web apps.",
+  "license": "Apache-2.0"
 }

--- a/plugins/agent-browser/.codex-plugin/plugin.json
+++ b/plugins/agent-browser/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "agent-browser",
   "version": "1.0.0",
-  "description": "Browser automation CLI for AI agents. Navigate pages, fill forms, click buttons, take screenshots, and test web apps."
+  "description": "Browser automation CLI for AI agents. Navigate pages, fill forms, click buttons, take screenshots, and test web apps.",
+  "license": "Apache-2.0"
 }

--- a/plugins/agent-browser/.cursor-plugin/plugin.json
+++ b/plugins/agent-browser/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "agent-browser",
   "version": "1.0.0",
-  "description": "Browser automation CLI for AI agents. Navigate pages, fill forms, click buttons, take screenshots, and test web apps."
+  "description": "Browser automation CLI for AI agents. Navigate pages, fill forms, click buttons, take screenshots, and test web apps.",
+  "license": "Apache-2.0"
 }

--- a/plugins/anthropic-office-skills/.claude-plugin/plugin.json
+++ b/plugins/anthropic-office-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "anthropic-office-skills",
   "version": "1.0.0",
-  "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing."
+  "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing.",
+  "license": "MIT"
 }

--- a/plugins/anthropic-office-skills/.codex-plugin/plugin.json
+++ b/plugins/anthropic-office-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "anthropic-office-skills",
   "version": "1.0.0",
-  "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing."
+  "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing.",
+  "license": "MIT"
 }

--- a/plugins/anthropic-office-skills/.cursor-plugin/plugin.json
+++ b/plugins/anthropic-office-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "anthropic-office-skills",
   "version": "1.0.0",
-  "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing."
+  "description": "Official Anthropic skills for PDF, Word, PowerPoint, and Excel document processing.",
+  "license": "MIT"
 }

--- a/plugins/azure-tools/.claude-plugin/plugin.json
+++ b/plugins/azure-tools/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "azure-tools",
   "version": "2.0.2",
-  "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication."
+  "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
+  "license": "Apache-2.0"
 }

--- a/plugins/azure-tools/.codex-plugin/plugin.json
+++ b/plugins/azure-tools/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "azure-tools",
   "version": "2.0.2",
-  "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication."
+  "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
+  "license": "Apache-2.0"
 }

--- a/plugins/azure-tools/.cursor-plugin/plugin.json
+++ b/plugins/azure-tools/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "azure-tools",
   "version": "2.0.2",
-  "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication."
+  "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
+  "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
   "version": "1.0.1",
-  "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events."
+  "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events.",
+  "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
   "version": "1.0.1",
-  "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events."
+  "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events.",
+  "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
   "version": "1.0.1",
-  "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events."
+  "description": "Hooks that enrich Claude Code OTel telemetry: sticky chat_id across resumed sessions, and categorized reject-reason feedback events.",
+  "license": "Apache-2.0"
 }

--- a/plugins/claude-tools/.claude-plugin/plugin.json
+++ b/plugins/claude-tools/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-tools",
   "version": "2.1.0",
-  "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync."
+  "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
+  "license": "Apache-2.0"
 }

--- a/plugins/claude-tools/.codex-plugin/plugin.json
+++ b/plugins/claude-tools/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-tools",
   "version": "2.1.0",
-  "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync."
+  "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
+  "license": "Apache-2.0"
 }

--- a/plugins/claude-tools/.cursor-plugin/plugin.json
+++ b/plugins/claude-tools/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "claude-tools",
   "version": "2.1.0",
-  "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync."
+  "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
+  "license": "Apache-2.0"
 }

--- a/plugins/cloudflare-skills/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "cloudflare-skills",
   "version": "1.0.0",
-  "description": "Official Cloudflare developer platform skill for Workers, Durable Objects, R2, D1, KV, AI, and 50+ services."
+  "description": "Official Cloudflare developer platform skill for Workers, Durable Objects, R2, D1, KV, AI, and 50+ services.",
+  "license": "Apache-2.0"
 }

--- a/plugins/cloudflare-skills/.codex-plugin/plugin.json
+++ b/plugins/cloudflare-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "cloudflare-skills",
   "version": "1.0.0",
-  "description": "Official Cloudflare developer platform skill for Workers, Durable Objects, R2, D1, KV, AI, and 50+ services."
+  "description": "Official Cloudflare developer platform skill for Workers, Durable Objects, R2, D1, KV, AI, and 50+ services.",
+  "license": "Apache-2.0"
 }

--- a/plugins/cloudflare-skills/.cursor-plugin/plugin.json
+++ b/plugins/cloudflare-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "cloudflare-skills",
   "version": "1.0.0",
-  "description": "Official Cloudflare developer platform skill for Workers, Durable Objects, R2, D1, KV, AI, and 50+ services."
+  "description": "Official Cloudflare developer platform skill for Workers, Durable Objects, R2, D1, KV, AI, and 50+ services.",
+  "license": "Apache-2.0"
 }

--- a/plugins/dokploy-skills/.claude-plugin/plugin.json
+++ b/plugins/dokploy-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "dokploy-skills",
   "version": "1.0.0",
-  "description": "Dokploy deployment skill for Dokploy Cloud, self-hosted dashboard, Docker Compose, databases, domains, remote servers, and Dokploy CLI workflows."
+  "description": "Dokploy deployment skill for Dokploy Cloud, self-hosted dashboard, Docker Compose, databases, domains, remote servers, and Dokploy CLI workflows.",
+  "license": "MIT"
 }

--- a/plugins/dokploy-skills/.codex-plugin/plugin.json
+++ b/plugins/dokploy-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "dokploy-skills",
   "version": "1.0.0",
-  "description": "Dokploy deployment skill for Dokploy Cloud, self-hosted dashboard, Docker Compose, databases, domains, remote servers, and Dokploy CLI workflows."
+  "description": "Dokploy deployment skill for Dokploy Cloud, self-hosted dashboard, Docker Compose, databases, domains, remote servers, and Dokploy CLI workflows.",
+  "license": "MIT"
 }

--- a/plugins/dokploy-skills/.cursor-plugin/plugin.json
+++ b/plugins/dokploy-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "dokploy-skills",
   "version": "1.0.0",
-  "description": "Dokploy deployment skill for Dokploy Cloud, self-hosted dashboard, Docker Compose, databases, domains, remote servers, and Dokploy CLI workflows."
+  "description": "Dokploy deployment skill for Dokploy Cloud, self-hosted dashboard, Docker Compose, databases, domains, remote servers, and Dokploy CLI workflows.",
+  "license": "MIT"
 }

--- a/plugins/frontend-design-skills/.claude-plugin/plugin.json
+++ b/plugins/frontend-design-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "frontend-design-skills",
   "version": "1.0.0",
-  "description": "Frontend design skills from Anthropic and OpenAI for building visually strong landing pages, websites, and apps."
+  "description": "Frontend design skills from Anthropic and OpenAI for building visually strong landing pages, websites, and apps.",
+  "license": "Apache-2.0"
 }

--- a/plugins/frontend-design-skills/.codex-plugin/plugin.json
+++ b/plugins/frontend-design-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "frontend-design-skills",
   "version": "1.0.0",
-  "description": "Frontend design skills from Anthropic and OpenAI for building visually strong landing pages, websites, and apps."
+  "description": "Frontend design skills from Anthropic and OpenAI for building visually strong landing pages, websites, and apps.",
+  "license": "Apache-2.0"
 }

--- a/plugins/frontend-design-skills/.cursor-plugin/plugin.json
+++ b/plugins/frontend-design-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "frontend-design-skills",
   "version": "1.0.0",
-  "description": "Frontend design skills from Anthropic and OpenAI for building visually strong landing pages, websites, and apps."
+  "description": "Frontend design skills from Anthropic and OpenAI for building visually strong landing pages, websites, and apps.",
+  "license": "Apache-2.0"
 }

--- a/plugins/gcloud-tools/.claude-plugin/plugin.json
+++ b/plugins/gcloud-tools/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "gcloud-tools",
   "version": "2.0.2",
-  "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill."
+  "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
+  "license": "Apache-2.0"
 }

--- a/plugins/gcloud-tools/.codex-plugin/plugin.json
+++ b/plugins/gcloud-tools/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "gcloud-tools",
   "version": "2.0.2",
-  "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill."
+  "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
+  "license": "Apache-2.0"
 }

--- a/plugins/gcloud-tools/.cursor-plugin/plugin.json
+++ b/plugins/gcloud-tools/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "gcloud-tools",
   "version": "2.0.2",
-  "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill."
+  "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
+  "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "github-dev",
   "version": "2.4.0",
-  "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
+  "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
+  "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "github-dev",
   "version": "2.4.0",
-  "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
+  "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
+  "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "github-dev",
   "version": "2.4.0",
-  "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
+  "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
+  "license": "Apache-2.0"
 }

--- a/plugins/hetzner-skills/.claude-plugin/plugin.json
+++ b/plugins/hetzner-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "hetzner-skills",
   "version": "1.0.0",
-  "description": "Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, volumes, and storage."
+  "description": "Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, volumes, and storage.",
+  "license": "MIT"
 }

--- a/plugins/hetzner-skills/.codex-plugin/plugin.json
+++ b/plugins/hetzner-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "hetzner-skills",
   "version": "1.0.0",
-  "description": "Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, volumes, and storage."
+  "description": "Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, volumes, and storage.",
+  "license": "MIT"
 }

--- a/plugins/hetzner-skills/.cursor-plugin/plugin.json
+++ b/plugins/hetzner-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "hetzner-skills",
   "version": "1.0.0",
-  "description": "Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, volumes, and storage."
+  "description": "Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, volumes, and storage.",
+  "license": "MIT"
 }

--- a/plugins/intelligent-compact/.claude-plugin/plugin.json
+++ b/plugins/intelligent-compact/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "intelligent-compact",
   "version": "1.0.0",
-  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings."
+  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings.",
+  "license": "Apache-2.0"
 }

--- a/plugins/intelligent-compact/.codex-plugin/plugin.json
+++ b/plugins/intelligent-compact/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "intelligent-compact",
   "version": "1.0.0",
-  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings."
+  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings.",
+  "license": "Apache-2.0"
 }

--- a/plugins/intelligent-compact/.cursor-plugin/plugin.json
+++ b/plugins/intelligent-compact/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "intelligent-compact",
   "version": "1.0.0",
-  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings."
+  "description": "PreCompact hook that injects a priority list so conversation summaries preserve unanswered questions, root causes, file paths, metrics, IDs, and subagent findings.",
+  "license": "Apache-2.0"
 }

--- a/plugins/livekit-skills/.claude-plugin/plugin.json
+++ b/plugins/livekit-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "livekit-skills",
   "version": "1.0.0",
-  "description": "LiveKit Agents SDK skills for building voice AI agents with CLI-based workflow, supporting both Cloud and self-hosted deployments."
+  "description": "LiveKit Agents SDK skills for building voice AI agents with CLI-based workflow, supporting both Cloud and self-hosted deployments.",
+  "license": "MIT"
 }

--- a/plugins/livekit-skills/.codex-plugin/plugin.json
+++ b/plugins/livekit-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "livekit-skills",
   "version": "1.0.0",
-  "description": "LiveKit Agents SDK skills for building voice AI agents with CLI-based workflow, supporting both Cloud and self-hosted deployments."
+  "description": "LiveKit Agents SDK skills for building voice AI agents with CLI-based workflow, supporting both Cloud and self-hosted deployments.",
+  "license": "MIT"
 }

--- a/plugins/livekit-skills/.cursor-plugin/plugin.json
+++ b/plugins/livekit-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "livekit-skills",
   "version": "1.0.0",
-  "description": "LiveKit Agents SDK skills for building voice AI agents with CLI-based workflow, supporting both Cloud and self-hosted deployments."
+  "description": "LiveKit Agents SDK skills for building voice AI agents with CLI-based workflow, supporting both Cloud and self-hosted deployments.",
+  "license": "MIT"
 }

--- a/plugins/mongodb-skills/.claude-plugin/plugin.json
+++ b/plugins/mongodb-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "mongodb-skills",
   "version": "1.0.0",
-  "description": "Official MongoDB agent skills for schema design, query tuning, search, and connections."
+  "description": "Official MongoDB agent skills for schema design, query tuning, search, and connections.",
+  "license": "Apache-2.0"
 }

--- a/plugins/mongodb-skills/.codex-plugin/plugin.json
+++ b/plugins/mongodb-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "mongodb-skills",
   "version": "1.0.0",
-  "description": "Official MongoDB agent skills for schema design, query tuning, search, and connections."
+  "description": "Official MongoDB agent skills for schema design, query tuning, search, and connections.",
+  "license": "Apache-2.0"
 }

--- a/plugins/mongodb-skills/.cursor-plugin/plugin.json
+++ b/plugins/mongodb-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "mongodb-skills",
   "version": "1.0.0",
-  "description": "Official MongoDB agent skills for schema design, query tuning, search, and connections."
+  "description": "Official MongoDB agent skills for schema design, query tuning, search, and connections.",
+  "license": "Apache-2.0"
 }

--- a/plugins/openai-office-skills/.claude-plugin/plugin.json
+++ b/plugins/openai-office-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "openai-office-skills",
   "version": "1.0.0",
-  "description": "Official OpenAI skills for PDF, Word, PowerPoint, and Excel document processing."
+  "description": "Official OpenAI skills for PDF, Word, PowerPoint, and Excel document processing.",
+  "license": "MIT"
 }

--- a/plugins/openai-office-skills/.codex-plugin/plugin.json
+++ b/plugins/openai-office-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "openai-office-skills",
   "version": "1.0.0",
-  "description": "Official OpenAI skills for PDF, Word, PowerPoint, and Excel document processing."
+  "description": "Official OpenAI skills for PDF, Word, PowerPoint, and Excel document processing.",
+  "license": "MIT"
 }

--- a/plugins/openai-office-skills/.cursor-plugin/plugin.json
+++ b/plugins/openai-office-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "openai-office-skills",
   "version": "1.0.0",
-  "description": "Official OpenAI skills for PDF, Word, PowerPoint, and Excel document processing."
+  "description": "Official OpenAI skills for PDF, Word, PowerPoint, and Excel document processing.",
+  "license": "MIT"
 }

--- a/plugins/openobserve-skills/.claude-plugin/plugin.json
+++ b/plugins/openobserve-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "openobserve-skills",
   "version": "1.0.0",
-  "description": "OpenObserve REST API skill for AI agents. Search logs/metrics/traces, manage streams, and create/edit/inspect dashboards via curl."
+  "description": "OpenObserve REST API skill for AI agents. Search logs/metrics/traces, manage streams, and create/edit/inspect dashboards via curl.",
+  "license": "Apache-2.0"
 }

--- a/plugins/openobserve-skills/.codex-plugin/plugin.json
+++ b/plugins/openobserve-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "openobserve-skills",
   "version": "1.0.0",
-  "description": "OpenObserve REST API skill for AI agents. Search logs/metrics/traces, manage streams, and create/edit/inspect dashboards via curl."
+  "description": "OpenObserve REST API skill for AI agents. Search logs/metrics/traces, manage streams, and create/edit/inspect dashboards via curl.",
+  "license": "Apache-2.0"
 }

--- a/plugins/openobserve-skills/.cursor-plugin/plugin.json
+++ b/plugins/openobserve-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "openobserve-skills",
   "version": "1.0.0",
-  "description": "OpenObserve REST API skill for AI agents. Search logs/metrics/traces, manage streams, and create/edit/inspect dashboards via curl."
+  "description": "OpenObserve REST API skill for AI agents. Search logs/metrics/traces, manage streams, and create/edit/inspect dashboards via curl.",
+  "license": "Apache-2.0"
 }

--- a/plugins/paper-search-tools/.claude-plugin/plugin.json
+++ b/plugins/paper-search-tools/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "paper-search-tools",
   "version": "2.0.2",
-  "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker."
+  "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
+  "license": "Apache-2.0"
 }

--- a/plugins/paper-search-tools/.codex-plugin/plugin.json
+++ b/plugins/paper-search-tools/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "paper-search-tools",
   "version": "2.0.2",
-  "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker."
+  "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
+  "license": "Apache-2.0"
 }

--- a/plugins/paper-search-tools/.cursor-plugin/plugin.json
+++ b/plugins/paper-search-tools/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "paper-search-tools",
   "version": "2.0.2",
-  "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker."
+  "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
+  "license": "Apache-2.0"
 }

--- a/plugins/polar-skills/.claude-plugin/plugin.json
+++ b/plugins/polar-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "polar-skills",
   "version": "1.0.0",
-  "description": "Official Polar payment processor skills for billing, subscriptions, and local development."
+  "description": "Official Polar payment processor skills for billing, subscriptions, and local development.",
+  "license": "Apache-2.0"
 }

--- a/plugins/polar-skills/.codex-plugin/plugin.json
+++ b/plugins/polar-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "polar-skills",
   "version": "1.0.0",
-  "description": "Official Polar payment processor skills for billing, subscriptions, and local development."
+  "description": "Official Polar payment processor skills for billing, subscriptions, and local development.",
+  "license": "Apache-2.0"
 }

--- a/plugins/polar-skills/.cursor-plugin/plugin.json
+++ b/plugins/polar-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "polar-skills",
   "version": "1.0.0",
-  "description": "Official Polar payment processor skills for billing, subscriptions, and local development."
+  "description": "Official Polar payment processor skills for billing, subscriptions, and local development.",
+  "license": "Apache-2.0"
 }

--- a/plugins/python-skills/.claude-plugin/plugin.json
+++ b/plugins/python-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "python-skills",
   "version": "1.0.0",
-  "description": "Python best practices grounded in PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Effective Python by Brett Slatkin."
+  "description": "Python best practices grounded in PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Effective Python by Brett Slatkin.",
+  "license": "Apache-2.0"
 }

--- a/plugins/python-skills/.codex-plugin/plugin.json
+++ b/plugins/python-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "python-skills",
   "version": "1.0.0",
-  "description": "Python best practices grounded in PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Effective Python by Brett Slatkin."
+  "description": "Python best practices grounded in PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Effective Python by Brett Slatkin.",
+  "license": "Apache-2.0"
 }

--- a/plugins/python-skills/.cursor-plugin/plugin.json
+++ b/plugins/python-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "python-skills",
   "version": "1.0.0",
-  "description": "Python best practices grounded in PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Effective Python by Brett Slatkin."
+  "description": "Python best practices grounded in PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Effective Python by Brett Slatkin.",
+  "license": "Apache-2.0"
 }

--- a/plugins/react-skills/.claude-plugin/plugin.json
+++ b/plugins/react-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "react-skills",
   "version": "1.0.0",
-  "description": "React, Next.js, and React Native best practices with web design guidelines."
+  "description": "React, Next.js, and React Native best practices with web design guidelines.",
+  "license": "MIT"
 }

--- a/plugins/react-skills/.codex-plugin/plugin.json
+++ b/plugins/react-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "react-skills",
   "version": "1.0.0",
-  "description": "React, Next.js, and React Native best practices with web design guidelines."
+  "description": "React, Next.js, and React Native best practices with web design guidelines.",
+  "license": "MIT"
 }

--- a/plugins/react-skills/.cursor-plugin/plugin.json
+++ b/plugins/react-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "react-skills",
   "version": "1.0.0",
-  "description": "React, Next.js, and React Native best practices with web design guidelines."
+  "description": "React, Next.js, and React Native best practices with web design guidelines.",
+  "license": "MIT"
 }

--- a/plugins/stripe-skills/.claude-plugin/plugin.json
+++ b/plugins/stripe-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "stripe-skills",
   "version": "1.0.0",
-  "description": "Official Stripe payment platform skills for checkout, billing, Connect, and API upgrades."
+  "description": "Official Stripe payment platform skills for checkout, billing, Connect, and API upgrades.",
+  "license": "MIT"
 }

--- a/plugins/stripe-skills/.codex-plugin/plugin.json
+++ b/plugins/stripe-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "stripe-skills",
   "version": "1.0.0",
-  "description": "Official Stripe payment platform skills for checkout, billing, Connect, and API upgrades."
+  "description": "Official Stripe payment platform skills for checkout, billing, Connect, and API upgrades.",
+  "license": "MIT"
 }

--- a/plugins/stripe-skills/.cursor-plugin/plugin.json
+++ b/plugins/stripe-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "stripe-skills",
   "version": "1.0.0",
-  "description": "Official Stripe payment platform skills for checkout, billing, Connect, and API upgrades."
+  "description": "Official Stripe payment platform skills for checkout, billing, Connect, and API upgrades.",
+  "license": "MIT"
 }

--- a/plugins/supabase-skills/.claude-plugin/plugin.json
+++ b/plugins/supabase-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "supabase-skills",
   "version": "1.0.0",
-  "description": "Supabase skills for Postgres best practices, JavaScript SDK (auth, database, storage, realtime), and CLI (migrations, edge functions, local dev)."
+  "description": "Supabase skills for Postgres best practices, JavaScript SDK (auth, database, storage, realtime), and CLI (migrations, edge functions, local dev).",
+  "license": "MIT"
 }

--- a/plugins/supabase-skills/.codex-plugin/plugin.json
+++ b/plugins/supabase-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "supabase-skills",
   "version": "1.0.0",
-  "description": "Supabase skills for Postgres best practices, JavaScript SDK (auth, database, storage, realtime), and CLI (migrations, edge functions, local dev)."
+  "description": "Supabase skills for Postgres best practices, JavaScript SDK (auth, database, storage, realtime), and CLI (migrations, edge functions, local dev).",
+  "license": "MIT"
 }

--- a/plugins/supabase-skills/.cursor-plugin/plugin.json
+++ b/plugins/supabase-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "supabase-skills",
   "version": "1.0.0",
-  "description": "Supabase skills for Postgres best practices, JavaScript SDK (auth, database, storage, realtime), and CLI (migrations, edge functions, local dev)."
+  "description": "Supabase skills for Postgres best practices, JavaScript SDK (auth, database, storage, realtime), and CLI (migrations, edge functions, local dev).",
+  "license": "MIT"
 }

--- a/plugins/tavily-tools/.claude-plugin/plugin.json
+++ b/plugins/tavily-tools/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "tavily-tools",
   "version": "2.0.2",
-  "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection."
+  "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
+  "license": "Apache-2.0"
 }

--- a/plugins/tavily-tools/.codex-plugin/plugin.json
+++ b/plugins/tavily-tools/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "tavily-tools",
   "version": "2.0.2",
-  "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection."
+  "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
+  "license": "Apache-2.0"
 }

--- a/plugins/tavily-tools/.cursor-plugin/plugin.json
+++ b/plugins/tavily-tools/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "tavily-tools",
   "version": "2.0.2",
-  "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection."
+  "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
+  "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "ultralytics-dev",
   "version": "2.1.1",
-  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks."
+  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
+  "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "ultralytics-dev",
   "version": "2.1.1",
-  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks."
+  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
+  "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "ultralytics-dev",
   "version": "2.1.1",
-  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks."
+  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
+  "license": "Apache-2.0"
 }

--- a/plugins/web-performance-skills/.claude-plugin/plugin.json
+++ b/plugins/web-performance-skills/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "web-performance-skills",
   "version": "1.0.0",
-  "description": "Web performance auditing skill for Core Web Vitals, Lighthouse scores, render-blocking resources, and accessibility."
+  "description": "Web performance auditing skill for Core Web Vitals, Lighthouse scores, render-blocking resources, and accessibility.",
+  "license": "Apache-2.0"
 }

--- a/plugins/web-performance-skills/.codex-plugin/plugin.json
+++ b/plugins/web-performance-skills/.codex-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "web-performance-skills",
   "version": "1.0.0",
-  "description": "Web performance auditing skill for Core Web Vitals, Lighthouse scores, render-blocking resources, and accessibility."
+  "description": "Web performance auditing skill for Core Web Vitals, Lighthouse scores, render-blocking resources, and accessibility.",
+  "license": "Apache-2.0"
 }

--- a/plugins/web-performance-skills/.cursor-plugin/plugin.json
+++ b/plugins/web-performance-skills/.cursor-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "web-performance-skills",
   "version": "1.0.0",
-  "description": "Web performance auditing skill for Core Web Vitals, Lighthouse scores, render-blocking resources, and accessibility."
+  "description": "Web performance auditing skill for Core Web Vitals, Lighthouse scores, render-blocking resources, and accessibility.",
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Adds the missing `license` field to all 25 plugins across the Claude, Codex, and Cursor manifests and the cursor marketplace. `sync-versions.sh` now syncs license alongside version, and edits marketplace files in place instead of rewriting them with default JSON formatting (which used to expand compact arrays and produce hundreds of churn lines per run). `anthropic-plugin-dev` stays unset because its upstream repo declares no license.

`bash .github/scripts/sync-versions.sh` is now idempotent: re-running it after this PR reports "All manifests already in sync" and writes no files.