### PR TITLE
Silence mongodb sync warnings on two skills

### DIFF
--- a/.github/scripts/sync-mongodb-skills.sh
+++ b/.github/scripts/sync-mongodb-skills.sh
@@ -19,10 +19,18 @@ SKILLS=(
   mongodb-search-and-ai
 )
 
+# Skills with a references/ dir upstream.
+sync_dir "$SRC/atlas-stream-processing" "plugins/mongodb-skills/skills/atlas-stream-processing" "SKILL.md" "references/"
+sync_dir "$SRC/mongodb-connection" "plugins/mongodb-skills/skills/mongodb-connection" "SKILL.md" "references/"
+sync_dir "$SRC/mongodb-query-optimizer" "plugins/mongodb-skills/skills/mongodb-query-optimizer" "SKILL.md" "references/"
+sync_dir "$SRC/mongodb-schema-design" "plugins/mongodb-skills/skills/mongodb-schema-design" "SKILL.md" "references/"
+sync_dir "$SRC/mongodb-search-and-ai" "plugins/mongodb-skills/skills/mongodb-search-and-ai" "SKILL.md" "references/"
+
+# Skills without references/ upstream.
+sync_dir "$SRC/mongodb-mcp-setup" "plugins/mongodb-skills/skills/mongodb-mcp-setup" "SKILL.md"
+sync_dir "$SRC/mongodb-natural-language-querying" "plugins/mongodb-skills/skills/mongodb-natural-language-querying" "SKILL.md"
+
 for skill in "${SKILLS[@]}"; do
-  sync_dir "$SRC/$skill" \
-    "plugins/mongodb-skills/skills/$skill" \
-    "SKILL.md" "references/"
   ensure_license "plugins/mongodb-skills/skills/$skill" Apache-2.0
   create_zip "plugins/mongodb-skills/skills/$skill"
 done


### PR DESCRIPTION
The mongodb sync was logging "WARNING: pattern not found" twice on every run because the loop unconditionally passed `references/` to `sync_dir` even for `mongodb-mcp-setup` and `mongodb-natural-language-querying`, which ship without that directory upstream. The script now splits the seven skills into two grouped sections, matching the shape used by `sync-stripe-skills.sh`. Each `sync_dir` call now passes only the patterns its skill actually has, so the run is warning-free.

Verified by running the script twice from a clean main: zero warnings, all seven skills synced, second run is idempotent.