### PR TITLE
Show contributor avatars in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,3 +957,9 @@ Settings in [`.vscode/settings.json`](./.vscode/settings.json):
 ## Thank you for the support!
 
 [![Star History Chart](https://api.star-history.com/svg?repos=fcakyon/claude-codex-settings&type=Date)](https://www.star-history.com/#fcakyon/claude-codex-settings&Date)
+
+<p align="center">
+    <a href="https://github.com/fcakyon/claude-codex-settings/graphs/contributors">
+      <img src="https://contrib.rocks/image?repo=fcakyon/claude-codex-settings" />
+    </a>
+</p>


### PR DESCRIPTION
Adds a [contrib.rocks](https://contrib.rocks) avatar collage under the Star History chart in the existing thank-you section, so contributors are visible at a glance and the list auto-updates as new people contribute.