### PR TITLE
Raise skill listing budget so all plugin descriptions fit

### DIFF
--- a/.claude/settings-auto.json
+++ b/.claude/settings-auto.json
@@ -16,7 +16,8 @@
     "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": "1",
     "CLAUDE_CODE_NEW_INIT": "1",
     "CLAUDE_CODE_NO_FLICKER": "1",
-    "ENABLE_PROMPT_CACHING_1H": "1"
+    "ENABLE_PROMPT_CACHING_1H": "1",
+    "SLASH_COMMAND_TOOL_CHAR_BUDGET": "60000"
   },
   "attribution": {
     "commit": "",
@@ -225,5 +226,6 @@
   "alwaysThinkingEnabled": true,
   "cleanupPeriodDays": 9999,
   "showClearContextOnPlanAccept": false,
-  "autoUpdatesChannel": "latest"
+  "autoUpdatesChannel": "latest",
+  "skillListingBudgetFraction": 0.02
 }

--- a/.claude/settings-minimax.json
+++ b/.claude/settings-minimax.json
@@ -19,7 +19,8 @@
     "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "1",
     "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": "1",
     "CLAUDE_CODE_NEW_INIT": "1",
-    "CLAUDE_CODE_NO_FLICKER": "1"
+    "CLAUDE_CODE_NO_FLICKER": "1",
+    "SLASH_COMMAND_TOOL_CHAR_BUDGET": "60000"
   },
   "attribution": {
     "commit": "",
@@ -163,5 +164,6 @@
   "alwaysThinkingEnabled": true,
   "cleanupPeriodDays": 9999,
   "showClearContextOnPlanAccept": false,
-  "autoUpdatesChannel": "latest"
+  "autoUpdatesChannel": "latest",
+  "skillListingBudgetFraction": 0.02
 }

--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -18,7 +18,8 @@
     "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "1",
     "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": "1",
     "CLAUDE_CODE_NEW_INIT": "1",
-    "CLAUDE_CODE_NO_FLICKER": "1"
+    "CLAUDE_CODE_NO_FLICKER": "1",
+    "SLASH_COMMAND_TOOL_CHAR_BUDGET": "60000"
   },
   "attribution": {
     "commit": "",
@@ -162,5 +163,6 @@
   "alwaysThinkingEnabled": true,
   "cleanupPeriodDays": 9999,
   "showClearContextOnPlanAccept": false,
-  "autoUpdatesChannel": "latest"
+  "autoUpdatesChannel": "latest",
+  "skillListingBudgetFraction": 0.02
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,8 @@
     "CLAUDE_CODE_NEW_INIT": "1",
     "CLAUDE_CODE_NO_FLICKER": "1",
     "ENABLE_PROMPT_CACHING_1H": "1",
-    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000",
+    "SLASH_COMMAND_TOOL_CHAR_BUDGET": "60000"
   },
   "attribution": {
     "commit": "",
@@ -173,5 +174,6 @@
   "alwaysThinkingEnabled": true,
   "cleanupPeriodDays": 9999,
   "showClearContextOnPlanAccept": false,
-  "autoUpdatesChannel": "latest"
+  "autoUpdatesChannel": "latest",
+  "skillListingBudgetFraction": 0.02
 }


### PR DESCRIPTION
With 100+ plugin skills installed, the default 1% / 8000-char budget truncates many skill descriptions, which weakens Claude Code's ability to autonomously match user requests to the right skill.

Bumps `SLASH_COMMAND_TOOL_CHAR_BUDGET` to 60000 and adds `skillListingBudgetFraction: 0.02` for redundancy across Claude Code builds. Empirical measurement: ~31700 chars needed for full descriptions of all installed skills.