### PR TITLE
Refresh cloudflare-deploy content from current upstream

### DIFF
--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/SKILL.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/SKILL.md
@@ -54,6 +54,7 @@ Need storage?
 ├─ Key-value (config, sessions, cache) → kv/
 ├─ Relational SQL → d1/ (SQLite) or hyperdrive/ (existing Postgres/MySQL)
 ├─ Object/file storage (S3-compatible) → r2/
+├─ Versioned file trees (repos, build outputs, checkpoints) → artifacts/
 ├─ Message queue (async processing) → queues/
 ├─ Vector embeddings (AI/semantic search) → vectorize/
 ├─ Strongly-consistent per-entity state → durable-objects/ (DO storage)
@@ -148,6 +149,7 @@ Need IaC? → pulumi/ (Pulumi), terraform/ (Terraform), or api/ (REST API)
 | KV | `references/kv/` |
 | D1 | `references/d1/` |
 | R2 | `references/r2/` |
+| Artifacts | `references/artifacts/` |
 | Queues | `references/queues/` |
 | Hyperdrive | `references/hyperdrive/` |
 | DO Storage | `references/do-storage/` |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/agents-sdk/README.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/agents-sdk/README.md
@@ -27,7 +27,7 @@ Build stateful, globally distributed AI agents with persistent memory, real-time
 
 **AI Chat Agent:**
 ```typescript
-import { AIChatAgent } from "agents";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 import { openai } from "@ai-sdk/openai";
 
 export class ChatAgent extends AIChatAgent<Env> {

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/agents-sdk/api.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/agents-sdk/api.md
@@ -7,7 +7,7 @@
 For AI chat with auto-streaming, message history, tools, resumable streaming.
 
 ```ts
