### PR TITLE
Label contributor avatar row in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,6 +958,8 @@ Settings in [`.vscode/settings.json`](./.vscode/settings.json):
 
 [![Star History Chart](https://api.star-history.com/svg?repos=fcakyon/claude-codex-settings&type=Date)](https://www.star-history.com/#fcakyon/claude-codex-settings&Date)
 
+<h3 align="center">Contributors</h3>
+
 <p align="center">
     <a href="https://github.com/fcakyon/claude-codex-settings/graphs/contributors">
       <img src="https://contrib.rocks/image?repo=fcakyon/claude-codex-settings" />


### PR DESCRIPTION
Follow-up to #195: adds a centered "Contributors" heading directly above the contrib.rocks avatar collage so readers can tell at a glance the row represents project contributors.