### PR TITLE
Refresh react-skills content from upstream

### DIFF
--- a/plugins/react-skills/skills/react-best-practices/SKILL.md
+++ b/plugins/react-skills/skills/react-best-practices/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 # Vercel React Best Practices
 
-Comprehensive performance optimization guide for React and Next.js applications, maintained by Vercel. Contains 68 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
+Comprehensive performance optimization guide for React and Next.js applications, maintained by Vercel. Contains 70 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
 
 ## When to Apply
 
@@ -47,6 +47,7 @@ Reference these guidelines when:
 ### 2. Bundle Size Optimization (CRITICAL)
 
 - `bundle-barrel-imports` - Import directly, avoid barrel files
+- `bundle-analyzable-paths` - Prefer statically analyzable import and file-system paths to avoid broad bundles and traces
 - `bundle-dynamic-imports` - Use next/dynamic for heavy components
 - `bundle-defer-third-party` - Load analytics/logging after hydration
 - `bundle-conditional` - Load modules only when feature is activated
@@ -123,6 +124,7 @@ Reference these guidelines when:
 
 ### 8. Advanced Patterns (LOW)
 
+- `advanced-effect-event-deps` - Don't put `useEffectEvent` results in effect deps
 - `advanced-event-handler-refs` - Store event handlers in refs
 - `advanced-init-once` - Initialize app once per app load
 - `advanced-use-latest` - useLatest for stable callback refs

