### PR TITLE
Add overleaf-skills plugin for applying Overleaf review comments locally

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -303,6 +303,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "search"
+    },
+    {
+      "name": "overleaf-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/overleaf-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "research"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -387,6 +387,21 @@
       "keywords": ["web-search", "tavily", "search", "content-extraction", "mcp"],
       "category": "search",
       "tags": ["search", "mcp", "integration"]
+    },
+    {
+      "name": "overleaf-skills",
+      "source": "./plugins/overleaf-skills",
+      "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["overleaf", "latex", "review", "comments", "academic", "writing"],
+      "category": "research",
+      "tags": ["research", "academic", "latex"]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -176,6 +176,13 @@
       "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
       "version": "2.0.2",
       "license": "Apache-2.0"
+    },
+    {
+      "name": "overleaf-skills",
+      "source": "./plugins/overleaf-skills",
+      "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     }
   ]
 }

--- a/plugins/overleaf-skills/.claude-plugin/plugin.json
+++ b/plugins/overleaf-skills/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "overleaf-skills",
+  "version": "1.0.0",
+  "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
+  "license": "Apache-2.0"
+}

--- a/plugins/overleaf-skills/.codex-plugin/plugin.json
+++ b/plugins/overleaf-skills/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "overleaf-skills",
+  "version": "1.0.0",
+  "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
+  "license": "Apache-2.0"
+}

--- a/plugins/overleaf-skills/.cursor-plugin/plugin.json
+++ b/plugins/overleaf-skills/.cursor-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "overleaf-skills",
+  "version": "1.0.0",
+  "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
+  "license": "Apache-2.0"
+}

--- a/plugins/overleaf-skills/gemini-extension.json
+++ b/plugins/overleaf-skills/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "overleaf-skills",
+  "version": "1.0.0",
+  "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo."
+}

