### PR TITLE
Lint plugin hook scripts with ruff

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -143,6 +143,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'F=$(jq -r \".tool_input.file_path // empty\"); case \"$F\" in *plugins/*/hooks/scripts/*.py|*.github/scripts/*.py) if command -v ruff >/dev/null 2>&1; then ruff check \"$F\" 2>&1 || true; elif command -v uvx >/dev/null 2>&1; then uvx ruff check \"$F\" 2>&1 || true; fi ;; esac'"
+          }
+        ]
+      }
     ]
   },
   "outputStyle": "Explanatory",

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,27 @@
+name: Ruff
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "plugins/**/hooks/scripts/*.py"
+      - ".github/scripts/*.py"
+      - "pyproject.toml"
+      - ".github/workflows/ruff.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "plugins/**/hooks/scripts/*.py"
+      - ".github/scripts/*.py"
+      - "pyproject.toml"
+      - ".github/workflows/ruff.yml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v4
+        with:
+          src: "plugins .github/scripts"
+          args: "check"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v3
         with:
-          src: "plugins .github/scripts"
+          src: "plugins/*/hooks/scripts .github/scripts"
           args: "check"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,10 @@
 target-version = "py39"
+extend-exclude = [
+    "plugins/*/skills",
+    "plugins/*/agents",
+    "plugins/*/commands",
+    "plugins/*/references",
+]
 
 [lint]
 select = ["FA", "UP", "F"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+target-version = "py39"
+
+[lint]
+select = ["FA", "UP", "F"]


### PR DESCRIPTION
Catch Python compatibility issues in plugin hook scripts before they hit users (e.g. PR #188 where `dict | None` crashed every prompt on macOS default Python 3.9).

- `ruff.toml` pins `target-version = py39` and enables `FA`, `UP`, and `F` rules
- `.github/workflows/ruff.yml` runs ruff on every push/PR that touches `plugins/*/hooks/scripts/*.py` or `.github/scripts/*.py`
- Repo `.claude/settings.json` adds a PostToolUse hook that runs `ruff check` after Claude edits a hook script (uses local `ruff` if installed, falls back to `uvx ruff`)

Scope is intentionally narrow: hook scripts run on every Claude event so they need py39 floor compatibility, while vendored skill scripts are out of scope.