--- a/plugins/react-skills/skills/react-best-practices/rules/advanced-effect-event-deps.md
+++ b/plugins/react-skills/skills/react-best-practices/rules/advanced-effect-event-deps.md
@@ -1,0 +1,56 @@
+---
+title: Do Not Put Effect Events in Dependency Arrays
+impact: LOW
+impactDescription: avoids unnecessary effect re-runs and lint errors
+tags: advanced, hooks, useEffectEvent, dependencies, effects
+---
+
+## Do Not Put Effect Events in Dependency Arrays
+
+Effect Event functions do not have a stable identity. Their identity intentionally changes on every render. Do not include the function returned by `useEffectEvent` in a `useEffect` dependency array. Keep the actual reactive values as dependencies and call the Effect Event from inside the effect body or subscriptions created by that effect.
+
+**Incorrect (Effect Event added as a dependency):**
+
+```tsx
+import { useEffect, useEffectEvent } from 'react'
+
+function ChatRoom({ roomId, onConnected }: {
+  roomId: string
+  onConnected: () => void
+}) {
+  const handleConnected = useEffectEvent(onConnected)
+
+  useEffect(() => {
+    const connection = createConnection(roomId)
+    connection.on('connected', handleConnected)
+    connection.connect()
+
+    return () => connection.disconnect()
+  }, [roomId, handleConnected])
+}
+```
+
+Including the Effect Event in dependencies makes the effect re-run every render and triggers the React Hooks lint rule.
+
+**Correct (depend on reactive values, not the Effect Event):**
+
+```tsx
+import { useEffect, useEffectEvent } from 'react'
+
+function ChatRoom({ roomId, onConnected }: {
+  roomId: string
+  onConnected: () => void
+}) {
+  const handleConnected = useEffectEvent(onConnected)
+
+  useEffect(() => {
+    const connection = createConnection(roomId)
+    connection.on('connected', handleConnected)
+    connection.connect()
+
+    return () => connection.disconnect()
+  }, [roomId])
+}
+```
+
+Reference: [React useEffectEvent: Effect Event in deps](https://react.dev/reference/react/useEffectEvent#effect-event-in-deps)

--- a/plugins/react-skills/skills/react-best-practices/rules/bundle-analyzable-paths.md
+++ b/plugins/react-skills/skills/react-best-practices/rules/bundle-analyzable-paths.md
@@ -1,0 +1,63 @@
+---
+title: Prefer Statically Analyzable Paths
+impact: HIGH
+impactDescription: avoids accidental broad bundles and file traces
+tags: bundle, nextjs, vite, webpack, rollup, esbuild, path
+---
+
+## Prefer Statically Analyzable Paths
+
+Build tools work best when import and file-system paths are obvious at build time. If you hide the real path inside a variable or compose it too dynamically, the tool either has to include a broad set of possible files, warn that it cannot analyze the import, or widen file tracing to stay safe.
+
+Prefer explicit maps or literal paths so the set of reachable files stays narrow and predictable. This is the same rule whether you are choosing modules with `import()` or reading files in server/build code.
+
+When analysis becomes too broad, the cost is real:
+- Larger server bundles
+- Slower builds
+- Worse cold starts
+- More memory use
+
+### Import Paths
+
+**Incorrect (the bundler cannot tell what may be imported):**
+
+```ts
+const PAGE_MODULES = {
+  home: './pages/home',
+  settings: './pages/settings',
+} as const
+
+const Page = await import(PAGE_MODULES[pageName])
+```
+
+**Correct (use an explicit map of allowed modules):**
+
+```ts
+const PAGE_MODULES = {
+  home: () => import('./pages/home'),
+  settings: () => import('./pages/settings'),
+} as const
+
+const Page = await PAGE_MODULES[pageName]()
+```
+
+### File-System Paths
+
+**Incorrect (a 2-value enum still hides the final path from static analysis):**
+
+```ts
+const baseDir = path.join(process.cwd(), 'content/' + contentKind)
+```
+
+**Correct (make each final path literal at the callsite):**
+
+```ts
+const baseDir =
+  kind === ContentKind.Blog
+    ? path.join(process.cwd(), 'content/blog')
+    : path.join(process.cwd(), 'content/docs')
+```
+
+In Next.js server code, this matters for output file tracing too. `path.join(process.cwd(), someVar)` can widen the traced file set because Next.js statically analyze `import`, `require`, and `fs` usage.
+
+Reference: [Next.js output](https://nextjs.org/docs/app/api-reference/config/next-config-js/output), [Next.js dynamic imports](https://nextjs.org/learn/seo/dynamic-imports), [Vite features](https://vite.dev/guide/features.html), [esbuild API](https://esbuild.github.io/api/), [Rollup dynamic import vars](https://www.npmjs.com/package/@rollup/plugin-dynamic-import-vars), [Webpack dependency management](https://webpack.js.org/guides/dependency-management/)

--- a/plugins/react-skills/skills/react-view-transitions/SKILL.md
+++ b/plugins/react-skills/skills/react-view-transitions/SKILL.md
@@ -25,7 +25,7 @@ Implement **all** applicable patterns from this list, in this order:
 | 4 | **State change** (`enter`/`exit`) | "Something appeared/disappeared" |
 | 5 | **Route change** (layout-level) | "Going to a new place" |
 
-This is an implementation order, not a "pick one" list. Most apps need #1–#3 at minimum. Only skip a pattern if the app has no use case for it. Only one tree level should animate at a time — adding a layout-level transition on top of per-page animations produces competing double-animation.
+This is an implementation order, not a "pick one" list. Implement every pattern that fits the app. Only skip a pattern if the app has no use case for it.
 
 ### Choosing Animation Style
 
@@ -36,13 +36,14 @@ This is an implementation order, not a "pick one" list. Most apps need #1–#3 a
 | Suspense reveal | `enter`/`exit` string props | Content arriving |
 | Revalidation / background refresh | `default="none"` | Silent — no animation needed |
 
-Reserve directional slides for hierarchical navigation only. Directional slides on sibling links falsely imply spatial depth.
+Reserve directional slides for hierarchical navigation (list → detail) and ordered sequences (prev/next photo, carousel, paginated results). For ordered sequences, the direction communicates position: "next" slides from right, "previous" from left. Lateral/unordered navigation (tab-to-tab) should not use directional slides — it falsely implies spatial depth.
 
 ---
 
 ## Availability
 
-- Requires `react@canary` or `react@experimental` — **not** in stable React (including 19.x). Verify with `npm ls react`.
+- **Next.js:** Do **not** install `react@canary` — the App Router already bundles React canary internally. `ViewTransition` works out of the box. `npm ls react` may show a stable-looking version; this is expected.
+- **Without Next.js:** Install `react@canary react-dom@canary` (`ViewTransition` is not in stable React).
 - Browser support: Chromium 111+, Firefox 144+, Safari 18.2+. Graceful degradation on unsupported browsers.
 
 ---
@@ -123,28 +124,60 @@ See `references/css-recipes.md` for ready-to-use animation recipes.
 
 ## Transition Types
 
-Tag transitions with `addTransitionType` so VTs can pick different animations based on context:
+Tag transitions with `addTransitionType` so VTs can pick different animations based on context. Call it multiple times to stack types — different VTs in the tree react to different types:
 
 ```jsx
 startTransition(() => {
   addTransitionType('nav-forward');
+  addTransitionType('select-item');
   router.push('/detail/1');
 });
 ```
 
-Pass an object to map types to CSS classes:
+Pass an object to map types to CSS classes. Works on `enter`, `exit`, **and** `share`:
 
 ```jsx
 <ViewTransition
   enter={{ 'nav-forward': 'slide-from-right', 'nav-back': 'slide-from-left', default: 'none' }}
   exit={{ 'nav-forward': 'slide-to-left', 'nav-back': 'slide-to-right', default: 'none' }}
+  share={{ 'nav-forward': 'morph-forward', 'nav-back': 'morph-back', default: 'morph' }}
   default="none"
 >
   <Page />
 </ViewTransition>
 ```
 
+`enter` and `exit` don't have to be symmetric. For example, fade in but slide out directionally:
+
+```jsx
+<ViewTransition
+  enter={{ 'nav-forward': 'fade-in', 'nav-back': 'fade-in', default: 'none' }}
+  exit={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+  default="none"
+>
+```
+
 **TypeScript:** `ViewTransitionClassPerType` requires a `default` key in the object.
+
+For apps with multiple pages, extract the type-keyed VT into a reusable wrapper:
+
+```jsx
+export function DirectionalTransition({ children }: { children: React.ReactNode }) {
+  return (
+    <ViewTransition
+      enter={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+      exit={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+      default="none"
+    >
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+### `router.back()` and Browser Back Button
+
+`router.back()` and the browser's back/forward buttons do **not** trigger view transitions (`popstate` is synchronous, incompatible with `startViewTransition`). Use `router.push()` with an explicit URL instead.
 
 ### Types and Suspense
 
@@ -167,7 +200,7 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 </ViewTransition>
 ```
 
-- Only one VT with a given `name` can be mounted at a time — use unique names (`photo-${id}`).
+- Only one VT with a given `name` can be mounted at a time — use unique names (`photo-${id}`). Watch for reusable components: if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Either make the name conditional (via a prop) or move the named VT out of the shared component into the specific consumer.
 - `share` takes precedence over `enter`/`exit`. Think through each navigation path: when no matching pair forms (e.g., the target page doesn't have the same name), `enter`/`exit` fires instead. Consider whether the element needs a fallback animation for those paths.
 - Never use a fade-out exit on pages with shared morphs — use a directional slide instead.
 
@@ -192,6 +225,25 @@ Same `name` on two VTs — one unmounting, one mounting — creates a shared ele
 ```
 
 Trigger inside `startTransition`. Avoid wrapper `<div>`s between list and VT.
+
+### Composing Shared Elements with List Identity
+
+Shared elements and list identity are independent concerns — don't confuse one for the other. When a list item contains a shared element (e.g., an image that morphs into a detail view), use two nested `<ViewTransition>` boundaries:
+
+```jsx
+{items.map(item => (
+  <ViewTransition key={item.id}>                                      {/* list identity */}
+    <Link href={`/items/${item.id}`}>
+      <ViewTransition name={`item-image-${item.id}`} share="morph">   {/* shared element */}
+        <Image src={item.image} />
+      </ViewTransition>
+      <p>{item.name}</p>
+    </Link>
+  </ViewTransition>
+))}
+```
+
+The outer VT handles list reorder/enter animations. The inner VT handles the cross-route shared element morph. Missing either layer means that animation silently doesn't happen.
 
 ### Force Re-Enter with `key`
 
@@ -238,25 +290,15 @@ Without it, every VT fires the browser cross-fade on **every** transition — Su
 
 They coexist because they fire at different moments. `default="none"` on both prevents cross-interference. Always pair `enter` with `exit`. Place directional VTs in page components, not layouts.
 
+### Nested VT Limitation
+
+When a parent VT exits, nested VTs inside it do **not** fire their own enter/exit — only the outermost VT animates. Per-item staggered animations during page navigation are not possible today. See [react#36135](https://github.com/facebook/react/pull/36135) for an experimental opt-in fix.
+
 ---
 
 ## Next.js Integration
 
-`<ViewTransition>` works out of the box for `startTransition`/`Suspense` updates. To also animate `<Link>` navigations:
-
-```js
-// next.config.js
-experimental: { viewTransition: true }
-```
-
-This wraps every `<Link>` navigation in `document.startViewTransition`. Use `default="none"` to prevent competing animations.
-
-`next/link` supports a native `transitionTypes` prop:
-```tsx
-<Link href="/products/1" transitionTypes={['nav-forward']}>View</Link>
-```
-
-For App Router patterns and Server Component details, see `references/nextjs.md`.
+For Next.js setup (`experimental.viewTransition` flag, `transitionTypes` prop on `next/link`, App Router patterns, Server Components), see `references/nextjs.md`.
 
 ---
 
@@ -272,3 +314,7 @@ Always add the reduced motion CSS from `references/css-recipes.md` to your globa
 - **`references/patterns.md`** — Patterns, animation timing, events API, troubleshooting.
 - **`references/css-recipes.md`** — Ready-to-use CSS animation recipes.
 - **`references/nextjs.md`** — Next.js App Router patterns and Server Component details.
+
+## Full Compiled Document
+
+For the complete guide with all reference files expanded: `AGENTS.md`

--- a/plugins/react-skills/skills/react-view-transitions/references/css-recipes.md
+++ b/plugins/react-skills/skills/react-view-transitions/references/css-recipes.md
@@ -136,14 +136,6 @@ Usage:
 }
 ```
 
-Triggering programmatically:
-```jsx
-startTransition(() => {
-  addTransitionType('nav-forward');
-  router.push('/next-page');
-});
-```
-
 ---
 
 ## Shared Element Morph
@@ -163,6 +155,28 @@ startTransition(() => {
 ```
 
 Usage: `<ViewTransition name={`product-${id}`} share="morph" />`
+
+**Note:** Shared element transitions take raster snapshots. For text with significant size differences (e.g., `<h3>` → `<h1>`), the old snapshot gets scaled up, producing a visible ghost artifact. Use `text-morph` for text shared elements.
+
+## Text Morph
+
+Avoids raster scaling artifacts on text by hiding the old snapshot and showing the new text at full resolution:
+
+```css
+::view-transition-group(.text-morph) {
+  animation-duration: var(--duration-move);
+}
+::view-transition-old(.text-morph) {
+  display: none;
+}
+::view-transition-new(.text-morph) {
+  animation: none;
+  object-fit: none;
+  object-position: left top;
+}
+```
+
+Usage: `<ViewTransition name={`title-${id}`} share="text-morph" />`
 
 ---
 

--- a/plugins/react-skills/skills/react-view-transitions/references/implementation.md
+++ b/plugins/react-skills/skills/react-view-transitions/references/implementation.md
@@ -20,7 +20,7 @@ Then classify every navigation and produce a navigation map:
 |-----------------|----------------------|--------------|-----------------------|
 | /               | /detail/[id]         | forward      | directional slide     |
 | /detail/[id]    | /                    | back         | directional slide     |
-| /detail/[id]    | /detail/[other]      | lateral      | key+share crossfade   |
+| /detail/[id]    | /detail/[other]      | sequential   | directional slide (ordered prev/next) or key+share crossfade |
 | /tab/[a]        | /tab/[b]             | lateral      | key+share crossfade   |
 | (Suspense)      | (content loads)      | —            | slide-up reveal       |
 ```
@@ -41,16 +41,7 @@ For every persistent element identified in Step 1, add a `viewTransitionName` st
 <header style={{ viewTransitionName: "site-header" }}>...</header>
 ```
 
-Then add CSS to prevent the element from animating during page transitions:
-
-```css
-::view-transition-group(site-header) {
-  animation: none;
-  z-index: 100;
-}
-```
-
-If the element uses `backdrop-blur` or `backdrop-filter`, use the backdrop-blur workaround from `css-recipes.md` instead (hide old snapshot, disable animation on new).
+Then add the persistent element isolation CSS from `css-recipes.md` (prevents the element from animating during page transitions). If the element uses `backdrop-blur` or `backdrop-filter`, use the backdrop-blur workaround from `css-recipes.md` instead.
 
 If a Suspense fallback mirrors a persistent control (e.g., a skeleton search input), give both the real control and the skeleton the same `viewTransitionName` so they morph in place.
 
@@ -87,11 +78,29 @@ Then wrap each **page component** (not layout) in a type-keyed `<ViewTransition>
 
 The `nav-forward` and `nav-back` CSS classes from `css-recipes.md` produce horizontal slides. For simpler apps where directional motion isn't needed, a bare `<ViewTransition default="none">` wrapper with `enter="fade-in"` / `exit="fade-out"` works too.
 
+Extract this into a reusable component so every page doesn't repeat the verbose type map:
+
+```jsx
+export function DirectionalTransition({ children }: { children: React.ReactNode }) {
+  return (
+    <ViewTransition
+      enter={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+      exit={{ 'nav-forward': 'nav-forward', 'nav-back': 'nav-back', default: 'none' }}
+      default="none"
+    >
+      {children}
+    </ViewTransition>
+  );
+}
+```
+
+This also becomes the single place to adjust if you add new transition types later.
+
 **Rules:**
 - Always pair `enter` with `exit` — without an exit animation, the old page disappears instantly while the new one animates in.
 - Always include `default: "none"` in type map objects and `default="none"` on the component — otherwise it fires on every transition.
 - Place the directional `<ViewTransition>` in each page component, not in a layout. Layouts persist across navigations and never trigger enter/exit.
-- Only use directional slides for hierarchical navigation. Lateral/sibling navigation (tab-to-tab) should use a bare `<ViewTransition>` (cross-fade) or `default="none"`.
+- Only use directional slides for hierarchical navigation or ordered sequences (prev/next). Lateral/sibling navigation (tab-to-tab) should use a bare `<ViewTransition>` (cross-fade) or `default="none"`.
 
 ## Step 5: Add Suspense Reveals
 
@@ -135,24 +144,11 @@ For every shared visual element identified in Step 1, add matching named `<ViewT
 
 The `share="morph"` class uses the morph recipe from `css-recipes.md` (controlled duration + motion blur). For a simpler cross-fade, use `share="auto"` (browser default).
 
-For list items that should animate individually on enter/exit, add a per-item `<ViewTransition key={id}>` wrapper:
-
-```jsx
-{items.map(item => (
-  <ViewTransition key={item.id}>
-    <Link href={`/detail/${item.id}`}>
-      <ViewTransition name={`item-${item.id}`} share="morph" default="none">
-        <Image src={item.image} ... />
-      </ViewTransition>
-    </Link>
-  </ViewTransition>
-))}
-```
+When list items contain shared elements, compose both patterns with two nested `<ViewTransition>` layers — see "Composing Shared Elements with List Identity" in `SKILL.md`.
 
 **Rules:**
 - Names must be globally unique — use prefixes like `photo-${id}`.
 - Add `default="none"` on list-side shared elements to prevent per-item cross-fades on filter/search updates.
-- Never use a fade-out exit on pages with shared element morphs — the page dissolving conflicts with the morph, causing a flash. Use a directional slide exit instead.
 
 ## Step 7: Verify Each Navigation Path
 
@@ -178,6 +174,8 @@ If any path produces no animation or competing animations, revisit the relevant 
 - **Type maps on Suspense reveals** — Suspense resolves fire as separate transitions with no type. Type-keyed props won't match — use simple string props instead.
 - **Raw `viewTransitionName` CSS to trigger animations** — React only calls `document.startViewTransition` when `<ViewTransition>` components are in the tree. A bare `viewTransitionName` style is for isolating elements from a parent's snapshot, not for triggering animations.
 - **`update` trigger for same-route navigations** — nested VTs inside the content steal the mutation from the parent, so `update` never fires on the outer VT. Use `key` + `name` + `share` instead.
+- **Named VT in a reusable component** — if a component with a named VT is rendered in both a modal/popover *and* a page, both mount simultaneously and break the morph. Make the name conditional or move it to the specific consumer.
+- **`router.back()` for back navigation** — `router.back()` triggers synchronous `popstate`, incompatible with view transitions. Use `router.push()` with an explicit URL.
 
 ---
 

--- a/plugins/react-skills/skills/react-view-transitions/references/nextjs.md
+++ b/plugins/react-skills/skills/react-view-transitions/references/nextjs.md
@@ -14,7 +14,7 @@ module.exports = nextConfig;
 
 This wraps every `<Link>` navigation in `document.startViewTransition`. Any VT with `default="auto"` fires on **every** link click — use `default="none"` to prevent competing animations.
 
-Requires `react@canary`: `npm install react@canary react-dom@canary`
+Do **not** install `react@canary` — see SKILL.md "Availability" for details.
 
 ---
 
@@ -24,14 +24,7 @@ When following `implementation.md`, apply these additions:
 
 **After Step 2:** Enable the experimental flag above.
 
-**Step 4:** Use `transitionTypes` on `<Link>` instead of manual `addTransitionType`:
-
-```tsx
-<Link href="/photo/1" transitionTypes={["nav-forward"]}>View</Link>
-<Link href="/" transitionTypes={["nav-back"]}>Back</Link>
-```
-
-Reserve `startTransition` + `addTransitionType` for programmatic navigation (buttons, forms).
+**Step 4:** Use `transitionTypes` on `<Link>` — see "The `transitionTypes` Prop" section below for usage and availability.
 
 **After Step 6:** For same-route dynamic segments (e.g., `/collection/[slug]`), use the `key` + `name` + `share` pattern — see Same-Route Dynamic Segment Transitions below.
 
@@ -39,28 +32,25 @@ Reserve `startTransition` + `addTransitionType` for programmatic navigation (but
 
 ## Layout-Level ViewTransition
 
-**Do NOT add a layout-level VT wrapping `{children}` if pages have their own VTs.** Both fire simultaneously, producing competing animations.
+**Do NOT add a layout-level VT wrapping `{children}` if pages have their own VTs.** Nested VTs never fire enter/exit when inside a parent VT — page-level enter/exit will silently not work. Remove the layout VT entirely.
 
-A bare `<ViewTransition>` in layout works only if pages have **no** VTs of their own. Once any page adds a VT, use `default="none"` on the layout VT or remove it.
+A bare `<ViewTransition>` in layout works only if pages have **no** VTs of their own.
 
 **Layouts persist across navigations** — `enter`/`exit` only fire on initial mount, not on route changes. Don't use type-keyed maps in layouts.
-
-```tsx
-// Prevents layout from interfering with per-page VTs
-<ViewTransition default="none">{children}</ViewTransition>
-```
 
 ---
 
 ## The `transitionTypes` Prop on `next/link`
 
-Native prop — no wrapper component needed, works in Server Components:
+No wrapper component needed, works in Server Components:
 
 ```tsx
 <Link href="/products/1" transitionTypes={['transition-to-detail']}>View Product</Link>
 ```
 
 Replaces the manual pattern of `onNavigate` + `startTransition` + `addTransitionType` + `router.push()`. Reserve manual `startTransition` for non-link interactions (buttons, forms).
+
+**Availability:** `transitionTypes` requires `experimental.viewTransition: true` and is available in Next.js 15+ canary builds and Next.js 16+. If unavailable, use `startTransition` + `addTransitionType` + `router.push()` (see Programmatic Navigation below). To check: `grep -r "transitionTypes" node_modules/next/dist/` — if no results, fall back to programmatic navigation.
 
 ---
 
@@ -83,23 +73,31 @@ function handleNavigate(href: string) {
 
 ---
 
-## Directional Navigation
+## Server-Side Filtering with `router.replace`
 
-Place type-keyed VTs in **page components** (not layouts):
+For search/sort/filter that re-renders on the server (via URL params), use `startTransition` + `router.replace`. VTs activate because the state update is inside `startTransition`:
 
 ```tsx
-<ViewTransition
-  default="none"
-  enter={{ 'nav-forward': 'slide-from-right', 'nav-back': 'slide-from-left', default: 'none' }}
-  exit={{ 'nav-forward': 'slide-to-left', 'nav-back': 'slide-to-right', default: 'none' }}
->
-  <PageContent />
-</ViewTransition>
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition } from 'react';
+
+function handleSort(sort: string) {
+  const router = useRouter();
+  startTransition(() => {
+    router.replace(`?sort=${sort}`);
+  });
+}
 ```
 
-### Two-Layer Pattern
+List items wrapped in `<ViewTransition key={item.id}>` will animate reorder. This is the server-component alternative to the client-side `useDeferredValue` pattern in `patterns.md`.
 
-Directional slides + Suspense reveals coexist because they fire at different moments:
+---
+
+## Two-Layer Pattern (Directional + Suspense)
+
+Directional slides + Suspense reveals coexist because they fire at different moments. Place the directional VT in the **page component** (not layout):
 
 ```tsx
 <ViewTransition
@@ -114,6 +112,22 @@ Directional slides + Suspense reveals coexist because they fire at different mom
   </div>
 </ViewTransition>
 ```
+
+---
+
+## `loading.tsx` as Suspense Boundary
+
+Next.js `loading.tsx` is an implicit `<Suspense>` boundary. Wrap the skeleton in `<ViewTransition exit="...">` in `loading.tsx`, and the content in `<ViewTransition enter="..." default="none">` in the page:
+
+```tsx
+// loading.tsx
+<ViewTransition exit="slide-down"><PhotoGridSkeleton /></ViewTransition>
+
+// page.tsx
+<ViewTransition enter="slide-up" default="none"><PhotoGrid photos={photos} /></ViewTransition>
+```
+
+Same rules as explicit `<Suspense>`: use simple string props (not type maps) since Suspense reveals fire without transition types.
 
 ---
 
@@ -152,18 +166,6 @@ When navigating between dynamic segments of the same route (e.g., `/collection/[
 - `key={slug}` forces unmount/remount on change
 - `name` + `share="auto"` creates a shared element crossfade
 - VT inside `<Suspense>` (without keying Suspense) keeps old content visible during loading
-
----
-
-## Suspense and Loading States
-
-```tsx
-<Suspense fallback={<ViewTransition exit="slide-down"><Skeleton /></ViewTransition>}>
-  <ViewTransition default="none" enter="slide-up"><PageContent /></ViewTransition>
-</Suspense>
-```
-
-Don't combine with a layout-level VT using `default="auto"`.
 
 ---
 

--- a/plugins/react-skills/skills/react-view-transitions/references/patterns.md
+++ b/plugins/react-skills/skills/react-view-transitions/references/patterns.md
@@ -122,14 +122,7 @@ Persistent elements (headers, navbars, sidebars) get captured in the page's tran
 <nav style={{ viewTransitionName: "persistent-nav" }}>{/* ... */}</nav>
 ```
 
-```css
-::view-transition-group(persistent-nav) {
-  animation: none;
-  z-index: 100;
-}
-```
-
-For `backdrop-blur`/`backdrop-filter`, see Backdrop-Blur Workaround in `css-recipes.md`.
+Then add the persistent element isolation CSS from `css-recipes.md`. For `backdrop-blur`/`backdrop-filter`, use the backdrop-blur workaround from `css-recipes.md`.
 
 ### Floating Elements
 
@@ -139,7 +132,7 @@ Give popovers/tooltips their own `viewTransitionName`:
 <SelectPopover style={{ viewTransitionName: 'popover' }}>{options}</SelectPopover>
 ```
 
-Global fix: `::view-transition-group(*) { z-index: 100; }`
+Global fix: see persistent element isolation in `css-recipes.md`.
 
 ## Shared Controls Between Skeleton and Content
 
@@ -246,13 +239,13 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **"Two ViewTransition components with the same name":** Names must be globally unique. Use IDs: `name={`hero-${item.id}`}`.
 
-**Back button skips animation:** Legacy `popstate` conflicts with view transitions. Use Navigation API.
+**`router.back()` and browser back/forward skip animation:** Use `router.push()` with an explicit URL instead. See SKILL.md "router.back() and Browser Back Button."
 
 **`flushSync` skips animations:** Use `startTransition` instead.
 
 **Only updates animate (no enter/exit):** Without `<Suspense>`, React treats swaps as updates. Conditionally render the VT itself, or wrap in `<Suspense>`.
 
-**Competing double animations:** Multiple VTs at different tree levels fire simultaneously. Use `default="none"` on layout-level VTs.
+**Layout VT prevents page VTs from animating:** Nested VTs never fire enter/exit inside a parent VT. If your layout has a VT wrapping `{children}`, page-level enter/exit will silently not work. Remove the layout VT.
 
 **List reorder not animating with `useOptimistic`:** Optimistic values resolve before snapshot. Use committed state for list order.
 
@@ -260,7 +253,7 @@ The `types` array (second argument) lets you vary animation based on transition 
 
 **Hash fragments cause scroll jumps:** Navigate without hash; scroll programmatically after navigation.
 
-**Backdrop-blur flickers:** Use `::view-transition-old(name) { display: none }` + `::view-transition-new(name) { animation: none }`.
+**Backdrop-blur flickers:** Use the backdrop-blur workaround from `css-recipes.md`.
 
 **`border-radius` lost during transitions:** Apply `border-radius` directly to the captured element.
 

--- a/plugins/react-skills/skills/web-design-guidelines/references/web-interface-guidelines.md
+++ b/plugins/react-skills/skills/web-design-guidelines/references/web-interface-guidelines.md
@@ -117,6 +117,7 @@ Read files, check against rules below. Output concise but comprehensive—sacrif
 - Dates/times: use `Intl.DateTimeFormat` not hardcoded formats
 - Numbers/currency: use `Intl.NumberFormat` not hardcoded formats
 - Detect language via `Accept-Language` / `navigator.languages`, not IP
+- Brand names, code tokens, identifiers: wrap with `translate="no"` to prevent garbled auto-translation
 
 ### Hydration Safety
 


### PR DESCRIPTION
The react sync script picked up upstream additions: 2 new rule files (`advanced-effect-event-deps`, `bundle-analyzable-paths`), the `SKILL.md` index update that references them, edits to 4 `react-view-transitions` reference files, and the curled `web-interface-guidelines.md`.

Notable: rule count in `react-best-practices/SKILL.md` bumped from 68 to 70, and `bundle-analyzable-paths` is now indexed in the bundle-size section so Claude can discover and apply it. Without the index update, the new rule file would ship orphaned.