### PR TITLE
Enable ultracode effort by default

### DIFF
--- a/.claude/settings-auto.json
+++ b/.claude/settings-auto.json
@@ -10,7 +10,7 @@
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
     "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8",
     "MAX_MCP_OUTPUT_TOKENS": "40000",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
+    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "1",
     "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": "1",
@@ -210,6 +210,8 @@
       "GPU process interference: killing, pausing, or modifying GPU processes owned by other users on shared multi-user servers. Use nvidia-smi for read-only monitoring only"
     ]
   },
+  "ultracode": true,
+  "enableWorkflows": true,
   "outputStyle": "Explanatory",
   "model": "opus",
   "extraKnownMarketplaces": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
     "CLAUDE_CODE_SUBAGENT_MODEL": "claude-opus-4-8",
     "MAX_MCP_OUTPUT_TOKENS": "40000",
-    "CLAUDE_CODE_EFFORT_LEVEL": "max",
+    "CLAUDE_CODE_EFFORT_LEVEL": "xhigh",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL": "1",
     "CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING": "1",
@@ -157,6 +157,8 @@
       }
     ]
   },
+  "ultracode": true,
+  "enableWorkflows": true,
   "outputStyle": "Explanatory",
   "model": "opus",
   "autoScrollEnabled": false,


### PR DESCRIPTION
New Opus sessions now start in ultracode mode (xhigh effort plus dynamic workflow orchestration) instead of plain max effort, applied to both the standard and auto-mode profiles. The key has to live in the settings file because the in-session toggle never saves it.

```
/effort   # Current effort level: ultracode (xhigh + dynamic workflow orchestration)
```