### PR TITLE
Fix telemetry hook crash on Python 3.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "claude-telemetry-hooks",
       "source": "./plugins/claude-telemetry-hooks",
       "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "claude-telemetry-hooks",
       "source": "./plugins/claude-telemetry-hooks",
       "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
   "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
   "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
   "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/gemini-extension.json
+++ b/plugins/claude-telemetry-hooks/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard."
 }

--- a/plugins/claude-telemetry-hooks/hooks/scripts/user_prompt_reject_feedback.py
+++ b/plugins/claude-telemetry-hooks/hooks/scripts/user_prompt_reject_feedback.py
@@ -8,6 +8,8 @@ prompt into a reject category, and posts a `reject_feedback` log event so the da
 panel can show *why* tools get rejected, not just that they do.
 """
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os


### PR DESCRIPTION
The reject-feedback hook in `claude-telemetry-hooks` printed a traceback on every prompt on machines running macOS default Python (3.9), because the script uses `dict | None` annotation syntax that requires Python 3.10+. Adding `from __future__ import annotations` defers annotation evaluation so the script parses cleanly on 3.9 too.

Bumps the plugin from 1.0.1 to 1.0.2 so `claude plugin update` actually pulls the fix on installed machines.

```bash
claude plugin marketplace update claude-settings
claude plugin update claude-telemetry-hooks@claude-settings
```