-import { AIChatAgent } from "agents";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 import { openai } from "@ai-sdk/openai";
 
 export class ChatAgent extends AIChatAgent<Env> {
@@ -174,7 +174,7 @@ const result = await agent.processTask({ text: "Hello" }); // Call @callable met
 // agent.readyState: 0=CONNECTING, 1=OPEN, 2=CLOSING, 3=CLOSED
 
 // useAgentChat() - AI chat UI
-import { useAgentChat } from "agents/ai-react";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
 const agent = useAgent({ agent: "ChatAgent" });
 const { messages, input, handleInputChange, handleSubmit, isLoading, stop, clearHistory } = 
   useAgentChat({ 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/agents-sdk/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/agents-sdk/configuration.md
@@ -58,11 +58,11 @@ npx wrangler secret put OPENAI_API_KEY
 **Recommended: Use route helpers**
 
 ```typescript
-import { routeAgent } from "agents";
+import { routeAgentRequest } from "agents";
 
 export default {
   fetch(request: Request, env: Env) {
-    return routeAgent(request, env);
+    return routeAgentRequest(request, env);
   }
 }
 ```
@@ -91,7 +91,7 @@ export default {
 **Multi-agent setup:**
 
 ```typescript
-import { routeAgent } from "agents";
+import { routeAgentRequest } from "agents";
 
 export default {
   fetch(request: Request, env: Env) {
@@ -99,10 +99,10 @@ export default {
     
     // Route by path
     if (url.pathname.startsWith("/chat")) {
-      return routeAgent(request, env, "ChatAgent");
+      return routeAgentRequest(request, env, "ChatAgent");
     }
     if (url.pathname.startsWith("/task")) {
-      return routeAgent(request, env, "TaskAgent");
+      return routeAgentRequest(request, env, "TaskAgent");
     }
     
     return new Response("Not found", { status: 404 });
@@ -118,7 +118,7 @@ export default {
 import { routeAgentEmail } from "agents";
 
 export default {
-  fetch: (req: Request, env: Env) => routeAgent(req, env),
+  fetch: (req: Request, env: Env) => routeAgentRequest(req, env),
   email: (message: ForwardableEmailMessage, env: Env) => {
     return routeAgentEmail(message, env);
   }

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/agents-sdk/patterns.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/agents-sdk/patterns.md
@@ -5,7 +5,7 @@
 **Server (AIChatAgent):**
 
 ```ts
-import { AIChatAgent } from "agents";
+import { AIChatAgent } from "@cloudflare/ai-chat";
 import { openai } from "@ai-sdk/openai";
 import { tool } from "ai";
 import { z } from "zod";
@@ -39,7 +39,7 @@ export class ChatAgent extends AIChatAgent<Env> {
 
 ```tsx
 import { useAgent } from "agents/react";
-import { useAgentChat } from "agents/ai-react";
+import { useAgentChat } from "@cloudflare/ai-chat/react";
 
 function ChatUI() {
   const agent = useAgent({ agent: "ChatAgent" });

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/artifacts/README.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/artifacts/README.md
@@ -1,0 +1,79 @@
+# Cloudflare Artifacts
+
+Store versioned file trees behind a repo-style interface that works from Workers, the REST API, and Git-compatible tooling.
+
+## Overview
+
+Use **Artifacts** when the thing you need to store is a versioned filesystem tree rather than a single object, key, or SQL row.
+
+Typical Artifacts use cases:
+- Git-style repositories
+- Per-agent, per-session, or per-task repos
+- Build outputs and deployment bundles
+- Checkpoints and generated assets
+- Shared file trees passed between developer tools and Workers
+
+Artifacts is a good fit when the same content needs to be addressable from **Workers**, the **REST API**, and **Git-compatible clients**.
+
+Artifacts is especially useful for agent and automation workflows where each unit of work should have its own isolated repo and token.
+
+**Prefer retrieval over memory** for current availability, authentication details, route shapes, limits, and pricing. Start at `https://developers.cloudflare.com/artifacts/`.
+
+## When to Use Artifacts
+
+| Need | Use | Why |
+|------|-----|-----|
+| Versioned file trees such as repos, build outputs, checkpoints, or generated assets | Artifacts | Artifacts stores and shares **versioned filesystem content** |
+| A git-compatible workflow with `clone`, `fetch`, `pull`, or `push` | Artifacts | Artifacts exposes **git-over-HTTPS remotes** and repo-scoped tokens |
+| The same artifact accessible from Workers, HTTP APIs, and developer tooling | Artifacts | Artifacts is available through a **Workers binding**, **REST API**, and **git-compatible interface** |
+| Large files by object key, app config by key, or relational app data | R2, KV, or D1 | Use storage products directly when you need **objects, key-value entries, or SQL rows**, not versioned file trees |
+
+## Recommended Workflow
+
+- Create one repo per agent, session, user workspace, or task when work should stay isolated.
+- Fork from a stable baseline when many repos need the same starter files or prompts.
+- Use branches only when collaborators share the same lifecycle and need to work in one repo.
+- Use namespaces to separate environments, teams, or high-rate workloads.
+
+## Quick Start
+
+**From a Worker:**
+
+```typescript
+interface Env {
+  ARTIFACTS: Artifacts;
+}
+
+const created = await env.ARTIFACTS.create("starter-repo");
+// created.remote -> git remote URL
+// created.token -> initial repo token
+```
+
+**From the REST API:**
+
+Use the namespace-scoped Artifacts base URL plus a gateway JWT. For imports from existing HTTPS remotes, use the REST API rather than the Workers binding.
+
+## Reading Order
+
+| Task | Read |
+|------|------|
+| Decide whether Artifacts is the right product | README only |
+| Create or manage repos from a Worker | README → configuration.md → api.md |
+| Integrate Artifacts from an external system | README → api.md |
+| Set up agent or sandbox workflows | README → configuration.md |
+| Verify exact auth, routes, limits, or pricing | Live docs first: `https://developers.cloudflare.com/artifacts/` |
+
+## In This Reference
+
+- **[api.md](api.md)** - Workers binding methods, REST routes, token and repo operations
+- **[configuration.md](configuration.md)** - Wrangler binding shape, Worker typing, REST configuration guidance
+
+## See Also
+
+- [Cloudflare Artifacts Docs](https://developers.cloudflare.com/artifacts/)
+- [Artifacts Git Protocol Docs](https://developers.cloudflare.com/artifacts/api/git-protocol/)
+- [ArtifactFS Docs](https://developers.cloudflare.com/artifacts/api/artifactfs/)
+- [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
+- [Cloudflare Durable Objects Docs](https://developers.cloudflare.com/durable-objects/)
+- [Cloudflare R2 Docs](https://developers.cloudflare.com/r2/)
+- [Cloudflare D1 Docs](https://developers.cloudflare.com/d1/)

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/artifacts/api.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/artifacts/api.md
@@ -1,0 +1,128 @@
+# Artifacts API Reference
+
+Use Artifacts through the **Workers binding**, the **REST control plane**, and **Git-compatible remotes**.
+
+**Prefer retrieval** for exact request and response details. Verify current behavior at `https://developers.cloudflare.com/artifacts/` before relying on specific auth flows, route details, or generated binding types.
+
+## Workers Binding
+
+Artifacts exposes a Worker binding on `env.ARTIFACTS`.
+
+### Namespace Methods
+
+| Method | Use For |
+|--------|---------|
+| `create(name, opts?)` | Create a repo and receive its initial remote and token |
+| `get(name)` | Resolve a repo handle for repo-scoped operations |
+| `list(opts?)` | List repos in a namespace |
+| `delete(name)` | Delete a repo |
+
+```typescript
+const created = await env.ARTIFACTS.create("starter-repo", {
+  description: "Repository for automation experiments",
+  setDefaultBranch: "main"
+});
+const repo = await env.ARTIFACTS.get("starter-repo");
+const page = await env.ARTIFACTS.list({ limit: 10 });
+```
+
+Use the REST API when you need to import a repo from another HTTPS remote.
+
+### Repo Handle Methods
+
+Use a repo handle returned by `get()` or `create()`.
+
+| Method | Use For |
+|--------|---------|
+| `info()` | Read repo metadata, including the remote URL |
+| `createToken(scope?, ttl?)` | Mint a repo-scoped read or write token |
+| `listTokens()` | Inspect active tokens |
+| `validateToken(token)` | Check whether a token is still valid |
+| `revokeToken(tokenOrId)` | Revoke a token by ID or value |
+| `fork(name, opts?)` | Fork one repo into another |
+
+```typescript
+const repo = await env.ARTIFACTS.get("starter-repo");
+if (!repo) throw new Error("Repo not found");
+
+const info = await repo.info();
+const token = await repo.createToken("read", 3600);
+const forked = await repo.fork("starter-repo-copy", {
+  defaultBranchOnly: true
+});
+```
+
+### Binding Notes
+
+- Current docs describe the runtime binding surface as `create`, `get`, `list`, `delete`, and repo-handle methods like `info`, `createToken`, and `fork`.
+- Use `npx wrangler types` in the target project and treat the generated `worker-configuration.d.ts` as the source of truth for that environment.
+- If generated types appear to expose `import()` or a different `get()` shape, verify the live docs before depending on those methods.
+
+Verify current runtime behavior in the live docs before depending on methods that are not shown in the Workers binding reference.
+
+## REST API
+
+Artifacts currently documents a namespace-scoped control plane:
+
+```txt
+https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE
+```
+
+Some deployments also expose an `/edge/v1/api/...` base path. Verify the correct base URL for your environment in the live docs.
+
+Requests to the standard `/v1/api/...` routes use a **gateway JWT** with Bearer authentication.
+
+Returned repo tokens authenticate **Git operations** against the repo `remote`. They do not authenticate REST control-plane requests.
+
+Current docs show the standard Cloudflare v4 response envelope around REST results.
+
+### Repo Routes
+
+| Route | Use For |
+|-------|---------|
+| `POST /repos` | Create a repo |
+| `GET /repos` | List repos |
+| `GET /repos/:name` | Read repo metadata and remote |
+| `DELETE /repos/:name` | Delete a repo |
+| `POST /repos/:name/fork` | Fork a repo |
+| `POST /repos/:name/import` | Import a public HTTPS remote |
+
+```bash
+curl --request POST "$ARTIFACTS_BASE_URL/repos" \
+  --header "Authorization: Bearer $ARTIFACTS_JWT" \
+  --header "Content-Type: application/json" \
+  --data '{"name":"starter-repo"}'
+```
+
+Important current details from the docs draft:
+- `POST /repos/:name/import` accepts a full HTTPS remote URL such as GitHub or GitLab.
+- Import supports options such as `branch`, `depth`, and `read_only`.
+- Repo metadata includes fields such as description, default branch, timestamps, and the Git `remote`.
+
+### Token Routes
+
+| Route | Use For |
+|-------|---------|
+| `GET /repos/:name/tokens` | List repo tokens |
+| `POST /tokens` | Create a token for a repo |
+| `DELETE /tokens/:id` | Revoke a token by ID |
+
+Current docs show list-token filtering and pagination by token state. Retrieve the exact query shape from the live docs when you need token audit or cleanup workflows.
+
+Use **read** tokens for clone, fetch, pull, and indexing workflows. Use **write** tokens only when a workflow must push or otherwise mutate a repo.
+
+## Git-Compatible Access
+
+Artifacts returns repo `remote` URLs that work with standard git-over-HTTPS tooling.
+
+Recommended current auth pattern for local workflows:
+
+```bash
+git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" clone "$ARTIFACTS_REMOTE" artifacts-clone
+```
+
+Use a self-contained Basic-auth remote only for short-lived commands that need credentials embedded in the URL.
+
+`read` tokens support `clone`, `fetch`, and `pull`. `git push` requires a `write` token.
+
+For large repos where startup time matters more than a full clone, Artifacts also documents **ArtifactFS**. Retrieve current details from `https://developers.cloudflare.com/artifacts/` when you need mount-style access.

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/artifacts/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/artifacts/configuration.md
@@ -1,0 +1,92 @@
+# Artifacts Configuration
+
+## Worker Binding
+
+Configure the `artifacts` binding in your Wrangler config:
+
+```toml
+[[artifacts]]
+binding = "ARTIFACTS"
+namespace = "default"
+```
+
+This exposes Artifacts on `env.ARTIFACTS` inside your Worker.
+
+If you authenticate with `wrangler login`, current docs say Wrangler requests `artifacts:write` by default.
+
+## TypeScript
+
+Regenerate Worker types after adding the binding:
+
+```bash
+npx wrangler types
+```
+
+Use the generated binding type in your environment definition:
+
+```typescript
+interface Env {
+  ARTIFACTS: Artifacts;
+}
+```
+
+Wrangler generates the `Artifacts` type from the binding. Treat the generated `worker-configuration.d.ts` file as the source of truth for your environment.
+
+## Structure Repos for Isolation
+
+Artifacts works best when autonomous work is isolated:
+- Create one repo per agent, session, sandbox, or task when work should stay separate.
+- Fork from a reviewed baseline instead of copying starter files into every new repo.
+- Use branches only when collaborators share the same lifecycle and need to work in one repo.
+- Use namespaces to separate environments, teams, or high-rate workloads.
+
+## REST Configuration
+
+For external systems, configure the namespace-scoped base URL and gateway JWT:
+
+```bash
+export ARTIFACTS_NAMESPACE="default"
+export ARTIFACTS_JWT="<YOUR_GATEWAY_JWT>"
+export ARTIFACTS_BASE_URL="https://artifacts.cloudflare.net/v1/api/namespaces/$ARTIFACTS_NAMESPACE"
+```
+
+Some environments also expose an `/edge/v1/api/...` base path. Verify the correct host and base path in the live docs for your Artifacts environment.
+
+Use environment variables or your secret manager. Do not hardcode gateway JWTs or repo tokens.
+
+## Repo Tokens
+
+Artifacts workflows usually involve repo-scoped tokens returned by `create()` or minted later through the binding or REST API.
+
+Keep the control plane and data plane separate:
+- Use the **Workers binding** or **REST API** with a gateway JWT to create repos and mint tokens.
+- Use repo-scoped tokens only for **Git operations** against the returned `remote`.
+
+Recommended handling:
+- Mint the narrowest scope you need: `read` or `write`
+- Prefer short-lived tokens for handoff between systems
+- Revoke tokens that are no longer needed
+
+Verify the current token behavior and auth guidance in `https://developers.cloudflare.com/artifacts/` before building long-lived automation.
+
+## Git Consumers
+
+Artifacts is designed to work with standard git-over-HTTPS clients once you have a repo `remote` and an access token.
+
+Prefer header-based auth for local tooling so the full token stays out of the remote URL:
+
+```bash
+git -c http.extraHeader="Authorization: Bearer $ARTIFACTS_TOKEN" clone "$ARTIFACTS_REMOTE" artifacts-clone
+```
+
+Use a Basic-auth remote only for short-lived commands that need a self-contained URL.
+
+## Retrieval Checklist
+
+Check the live docs before relying on:
+- the current Workers binding surface
+- exact token formats
+- availability or product status
+- route details for import, fork, and token-management flows
+- the correct control-plane host or `/edge/v1` base path for your environment
+- platform limits or pricing

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/cron-triggers/README.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/cron-triggers/README.md
@@ -74,7 +74,7 @@ curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*"
 ## Limits
 
 - **Free:** 3 triggers/worker, 10ms CPU
-- **Paid:** Unlimited triggers, 50ms CPU
+- **Paid:** Unlimited triggers, 30s CPU (<1hr interval) / 15min CPU (≥1hr interval)
 - **Propagation:** 15min global deployment
 - **Timezone:** UTC only
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/cron-triggers/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/cron-triggers/gotchas.md
@@ -168,7 +168,7 @@ export default {
 | Limit | Free | Paid | Notes |
 |-------|------|------|-------|
 | Triggers per Worker | 3 | Unlimited | Maximum cron schedules per Worker |
-| CPU time | 10ms | 50ms | May need `ctx.waitUntil()` or Workflows |
+| CPU time | 10ms | 30s (<1hr interval), 15min (≥1hr interval) | May need `ctx.waitUntil()` or Workflows |
 | Execution guarantee | At-least-once | At-least-once | Duplicates possible - use idempotency |
 | Propagation delay | Up to 15 minutes | Up to 15 minutes | Time for changes to take effect globally |
 | Min interval | 1 minute | 1 minute | Cannot schedule more frequently |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/d1/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/d1/configuration.md
@@ -166,8 +166,11 @@ wrangler d1 execute <db-name> --remote --file=./backup.sql
 
 ## Plan Tiers
 
-| Feature | Free | Paid |
-|---------|------|------|
+| Feature | Free (Workers Free) | Paid (Workers Paid) |
+|---------|---------------------|---------------------|
+| Rows read | 5 million / day | First 25 billion / month included |
+| Rows written | 100,000 / day | First 50 million / month included |
+| Storage | 5 GB (total) | First 5 GB included |
 | Database size | 500 MB | 10 GB |
 | Batch size | 1,000 statements | 10,000 statements |
 | Time Travel | 7 days | 30 days |
@@ -175,7 +178,7 @@ wrangler d1 execute <db-name> --remote --file=./backup.sql
 | Sessions API | ❌ | ✅ (up to 15 min) |
 | Pricing | Free | $5/mo + usage |
 
-**Usage pricing** (paid plans): $0.001 per 1K reads + $1 per 1M writes + $0.75/GB storage/month
+**Usage pricing** (paid plans, beyond included allowances): $0.001 per million rows read + $1.00 per million rows written + $0.75/GB-mo storage
 
 ## Local Development
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/email-routing/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/email-routing/gotchas.md
@@ -108,7 +108,7 @@ const subj = message.headers.get("subject")?.toLowerCase() || "";
 | Email size | 25 MB | 25 MB |
 | Rules | 200 | 200 |
 | Destinations | 200 | 200 |
-| CPU time | 10ms | 50ms |
+| CPU time | 10ms | 30s (default), 5min (max) |
 | SendEmail | ~100/min | Higher |
 
 ## Debugging

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/email-workers/README.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/email-workers/README.md
@@ -123,7 +123,7 @@ See [gotchas.md](./gotchas.md#readablestream-can-only-be-consumed-once) for deta
 | Max routing rules | 200 |
 | Max destinations | 200 |
 | CPU time (free tier) | 10ms |
-| CPU time (paid tier) | 50ms |
+| CPU time (paid tier) | 30s (default), 5min (max) |
 
 See [gotchas.md](./gotchas.md#limits-reference) for complete limits table.
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/email-workers/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/email-workers/gotchas.md
@@ -112,7 +112,7 @@ Monitor: `npx wrangler tail`
 |-------|-------|
 | Max message size | 25 MiB |
 | Max rules/zone | 200 |
-| CPU time (free/paid) | 10ms / 50ms |
+| CPU time (free/paid) | 10ms / 30s default, 5min max |
 | Reply References | 100 |
 
 ## Common Errors

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/kv/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/kv/gotchas.md
@@ -125,7 +125,7 @@ const value = await env.KV.get("key") ?? "default-value";
 | Propagation time | ≤60s | Global propagation time |
 | Bulk get max | 100 keys | Maximum keys per bulk operation |
 | Operations per Worker | 1,000 | Per request (bulk counts as 1) |
-| Reads pricing | $0.50 per 10M | Per million reads |
+| Reads pricing | $0.50 per 1M | Per million reads |
 | Writes pricing | $5.00 per 1M | Per million writes |
 | Deletes pricing | $5.00 per 1M | Per million deletes |
 | Storage pricing | $0.50 per GB-month | Per GB per month |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/pages-functions/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/pages-functions/gotchas.md
@@ -61,7 +61,7 @@ npx wrangler pages deployment tail --status error
 
 | Resource | Free | Paid |
 |----------|------|------|
-| CPU time | 10ms | 50ms |
+| CPU time | 10ms | 30s (default), 5min (max) |
 | Memory | 128 MB | 128 MB |
 | Script size | 10 MB compressed | 10 MB compressed |
 | Env vars | 5 KB per var, 64 max | 5 KB per var, 64 max |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/pages/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/pages/configuration.md
@@ -181,7 +181,7 @@ npx wrangler pages dev -- npm run dev
 | Resource | Free | Paid |
 |----------|------|------|
 | **Functions Requests** | 100k/day | Unlimited (metered) |
-| **Function CPU Time** | 10ms/req | 30ms/req (Workers Paid) |
+| **Function CPU Time** | 10ms/req | 30s default, 5min max (Workers Paid) |
 | **Function Memory** | 128MB | 128MB |
 | **Script Size** | 1MB compressed | 10MB compressed |
 | **Deployments** | 500/month | 5,000/month |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/pages/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/pages/gotchas.md
@@ -51,7 +51,7 @@
 ## Performance Issues
 
 **Problem**: Slow responses or CPU limit errors  
-**Causes**: Functions invoked for static assets; cold starts; 10ms CPU limit; large bundle  
+**Causes**: Functions invoked for static assets; cold starts; 10ms CPU limit (free) / 30s default (paid); large bundle  
 **Solution**: Exclude static via `_routes.json`; optimize hot paths; keep bundle < 1MB
 
 ## Framework-Specific
@@ -185,7 +185,7 @@ console.log('Params:', params);
 | Resource | Free | Paid |
 |----------|------|------|
 | Functions Requests | 100k/day | Unlimited |
-| CPU Time | 10ms/req | 30ms/req |
+| CPU Time | 10ms/req | 30s default, 5min max |
 | Memory | 128MB | 128MB |
 | Script Size | 1MB | 10MB |
 | Subrequests | 50/req | 10,000/req |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/pulumi/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/pulumi/gotchas.md
@@ -161,7 +161,7 @@ const deployment = new cloudflare.WorkersDeployment("prod", {
 | Resource | Limit | Notes |
 |----------|-------|-------|
 | Worker script size | 10 MB | Includes all dependencies, after compression |
-| Worker CPU time | 50ms (free), 30s (paid) | Per request |
+| Worker CPU time | 10ms (free), 30s default / 5min max (paid) | Per request |
 | KV keys per namespace | Unlimited | 1000 ops/sec write, 100k ops/sec read |
 | R2 storage | Unlimited | Class A ops: 1M/mo free, Class B: 10M/mo free |
 | D1 databases | 50,000 per account | Free: 10 per account, 5 GB each |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/README.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/README.md
@@ -59,7 +59,7 @@ export default {
 
 **Dockerfile**:
 ```dockerfile
-FROM docker.io/cloudflare/sandbox:latest
+FROM docker.io/cloudflare/sandbox:0.7.0
 RUN pip3 install --no-cache-dir pandas numpy matplotlib
 EXPOSE 8080 3000  # Required for wrangler dev
 ```

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/api.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/api.md
@@ -105,16 +105,16 @@ const ctx = await sandbox.createCodeContext({
 });
 
 // Execute code with rich outputs
-const result = await ctx.runCode(`
+const result = await sandbox.runCode(`
 import matplotlib.pyplot as plt
 plt.plot(data, [x**2 for x in data])
 plt.savefig('plot.png')
 print(f"Processed {len(data)} points")
-`);
-// Returns: { outputs: [{ type: 'text'|'image'|'html', content }], error }
+`, { context: ctx });
+// Returns: ExecutionResult { code, logs, results: RichOutput[], error, executionCount }
 
 // Context persists variables across runs
-const result2 = await ctx.runCode('print(data[0])');  // Still has 'data'
+const result2 = await sandbox.runCode('print(data[0])', { context: ctx });  // Still has 'data'
 ```
 
 ## WebSocket Connections

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/configuration.md
@@ -32,14 +32,14 @@ wrangler.jsonc `instance_type`:
 
 **Basic**:
 ```dockerfile
-FROM docker.io/cloudflare/sandbox:latest
+FROM docker.io/cloudflare/sandbox:0.7.0
 RUN pip3 install --no-cache-dir pandas numpy
 EXPOSE 8080  # Required for wrangler dev
 ```
 
 **Scientific**:
 ```dockerfile
-FROM docker.io/cloudflare/sandbox:latest
+FROM docker.io/cloudflare/sandbox:0.7.0
 RUN pip3 install --no-cache-dir \
     jupyter-server ipykernel matplotlib \
     pandas seaborn plotly scipy scikit-learn
@@ -47,7 +47,7 @@ RUN pip3 install --no-cache-dir \
 
 **Node.js**:
 ```dockerfile
-FROM docker.io/cloudflare/sandbox:latest
+FROM docker.io/cloudflare/sandbox:0.7.0
 RUN npm install -g typescript ts-node
 ```
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/gotchas.md
@@ -173,7 +173,7 @@ Token changes on each expose operation, preventing unauthorized access.
 |-----------|----------------|----------|
 | Container provisioning | 30s | `SANDBOX_INSTANCE_TIMEOUT_MS` |
 | Port readiness | 90s | `SANDBOX_PORT_TIMEOUT_MS` |
-| exec() | 120s | `timeout` option |
+| exec() | None (no default) | `timeout` option |
 | sleepAfter | 10m | `sleepAfter` option |
 
 **Performance**:

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/patterns.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/sandbox/patterns.md
@@ -15,10 +15,10 @@ export default {
     });
     
     // Execute with rich outputs (text, images, HTML)
-    const result = await ctx.runCode(code);
+    const result = await sandbox.runCode(code, { context: ctx });
     
     return Response.json({
-      outputs: result.outputs,  // [{ type: 'text'|'image'|'html', content }]
+      results: result.results,  // RichOutput[] (text, html, png, json, etc.)
       error: result.error,
       success: !result.error
     });
@@ -76,7 +76,7 @@ export default {
 
 **Dockerfile**:
 ```dockerfile
-FROM docker.io/cloudflare/sandbox:latest
+FROM docker.io/cloudflare/sandbox:0.7.0
 RUN npm install -g ws
 EXPOSE 8080
 ```

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/tail-workers/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/tail-workers/configuration.md
@@ -149,7 +149,7 @@ wrangler tail my-producer-worker
 |-------|-------|-------|
 | Max tail consumers per producer | 10 | Each receives all events independently |
 | Events batch size | Up to 100 events per invocation | Larger batches split across invocations |
-| Tail Worker CPU time | Same as regular Workers | 10ms (free), 30ms (paid), 50ms (paid bundle) |
+| Tail Worker CPU time | Same as regular Workers | 10ms (free), 30s default / 5min max (paid) |
 | Pricing tier | Workers Paid or Enterprise | Not available on free plan |
 | Request body size | 100 MB max | When sending to external endpoints |
 | Event retention | None | Events not retried if tail handler fails |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/vectorize/api.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/vectorize/api.md
@@ -41,7 +41,7 @@ await env.VECTORIZE.insert([{ id, values, metadata }]);
 await env.VECTORIZE.upsert([{ id, values, metadata }]);
 ```
 
-**Max 500 vectors per call.** Queryable after 5-10 seconds.
+**Max 1,000 vectors per call (Workers) / 5,000 (HTTP API).** Queryable after 5-10 seconds.
 
 ## Other Operations
 
@@ -79,10 +79,10 @@ Requires metadata index. Filter operators:
 | `returnMetadata: "all"` | 20 | Slower |
 | `returnValues: true` | 20 | Slower |
 
-**Batch operations:** Always batch (500/call) for optimal throughput.
+**Batch operations:** Always batch (1,000/call via Workers, 5,000 via HTTP API) for optimal throughput.
 
 ```typescript
-for (let i = 0; i < vectors.length; i += 500) {
-  await env.VECTORIZE.upsert(vectors.slice(i, i + 500));
+for (let i = 0; i < vectors.length; i += 1000) {
+  await env.VECTORIZE.upsert(vectors.slice(i, i + 1000));
 }
 ```

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/vectorize/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/vectorize/gotchas.md
@@ -6,12 +6,12 @@
 Insert/upsert/delete return immediately but vectors aren't queryable for 5-10 seconds.
 
 ### Batch Size Limit
-**Workers API: 500 vectors max per call** (undocumented, silently truncates)
+**Workers API: 1,000 vectors max per call (HTTP API: 5,000).** Silently truncates if exceeded.
 
 ```typescript
-// ✅ Chunk into 500
-for (let i = 0; i < vectors.length; i += 500) {
-  await env.VECTORIZE.upsert(vectors.slice(i, i + 500));
+// ✅ Chunk into 1000 (Workers API limit; HTTP API allows 5000)
+for (let i = 0; i < vectors.length; i += 1000) {
+  await env.VECTORIZE.upsert(vectors.slice(i, i + 1000));
 }
 ```
 
@@ -44,7 +44,7 @@ Cannot change dimensions/metric after creation. Must create new index and migrat
 |----------|-------|
 | Vectors per index | 10,000,000 |
 | Max dimensions | 1536 |
-| Batch upsert (Workers) | **500** |
+| Batch upsert (Workers / HTTP API) | **1,000 / 5,000** |
 | Indexed string metadata | **64 bytes** |
 | Metadata indexes | 10 |
 | Namespaces | 50,000 (paid) / 1,000 (free) |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers-playground/README.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers-playground/README.md
@@ -115,7 +115,7 @@ export default {
 | Bindings | None | KV, D1, R2, DO, AI, etc. |
 | Environment vars | None | Full support |
 | Module format | ES only | ES + Service Worker |
-| CPU time | 10ms (Free plan) | 10ms Free / 50ms Paid |
+| CPU time | 10ms (Free plan) | 10ms Free / 30s default, 5min max Paid |
 | Custom domains | No | Yes |
 | Analytics | No | Yes |
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers-playground/api.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers-playground/api.md
@@ -96,6 +96,6 @@ const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(data
 
 | Resource | Limit |
 |----------|-------|
-| CPU time | 10ms |
+| CPU time | 10ms (Free plan; Paid: 30s default, 5min max) |
 | Subrequests | 50 |
 | Memory | 128 MB |

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers-playground/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers-playground/configuration.md
@@ -160,4 +160,4 @@ Same as production Free plan:
 | Request size | 100 MB | Incoming |
 | Response size | Unlimited | Outgoing (streamed) |
 
-**Exceeding CPU time** throws error immediately. Optimize hot paths or upgrade to Paid plan (50ms CPU).
+**Exceeding CPU time** throws error immediately. Optimize hot paths or upgrade to Paid plan (30s default, 5min max CPU).

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers-playground/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers-playground/gotchas.md
@@ -26,7 +26,7 @@ await fetch(url, { body: clone.body });
 
 ### "Worker exceeded CPU time"
 
-**Limit:** 10ms (free), 50ms (paid)
+**Limit:** 10ms (free), 30s default / 5min max (paid)
 
 ```javascript
 // ✅ Move slow work to background
@@ -66,7 +66,7 @@ try { ... } catch (e) {
 
 | Resource | Free | Paid |
 |----------|------|------|
-| CPU time | 10ms | 50ms |
+| CPU time | 10ms | 30s (default), 5min (max) |
 | Memory | 128 MB | 128 MB |
 | Subrequests | 50 | 10,000 |
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers/configuration.md
@@ -154,7 +154,7 @@ interface Env {
   "placement": { "mode": "smart" },
   
   // Enable Node.js built-ins (Buffer, process, path, etc.)
-  "compatibility_flags": ["nodejs_compat_v2"],
+  "compatibility_flags": ["nodejs_compat"],
   
   // Observability (10% sampling)
   "observability": { "enabled": true, "head_sampling_rate": 0.1 }
@@ -163,7 +163,7 @@ interface Env {
 
 ### Node.js Compatibility
 
-`nodejs_compat_v2` enables:
+`nodejs_compat` enables:
 - `Buffer`, `process.env`, `path`, `stream`
 - CommonJS `require()` for Node modules
 - `node:` imports (e.g., `import { Buffer } from 'node:buffer'`)

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workers/gotchas.md
@@ -20,7 +20,7 @@
 ### "Node.js module not found"
 
 **Cause:** Node.js built-ins not available by default  
-**Solution:** Use Workers APIs (e.g., R2 for file storage) or enable Node.js compat with `"compatibility_flags": ["nodejs_compat_v2"]`
+**Solution:** Use Workers APIs (e.g., R2 for file storage) or enable Node.js compat with `"compatibility_flags": ["nodejs_compat"]`
 
 ### "Cannot fetch in global scope"
 
@@ -125,7 +125,7 @@ See [frameworks.md](./frameworks.md) for full patterns
 | CPU time (Paid) | 30s default / 5min max | Configurable via `limits.cpu_ms` |
 | Subrequests (Free) | 50 | Per invocation |
 | Subrequests (Paid) | 10,000 | Per invocation |
-| KV reads | 1000 | Per request |
+| Subrequest operations (KV, R2, Cache API) | 1,000 | Shared across KV reads, R2 ops, Cache API calls per request |
 | KV value size | 25 MiB | Maximum per key |
 | Environment variable size | 5 KB | Per variable |
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/README.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/README.md
@@ -47,10 +47,18 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 
 - **Durability**: Failed steps don't re-run successful ones
 - **Retries**: Configurable backoff (constant/linear/exponential)
-- **Events**: `waitForEvent()` for webhooks/approvals (timeout: 1h → 365d)
-- **Sleep**: `sleep()` / `sleepUntil()` for scheduling (max 365d)
+- **Events**: `waitForEvent()` for webhooks/approvals (configurable timeout)
+- **Sleep**: `sleep()` / `sleepUntil()` for scheduling
 - **Parallel**: `Promise.all()` for concurrent steps
 - **Idempotency**: Check-then-execute patterns
+
+## Retrieval
+
+These reference files cover API shapes, code patterns, and debugging — things that are stable. For **limits, pricing, and other values that change**, always fetch the latest from the official docs:
+
+- **Limits:** https://developers.cloudflare.com/workflows/reference/limits/
+- **Pricing:** https://developers.cloudflare.com/workflows/reference/pricing/
+- **Workers API:** https://developers.cloudflare.com/workflows/build/workers-api/
 
 ## Reading Order
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/api.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/api.md
@@ -15,17 +15,44 @@ await step.sleep('description', 5000); // ms
 await step.sleepUntil('description', Date.parse('2024-12-31'));
 
 // step.waitForEvent()
-const data = await step.waitForEvent<PayloadType>('wait', {event: 'webhook-type', timeout: '24h'}); // Default 24h, max 365d
-try { const event = await step.waitForEvent('wait', { event: 'approval', timeout: '1h' }); } catch (e) { /* Timeout */ }
+const data = await step.waitForEvent<PayloadType>('wait', {type: 'webhook-type', timeout: '24h'});
+try { const event = await step.waitForEvent('wait', { type: 'approval', timeout: '1h' }); } catch (e) { /* Timeout */ }
+```
+
+## WorkflowStepContext
+
+The `WorkflowStepContext` is passed as the first argument to the `step.do()` callback. It provides runtime information about the current step execution.
+
+```typescript
+type WorkflowStepContext = {
+  step: {
+    name: string;   // Step name as passed to step.do()
+    count: number;  // How many times step.do() called with this name in current run (1-indexed)
+  };
+  attempt: number;  // Current attempt number (1-indexed): 1 = first try, 2 = first retry, etc.
+  config: WorkflowStepConfig; // Resolved config for this step, including runtime defaults
+};
+```
+
+**Use cases:**
+```typescript
+// Adjust behavior based on retry attempt
+await step.do('call api', { retries: { limit: 3, delay: '5 seconds', backoff: 'exponential' } }, async (ctx) => {
+  if (ctx.attempt > 1) console.log(`Retry attempt ${ctx.attempt} for step "${ctx.step.name}"`);
+  const res = await fetch('https://api.example.com/data');
+  if (!res.ok) throw new Error(`API failed (attempt ${ctx.attempt})`);
+  return res.json();
+});
+
 ```
 
 ## Instance Management
 
 ```typescript
 // Create single
-const instance = await env.MY_WORKFLOW.create({id: crypto.randomUUID(), params: { userId: 'user123' }}); // id optional, auto-generated if omitted
+const instance = await env.MY_WORKFLOW.create({id: crypto.randomUUID(), params: { userId: 'user123' }}); // id optional, auto-generated if omitted; throws if ID already exists within retention period
 
-// Create with custom retention (default: 3 days free, 30 days paid)
+// Create with custom retention (check docs for default per plan)
 const instance = await env.MY_WORKFLOW.create({
   id: crypto.randomUUID(),
   params: { userId: 'user123' },
@@ -69,7 +96,7 @@ export class ParentWorkflow extends WorkflowEntrypoint<Env, Params> {
 ## Error Handling
 
 ```typescript
-import { NonRetryableError } from 'cloudflare:workers';
+import { NonRetryableError } from 'cloudflare:workflows';
 
 // NonRetryableError
 await step.do('validate', async () => {
@@ -115,6 +142,12 @@ type InvalidParams = {
 const result = await step.do('fetch', async () => {
   return { userId: '123', data: [1, 2, 3] }; // ✅ Plain object
 });
+
+// ✅ ReadableStream<Uint8Array> for large binary output (bypasses non-stream step result size limit)
+const stream = await step.do('read from R2', async () => {
+  const obj = await this.env.BUCKET.get('large-file.csv');
+  return obj.body; // Return the ReadableStream directly
+});
 ```
 
 ## Sleep & Scheduling
@@ -130,7 +163,7 @@ await step.sleepUntil('launch date', Date.parse('24 Oct 2024 13:00:00 UTC'));
 await step.sleepUntil('deadline', new Date('2024-12-31T23:59:59Z'));
 ```
 
-Units: second, minute, hour, day, week, month, year. Max: 365 days.
+Units: second, minute, hour, day, week, month, year.
 Sleeping instances don't count toward concurrency.
 
 ## Parameters

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/configuration.md
@@ -6,7 +6,7 @@
 {
   "name": "my-worker",
   "main": "src/index.ts",
-  "compatibility_date": "2025-01-01",  // Use current date for new projects
+  "compatibility_date": "2025-01-01",  // Minimum 2024-10-22 required for Workflows bindings
   "observability": {
     "enabled": true  // Enables Workflows dashboard + structured logs
   },
@@ -14,12 +14,13 @@
     {
       "name": "my-workflow",           // Workflow name
       "binding": "MY_WORKFLOW",        // Env binding
-      "class_name": "MyWorkflow"      // TS class name
+      "class_name": "MyWorkflow",      // TS class name
       // "script_name": "other-worker" // For cross-script calls
+      // "limits": { "steps": 25000 }  // Optional: max steps per instance (check docs for default/max per plan)
     }
   ],
   "limits": {
-    "cpu_ms": 300000  // 5 min max (default 30s)
+    "cpu_ms": 300000  // Check docs for default and max CPU time per plan
   }
 }
 ```
@@ -33,11 +34,11 @@ const data = await step.do('step name', async () => ({ result: 'value' }));
 // With retry config
 await step.do('api call', {
   retries: {
-    limit: 10,              // Default: 5, or Infinity
-    delay: '10 seconds',    // Default: 10000ms
+    limit: 10,              // Accepts number or Infinity
+    delay: '10 seconds',    // Accepts number (ms) or duration string
     backoff: 'exponential'  // constant | linear | exponential
   },
-  timeout: '30 minutes'     // Per-attempt timeout (default: 10min)
+  timeout: '30 minutes'     // Per-attempt timeout
 }, async () => {
   const res = await fetch('https://api.example.com/data');
   if (!res.ok) throw new Error('Failed');

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/gotchas.md
@@ -4,12 +4,12 @@
 
 ### "Step Timeout"
 
-**Cause:** Step execution exceeding 10 minute default timeout or configured timeout  
-**Solution:** Set custom timeout with `step.do('long operation', {timeout: '30 minutes'}, async () => {...})` or increase CPU limit in wrangler.jsonc (max 5min CPU time)
+**Cause:** Step execution exceeding the default or configured timeout  
+**Solution:** Set custom timeout with `step.do('long operation', {timeout: '30 minutes'}, async () => {...})` or increase CPU limit via `limits.cpu_ms` in wrangler.jsonc
 
 ### "waitForEvent Timeout"
 
-**Cause:** Event not received within timeout period (default 24h, max 365d)  
+**Cause:** Event not received within timeout period (check docs for default/max)  
 **Solution:** Wrap in try-catch to handle timeout gracefully and proceed with default behavior
 
 ### "Non-Deterministic Step Names"
@@ -29,13 +29,13 @@
 
 ### "Large Step Returns Exceeding Limit"
 
-**Cause:** Returning data >1 MiB from step  
-**Solution:** Store large data in R2 and return only reference: `{ key: 'r2-object-key' }`
+**Cause:** Returning data exceeding the per-step return size limit  
+**Solution:** Store large data in R2 and return only reference: `{ key: 'r2-object-key' }`. Alternatively, return a `ReadableStream<Uint8Array>` for large binary output
 
-### "Step Exceeded CPU Limit But Ran for < 30s"
+### "Step Exceeded CPU Limit But Ran for a Short Time"
 
 **Cause:** Confusion between CPU time (active compute) and wall-clock time (includes I/O waits)  
-**Solution:** Network requests, database queries, and sleeps don't count toward CPU. 30s limit = 30s of active processing
+**Solution:** Network requests, database queries, and sleeps don't count toward CPU. The CPU limit refers to active processing time only
 
 ### "Idempotency Violation"
 
@@ -49,7 +49,7 @@
 
 ### "Instance Data Disappeared After Completion"
 
-**Cause:** Completed/errored instances are automatically deleted after retention period (3 days free / 30 days paid)  
+**Cause:** Completed/errored instances are automatically deleted after the retention period (differs by plan)  
 **Solution:** Export critical data to KV/R2/D1 before workflow completes
 
 ### "Missing await on step.do"
@@ -57,32 +57,25 @@
 **Cause:** Forgetting to await step.do() causing fire-and-forget behavior  
 **Solution:** Always await step operations: `await step.do('task', ...)`
 
-## Limits
+### "Provided event type is invalid"
 
-| Limit | Free | Paid | Notes |
-|-------|------|------|-------|
-| CPU per step | 10ms | 30s (default), 5min (max) | Set via `limits.cpu_ms` in wrangler.jsonc |
-| Step state | 1 MiB | 1 MiB | Per step return value |
-| Instance state | 100 MB | 1 GB | Total state per workflow instance |
-| Steps per workflow | 1,024 | 1,024 | `step.sleep()` doesn't count |
-| Executions per day | 100k | Unlimited | Daily execution limit |
-| Concurrent instances | 25 | 10k | Maximum concurrent workflows; waiting state excluded |
-| Queued instances | 100k | 1M | Maximum queued workflow instances |
-| Subrequests per instance | 50 | 10,000 (default), up to 10M | Maximum outbound requests per workflow instance |
-| State retention | 3 days | 30 days | How long completed instances kept |
-| Step timeout default | 10 min | 10 min | Per attempt |
-| waitForEvent timeout default | 24h | 24h | Maximum 365 days |
-| waitForEvent timeout max | 365 days | 365 days | Maximum wait time |
+**Cause:** Using unsupported characters in `waitForEvent` type (e.g. `.`)  
+**Solution:** Type only supports letters, digits, `-`, and `_`. Pattern: `^[a-zA-Z0-9_][a-zA-Z0-9-_]*$`
 
-**Note:** Instances in `waiting` state (from `step.sleep` or `step.waitForEvent`) don't count toward concurrent instance limit, allowing millions of sleeping workflows.
+## Limits & Pricing
 
-## Pricing
+Limits and pricing change over time. **Always fetch the latest values** from the official docs before citing specific numbers:
 
-| Metric | Free | Paid | Notes |
-|--------|------|------|-------|
-| Requests | 100k/day | 10M/mo + $0.30/M | Workflow invocations |
-| CPU time | 10ms/invoke | 30M CPU-ms/mo + $0.02/M CPU-ms | Actual CPU usage |
-| Storage | 1 GB | 1 GB/mo + $0.20/GB-mo | All instances (running/errored/sleeping/completed) |
+- **Limits:** https://developers.cloudflare.com/workflows/reference/limits/
+- **Pricing:** https://developers.cloudflare.com/workflows/reference/pricing/
+
+Key areas to check: CPU time per step, max steps per workflow, concurrent instance limits, step return size, event payload size, instance creation rate, subrequest limits, state retention period, and name/ID length constraints.
+
+**Behavioral notes** (stable, not subject to number changes):
+- `step.sleep()` and `step.waitForEvent()` don't count toward the max steps limit
+- Instances in `waiting` state (sleeping, waiting for event, waiting for retry) don't count toward the concurrent instance limit
+- CPU time is active processing only — network I/O, DB queries, and sleeps are wall-clock time, not CPU time
+- `waitForEvent` type and workflow/instance names follow pattern `^[a-zA-Z0-9_][a-zA-Z0-9-_]*$`
 
 ## References
 

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/patterns.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/workflows/patterns.md
@@ -9,7 +9,7 @@ export class ImageProcessingWorkflow extends WorkflowEntrypoint<Env, Params> {
     const description = await step.do('generate description', async () => 
       await this.env.AI.run('@cf/llava-hf/llava-1.5-7b-hf', {image: Array.from(new Uint8Array(imageData)), prompt: 'Describe this image', max_tokens: 50})
     );
-    await step.waitForEvent('await approval', { event: 'approved', timeout: '24h' });
+    await step.waitForEvent('await approval', { type: 'approved', timeout: '24h' });
     await step.do('publish', async () => await this.env.BUCKET.put(`public/${event.payload.imageKey}`, imageData));
   }
 }
@@ -68,7 +68,7 @@ export class ApprovalWorkflow extends WorkflowEntrypoint<Env, Params> {
   async run(event, step) {
     await step.do('create approval', async () => await this.env.DB.prepare('INSERT INTO approvals (id, user_id, status) VALUES (?, ?, ?)').bind(event.instanceId, event.payload.userId, 'pending').run());
     try {
-      const approval = await step.waitForEvent<{ approved: boolean }>('wait for approval', { event: 'approval-response', timeout: '48h' });
+      const approval = await step.waitForEvent<{ approved: boolean }>('wait for approval', { type: 'approval-response', timeout: '48h' });
       if (approval.approved) { await step.do('process approval', async () => {}); } 
       else { await step.do('handle rejection', async () => {}); }
     } catch (e) {
@@ -124,7 +124,7 @@ await introspector.modify(async (m) => {
 4. **Return state**: Persist via step returns, not variables
 5. **Always await**: `await step.do()`, avoid dangling promises
 6. **Deterministic conditionals**: Base on `event.payload` or step outputs
-7. **Store large data externally**: R2/KV for >1 MiB, return refs
+7. **Store large data externally**: R2/KV for data exceeding step return limit, return refs
 8. **Batch creation**: `createBatch()` for multiple instances
 
 ### ❌ DON'T

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/wrangler/README.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/wrangler/README.md
@@ -90,8 +90,8 @@ wrangler secret delete NAME       # Delete Worker secret
 wrangler secret bulk FILE.json    # Bulk upload from JSON
 
 # Secrets Store (centralized, reusable across Workers)
-wrangler secret-store:secret put STORE_NAME SECRET_NAME
-wrangler secret-store:secret list STORE_NAME
+wrangler secrets-store secret create <store-id> --name SECRET_NAME --scopes workers --remote
+wrangler secrets-store secret list <store-id> --remote
 ```
 
 ### Monitoring

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/wrangler/configuration.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/wrangler/configuration.md
@@ -4,7 +4,7 @@ Configuration reference for wrangler.jsonc (recommended).
 
 ## Config Format
 
-**wrangler.jsonc recommended** (v3.91.0+) - provides schema validation.
+**wrangler.jsonc recommended** (Wrangler v4+) - provides schema validation.
 
 ```jsonc
 {
@@ -90,9 +90,9 @@ Deploy: `wrangler deploy --env production`
 // Vectorize
 { "vectorize": [{ "binding": "VECTORS", "index_name": "embeddings" }] }
 
-// Hyperdrive (requires nodejs_compat_v2 for pg/postgres)
+// Hyperdrive (requires nodejs_compat for pg/postgres)
 { "hyperdrive": [{ "binding": "HYPERDRIVE", "id": "hyper-id" }] }
-{ "compatibility_flags": ["nodejs_compat_v2"] }  // For pg/postgres
+{ "compatibility_flags": ["nodejs_compat"] }  // For pg/postgres
 
 // Workers AI
 { "ai": { "binding": "AI" } }

--- a/plugins/cloudflare-skills/skills/cloudflare-deploy/references/wrangler/gotchas.md
+++ b/plugins/cloudflare-skills/skills/cloudflare-deploy/references/wrangler/gotchas.md
@@ -70,7 +70,7 @@ For local DOs in same Worker, `script_name` is optional.
 **Cause:** Missing Node.js compatibility flag
 **Solution:** Some bindings (Hyperdrive with `pg`) require:
 ```jsonc
-{ "compatibility_flags": ["nodejs_compat_v2"] }
+{ "compatibility_flags": ["nodejs_compat"] }
 ```
 
 ### "Workers Assets 404 errors"
@@ -131,7 +131,7 @@ const worker = await startWorker({
 | Workers Assets size | 25 MB | Per deployment |
 | Workers Assets files | 20,000 | Max number of files |
 | Script size (compressed) | 1 MB | Free, 10 MB paid |
-| CPU time | 10-50ms | Free, 50-500ms paid |
+| CPU time | 10ms | Free, 30s default (5min max) paid |
 | Subrequest limit | 50 | Free, 10,000 paid |
 
 ## Troubleshooting
@@ -145,7 +145,7 @@ wrangler whoami
 
 ### Configuration Errors
 ```bash
-wrangler check  # Validate config
+wrangler check startup  # Profile Worker startup time and detect scripts exceeding the startup time limit
 ```
 Use wrangler.jsonc with `$schema` for validation.
 


### PR DESCRIPTION
The cloudflare sync script picked up upstream edits across 38 reference files plus a new `artifacts/` subdir that weren't on disk yet. This commits the regenerated content so users installing from main get the current upstream snapshot instead of a stale one.

Notable correction being committed: `workers/gotchas.md` now uses `nodejs_compat` instead of `nodejs_compat_v2` in its example. Both flags still exist; with modern compatibility dates plain `nodejs_compat` already implies v2, so the upstream simplified the example. Without this commit the skill kept advising the explicit-v2 spelling. The KV limits table also got rewritten to reflect Workers' shared subrequest pool.