--- a/plugins/overleaf-skills/scripts/overleaf_reviews.py
+++ b/plugins/overleaf-skills/scripts/overleaf_reviews.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Fetch Overleaf review comments for a project and map them to local file:line.
+
+Usage:
+    python3 overleaf_reviews.py <project_id> [--repo .] [--json] [--unresolved-only]
+    python3 overleaf_reviews.py --check-auth
+    python3 overleaf_reviews.py --list-projects
+
+Auth: reads the Overleaf session cookie from (in order):
+    1. OVERLEAF_COOKIE env var
+    2. ~/.claude/overleaf-skills/cookie file (chmod 600, written by setup skill)
+
+Cookie name on current Overleaf is `overleaf_session2` (underscore). The legacy
+`overleaf.session2` (dot) name no longer authenticates. Sessions slide ~5 days
+idle, refresh on use.
+
+Each comment is anchored to its highlighted snippet (`op.c` field of the range);
+the script locates that snippet in *.tex files under the repo root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+OVERLEAF_BASE = "https://www.overleaf.com"
+COOKIE_FILE = Path.home() / ".claude" / "overleaf-skills" / "cookie"
+CHROME_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+)
+
+REFRESH_HINT = (
+    "\nOverleaf session missing or expired. To refresh:\n"
+    "  Ask Claude to 'set up overleaf' (triggers the overleaf-skills setup skill),\n"
+    "  or manually:\n"
+    "    1. Open https://www.overleaf.com in Chrome (logged in).\n"
+    "    2. DevTools -> Application -> Cookies -> www.overleaf.com.\n"
+    "    3. Find row with Name = 'overleaf_session2' (UNDERSCORE, not dot).\n"
+    "    4. Copy the Value. Save to ~/.claude/overleaf-skills/cookie as:\n"
+    "         overleaf_session2=<paste value>\n"
+    "    5. chmod 600 ~/.claude/overleaf-skills/cookie\n"
+    "Sessions slide ~5 days idle.\n"
+)
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Block redirects so 302 -> /login surfaces as 302, not silent HTML."""
+
+    def http_error_302(self, req, fp, code, msg, headers):
+        return fp
+
+    http_error_301 = http_error_303 = http_error_307 = http_error_302
+
+
+def load_cookie() -> str:
+    """Return the normalized `overleaf_session2=<value>` cookie pair, or exit with refresh hint."""
+    raw = os.environ.get("OVERLEAF_COOKIE")
+    if not raw and COOKIE_FILE.exists():
+        raw = COOKIE_FILE.read_text().strip()
+    if not raw:
+        sys.exit(REFRESH_HINT)
+    raw = raw.strip()
+    if not raw.startswith("overleaf_session2="):
+        if raw.startswith("overleaf.session2="):
+            sys.exit(
+                "Cookie name `overleaf.session2` (dot) no longer exists on Overleaf.\n"
+                "Re-grab the row named `overleaf_session2` (underscore)." + REFRESH_HINT
+            )
+        raw = "overleaf_session2=" + raw
+    return raw
+
+
+def _opener():
+    """Build a urllib opener that does not follow redirects."""
+    return urllib.request.build_opener(_NoRedirect)
+
+
+def _request(path: str, cookie: str):
+    """Issue a GET against Overleaf with the session cookie. Returns (status, content_type, body_bytes)."""
+    req = urllib.request.Request(
+        OVERLEAF_BASE + path,
+        headers={
+            "Cookie": cookie,
+            "Accept": "application/json",
+            "User-Agent": CHROME_UA,
+        },
+    )
+    try:
+        r = _opener().open(req)
+        return r.status, r.headers.get("content-type") or "", r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.headers.get("content-type") or "", e.read()
+
+
+def check_auth(cookie: str) -> tuple[bool, str]:
+    """Hit /user/personal_info and return (ok, email-or-error)."""
+    status, _, body = _request("/user/personal_info", cookie)
+    if status != 200:
+        return False, f"status={status}"
+    try:
+        data = json.loads(body)
+        return True, data.get("email", "<unknown>")
+    except json.JSONDecodeError:
+        return False, "non-json response"
+
+
+def list_projects(cookie: str) -> list[dict]:
+    """Return a sorted list of {_id, name, accessLevel} dicts."""
+    status, _, body = _request("/user/projects", cookie)
+    if status != 200:
+        sys.exit(REFRESH_HINT if status == 401 else f"/user/projects failed: status={status}")
+    data = json.loads(body)
+    projects = data.get("projects", []) if isinstance(data, dict) else []
+    return sorted(projects, key=lambda p: (p.get("name") or "").lower())
+
+
+def fetch_reviews(cookie: str, project_id: str) -> tuple[dict, list]:
+    """Fetch (threads_by_id, ranges_by_doc) for one project. Exit on 401."""
+    s1, _, b1 = _request(f"/project/{project_id}/threads", cookie)
+    s2, _, b2 = _request(f"/project/{project_id}/ranges", cookie)
+    if s1 == 401 or s2 == 401:
+        sys.exit(REFRESH_HINT)
+    if s1 != 200:
+        sys.exit(f"/threads failed: status={s1}")
+    if s2 != 200:
+        sys.exit(f"/ranges failed: status={s2}")
+    return json.loads(b1), json.loads(b2)
+
+
+def assemble(threads: dict, ranges: list) -> list[dict]:
+    """Flatten threads + ranges into one record per comment thread with messages and snippet."""
+    out = []
+    for doc in ranges:
+        for c in (doc.get("ranges") or {}).get("comments", []):
+            t = threads.get(c["id"], {})
+            out.append(
+                {
+                    "thread_id": c["id"],
+                    "doc_id": doc["id"],
+                    "snippet": c["op"]["c"],
+                    "offset": c["op"]["p"],
+                    "resolved": bool(t.get("resolved_at")),
+                    "messages": [
+                        {
+                            "user": ((m.get("user") or {}).get("first_name") or "").strip(),
+                            "ts": m.get("timestamp"),
+                            "content": m.get("content", ""),
+                        }
+                        for m in t.get("messages", [])
+                    ],
+                }
+            )
+    return out
+
+
+def find_snippet(repo: Path, snippet: str) -> tuple[str, int] | None:
+    """Locate `snippet` in any *.tex file under repo. Returns (relpath, 1-based line)."""
+    needle = snippet.split("\n", 1)[0].strip()
+    if not needle:
+        return None
+    for path in sorted(repo.rglob("*.tex")):
+        text = path.read_text(errors="replace")
+        idx = text.find(needle)
+        if idx == -1:
+            continue
+        return str(path.relative_to(repo)), text[:idx].count("\n") + 1
+    return None
+
+
+def _print_report(report: list[dict], repo: Path, project_id: str) -> None:
+    print(f"# {len(report)} comment thread(s) for project {project_id}\n")
+    for r in report:
+        loc = find_snippet(repo, r["snippet"])
+        loc_str = f"{loc[0]}:{loc[1]}" if loc else f"<unmapped doc_id={r['doc_id']}>"
+        status = " (resolved)" if r["resolved"] else ""
+        for m in r["messages"]:
+            print(f"{loc_str}{status}  [{m['user']}]  {m['content']}")
+        print()
+
+
+def main() -> None:
+    """Dispatch CLI subcommands: --check-auth, --list-projects, or fetch-by-project-id."""
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("project_id", nargs="?", help="24-char Overleaf project ID")
+    ap.add_argument("--repo", type=Path, default=Path.cwd())
+    ap.add_argument("--json", action="store_true", help="emit raw JSON instead of mapped report")
+    ap.add_argument("--unresolved-only", action="store_true", help="filter out resolved threads")
+    ap.add_argument("--check-auth", action="store_true", help="probe auth and exit")
+    ap.add_argument("--list-projects", action="store_true", help="list user projects and exit")
+    args = ap.parse_args()
+
+    cookie = load_cookie()
+
+    if args.check_auth:
+        ok, info = check_auth(cookie)
+        print(f"OK {info}" if ok else f"FAIL {info}")
+        sys.exit(0 if ok else 1)
+
+    if args.list_projects:
+        for p in list_projects(cookie):
+            print(f"{p.get('_id', ''):24}  {p.get('accessLevel', '?'):14}  {p.get('name', '')}")
+        return
+
+    if not args.project_id:
+        ap.error("project_id is required (or pass --check-auth / --list-projects)")
+    if not re.fullmatch(r"[0-9a-f]{24}", args.project_id):
+        ap.error(f"invalid project_id: must be 24 hex chars, got {args.project_id!r}")
+
+    threads, ranges = fetch_reviews(cookie, args.project_id)
+    report = assemble(threads, ranges)
+    if args.unresolved_only:
+        report = [r for r in report if not r["resolved"]]
+
+    if args.json:
+        # Annotate with mapped location so callers don't need to repeat find_snippet.
+        repo = args.repo.resolve()
+        for r in report:
+            loc = find_snippet(repo, r["snippet"])
+            r["file"], r["line"] = (loc[0], loc[1]) if loc else (None, None)
+        json.dump(report, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return
+
+    _print_report(report, args.repo.resolve(), args.project_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/overleaf-skills/skills/review-overleaf/SKILL.md
+++ b/plugins/overleaf-skills/skills/review-overleaf/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: review-overleaf
+description: This skill should be used when user asks to "fetch overleaf review comments", "address overleaf reviews", "apply overleaf comments", "review my overleaf paper", "sync overleaf feedback to local", "what comments are on my overleaf doc", or wants to act on Overleaf reviewer feedback in a local git-tracked LaTeX repo.
+---
+
+# Review Overleaf
+
+Pull unresolved review threads from an Overleaf project, locate each in the local repo, propose edits the user reviews, and apply them. Does not push back to Overleaf — the web UI is still the place to mark threads resolved after the user verifies the local change.
+
+## Step 1: Resolve project ID
+
+Accept any of:
+
+- Raw 24-char hex ID (`^[0-9a-f]{24}$`)
+- Full URL like `https://www.overleaf.com/project/<id>` — extract via regex
+- Project name in quotes — call:
+  ```bash
+  python3 ${CLAUDE_PLUGIN_ROOT}/scripts/overleaf_reviews.py --list-projects
+  ```
+  Each line is `<24-hex>  <accessLevel>  <name>`. Fuzzy-match the name. If multiple match, AskUserQuestion to disambiguate.
+
+If the user has not given a project ID at all, run `--list-projects` and show the user the table so they can pick one.
+
+## Step 2: Cookie precheck
+
+If `~/.claude/overleaf-skills/cookie` does not exist, tell the user to "set up overleaf" (which triggers the `setup` skill) and stop.
+
+If it exists but auth fails (the next script call returns a refresh hint), point at the same setup skill and stop.
+
+## Step 3: Access-level guard
+
+If the project ID came from name resolution, check the matched entry's `accessLevel`. If `readOnly`, warn:
+
+> Project is read-only. You can edit local files but cannot sync them back to Overleaf via the web UI; you would need to copy-paste manually. Continue?
+
+For `owner`, `readAndWrite`, or `review`, proceed silently.
+
+## Step 4: Fetch comments
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/overleaf_reviews.py --json --repo . < project-id > --unresolved-only
+```
+
+Parses to a JSON array. Each record has: `thread_id`, `doc_id`, `snippet`, `offset`, `resolved`, `messages` (list of `{user, ts, content}`), `file`, `line`. The `file` and `line` are null when the snippet did not match any local `*.tex`.
+
+## Step 5: Edit loop
+
+For each record where `file` is non-null:
+
+1. `Read` the file at `line` ± 5 lines for context.
+2. Summarize the comment thread in one sentence: who said what.
+3. Propose a concrete edit grounded in the comment text. If the comment is a question (e.g., "did you mean X?"), the edit should answer it in the prose; if it's a correction (e.g., "wrong notation"), the edit should make the correction.
+4. Apply via `Edit`. Do not batch — one comment, one edit, then move on.
+
+Skip records where `file` is null (snippet did not map). Collect them in an `<unmapped>` list.
+
+## Step 6: Wrap up
+
+After the loop:
+
+1. Run `git diff` and show the user the full set of changes.
+2. List the `<unmapped>` records (if any) with `doc_id` + snippet preview, so the user can hunt them manually.
+3. Suggest a commit message in the style: `address overleaf review: <one-line summary of the changes>`. Do NOT auto-commit. The user can run `/github-dev:commit-staged` or commit by hand.
+4. Remind the user to mark the addressed threads as resolved in the Overleaf web UI once they verify the local diff.
+
+## Non-goals
+
+- No re-upload to Overleaf (no write API used).
+- No thread resolution in Overleaf (web UI only).
+- No `.bib` edits unless a comment specifically targets a citation.
+- No multi-line snippets that span paragraph breaks — those land in `<unmapped>` for v1; the snippet matcher is line-anchored.
+
+## Pairs naturally with
+
+- `github-dev` — `/github-dev:commit-staged` after the edit loop, `/github-dev:create-pr` if the project is collaborative.

--- a/plugins/overleaf-skills/skills/setup/SKILL.md
+++ b/plugins/overleaf-skills/skills/setup/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: setup
+description: This skill should be used when user asks to "set up overleaf", "configure overleaf cookie", "overleaf auth failed", "overleaf 401", "overleaf session expired", "overleaf unauthorized", or needs to install or refresh their Overleaf session cookie for the overleaf-skills plugin.
+---
+
+# Overleaf Skills Setup
+
+Walk the user through pasting a fresh `overleaf_session2` cookie into `~/.claude/overleaf-skills/cookie`. Cookies slide ~5 days idle; users will hit this every few days.
+
+## Step 1: Status check
+
+Check if `~/.claude/overleaf-skills/cookie` already exists. If yes, run:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/overleaf_reviews.py --check-auth
+```
+
+- If `OK <email>`: tell user "Already configured, logged in as <email>". Ask via AskUserQuestion whether to refresh or keep.
+- If `FAIL`: tell user the stored cookie is expired and continue to Step 2.
+
+## Step 2: Show browser guide
+
+Tell the user to grab the cookie from their browser. Give all three branches; pick none for them:
+
+**Chrome / Edge / Brave / Arc:** `Cmd+Option+I` (mac) or `F12` → **Application** tab → **Storage → Cookies → https://www.overleaf.com** → row where Name = `overleaf_session2` → double-click Value cell → `Cmd+A` → `Cmd+C`.
+
+**Firefox:** `F12` → **Storage** tab (enable in DevTools settings if hidden) → **Cookies → https://www.overleaf.com** → click `overleaf_session2` row → right-click → **Copy Value**.
+
+**Safari:** Enable Develop menu (**Settings → Advanced → Show features for web developers**), then `Cmd+Option+I` → **Storage** → **Cookies → www.overleaf.com** → click `overleaf_session2` row → copy from right-hand detail pane.
+
+Add three warnings at the bottom:
+
+1. The row name is `overleaf_session2` (UNDERSCORE). A row named `overleaf.session2` (DOT) is a stale legacy cookie that will not authenticate.
+2. The cookie is `HttpOnly` — `document.cookie` in the JS console returns empty for it. The storage panel is the only path.
+3. The value should start with `s%3A` and be ~80+ chars. If it starts with `s%3Ac%3A1%3A`, you're logged out — log into overleaf.com and re-grab.
+
+## Step 3: Capture
+
+Use AskUserQuestion: "Do you have your `overleaf_session2` cookie value ready?" with options "Yes, paste it now" and "Skip for now". The user pastes via the "Other" free-text field.
+
+## Step 4: Validate
+
+Normalize the input: strip whitespace; if it does NOT start with `overleaf_session2=`, prepend it (accept bare value).
+
+Reject (re-prompt with reason):
+
+- Starts with `overleaf.session2=` → "Overleaf renamed this cookie to `overleaf_session2` (underscore). Re-grab the underscore row."
+- Value (after the `=`) starts with `s%3Ac%3A1%3A` → "That's an anonymous-visitor cookie. Log into overleaf.com first, then re-grab."
+- Value does not start with `s%3A` after the `=` → "Doesn't look like an Overleaf session cookie. Confirm you copied from the `overleaf_session2` row on www.overleaf.com."
+- Total length under 80 chars → "Cookie looks truncated. Re-copy with `Cmd+A` inside the Value cell."
+- Contains newlines or quotes → "Strip the surrounding quotes/newlines."
+
+## Step 5: Write
+
+```bash
+mkdir -p ~/.claude/overleaf-skills
+[ -f ~/.claude/overleaf-skills/cookie ] && cp ~/.claude/overleaf-skills/cookie ~/.claude/overleaf-skills/cookie.backup
+# Write the normalized value (one line, no trailing newline beyond what's natural)
+printf '%s\n' "<normalized-cookie>" > ~/.claude/overleaf-skills/cookie
+chmod 600 ~/.claude/overleaf-skills/cookie
+```
+
+## Step 6: Verify
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/overleaf_reviews.py --check-auth
+```
+
+- If `OK <email>`: report "Configured. Logged in as <email>." Done.
+- If `FAIL`: restore from `cookie.backup` if it exists (`mv ~/.claude/overleaf-skills/cookie.backup ~/.claude/overleaf-skills/cookie`), tell user the new cookie did not authenticate, loop back to Step 2.


### PR DESCRIPTION
Pulls reviewer comments from an Overleaf project and points to the matching `*.tex:line` in your local git repo, so you can apply edits in your editor instead of retyping each change from the web UI. Includes a `setup` skill that walks through capturing the `overleaf_session2` browser cookie and a `review-overleaf` skill that fetches threads, walks each edit with Read/Edit, then ends with `git diff` and a suggested commit message.

Trigger with phrases like `fetch overleaf review comments`, `address overleaf reviews`, or `apply overleaf comments`.