### PR TITLE
Drop 1m context suffix from haiku slot model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
     "DISABLE_ERROR_REPORTING": "1",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7[1m]",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-4-7",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6[1m]",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
     "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-7",
     "MAX_MCP_OUTPUT_TOKENS": "40000",
     "CLAUDE_CODE_EFFORT_LEVEL": "xhigh",


### PR DESCRIPTION
Switch the haiku slot in `.claude/settings.json` from `claude-sonnet-4-6[1m]` to `claude-sonnet-4-6` so it uses the standard context window instead of the 1M-token variant.

`"ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6"`