### PR TITLE
Drop slides and spreadsheet from openai office sync

### DIFF
--- a/.github/scripts/sync-openai-office-skills.sh
+++ b/.github/scripts/sync-openai-office-skills.sh
@@ -9,29 +9,14 @@ clone_or_update https://github.com/openai/skills openai-skills
 
 SRC="$HOME/dev/openai-skills/skills/.curated"
 
+# slides and spreadsheet are vendored locally (upstream removed them in openai/skills#350).
+
 # pdf
 sync_dir "$SRC/pdf" \
   "plugins/openai-office-skills/skills/pdf" \
   "SKILL.md" "LICENSE.txt"
 ensure_license "plugins/openai-office-skills/skills/pdf" MIT
 create_zip "plugins/openai-office-skills/skills/pdf"
-
-# slides (has references/, scripts/, assets/pptxgenjs_helpers/)
-sync_dir "$SRC/slides" \
-  "plugins/openai-office-skills/skills/slides" \
-  "SKILL.md" "references/" "scripts/" "assets/" "LICENSE.txt"
-# Remove platform icons, keep only pptxgenjs_helpers used by the skill
-rm -f "$REPO_ROOT/plugins/openai-office-skills/skills/slides/assets/"*.png \
-  "$REPO_ROOT/plugins/openai-office-skills/skills/slides/assets/"*.svg
-ensure_license "plugins/openai-office-skills/skills/slides" MIT
-create_zip "plugins/openai-office-skills/skills/slides"
-
-# spreadsheet (has references/)
-sync_dir "$SRC/spreadsheet" \
-  "plugins/openai-office-skills/skills/spreadsheet" \
-  "SKILL.md" "references/" "LICENSE.txt"
-ensure_license "plugins/openai-office-skills/skills/spreadsheet" MIT
-create_zip "plugins/openai-office-skills/skills/spreadsheet"
 
 # doc (has scripts/)
 sync_dir "$SRC/doc" \


### PR DESCRIPTION
Upstream [openai/skills#350](https://github.com/openai/skills/pull/350) removed both `slides` and `spreadsheet` from `.curated/`, so the sync script was failing with `source directory not found`. This PR drops the two missing blocks from the script. The local `plugins/openai-office-skills/skills/slides/` and `spreadsheet/` directories stay on disk as vendored content; their existing zips and the plugin description (PDF, Word, PowerPoint, Excel) are unchanged.