### PR TITLE
Block local timeout command in Bash tool hooks

### DIFF
--- a/.claude/settings-auto.json
+++ b/.claude/settings-auto.json
@@ -142,6 +142,15 @@
             "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); if ! echo \"$CMD\" | rg -qP \"(\\brm\\s+-|\\brm\\s+/|\\brmdir\\b|shutil\\.rmtree|os\\.remove|os\\.unlink|\\bsubprocess\\b|os\\.system|\\bopen\\(.*[\\x27\\\"]w|\\bcurl\\s|\\bwget\\s|\\bpip\\s+install|\\bkill\\s|\\bpkill\\b|\\bchmod\\b|\\bchown\\b|\\bmv\\s+|\\bcp\\s+|\\bdd\\s|\\bmkfs\\b|\\bgit\\s+push|\\bgit\\s+commit|\\bgit\\s+add|\\bgit\\s+stash|\\bgit\\s+rebase|\\bgit\\s+clean|\\bgit\\s+branch\\s+-[dD]|\\bgit\\s+reset|\\bgit\\s+checkout\\s+\\.|\\bapt\\s|\\byum\\s|\\bbrew\\s+install|\\bnpm\\s+install|\\bsudo\\s|\\bdocker\\s|\\bkubectl\\s|>\\s+/|>>\\s+/)\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"allow\\\"}}\"; else printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"ask\\\",\\\"permissionDecisionReason\\\":\\\"contains destructive operation, review carefully\\\"}}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); S=$(printf \"%s\" \"$CMD\" | sed -e \"s/'\\''[^'\\'']*'\\''//g\" -e \"s/\\\"[^\\\"]*\\\"//g\"); if printf \"%s\" \"$S\" | grep -qE \"(^|[;&|(){}]|[[:space:]]do|[[:space:]]then|[[:space:]]else)[[:space:]]*timeout[[:space:]]\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"macOS has no timeout command on this host, so timeout N ... exits 127 with empty output and silently hides the real result (a remote ssh sweep can look idle when it is not). Use ssh -o ConnectTimeout=N, or gtimeout N (brew coreutils), or for a remote Linux host put timeout inside the ssh quotes.\\\"}}\"; fi'"
+          }
+        ]
       }
     ]
   },

--- a/.claude/settings-minimax.json
+++ b/.claude/settings-minimax.json
@@ -145,6 +145,15 @@
             "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); if ! echo \"$CMD\" | rg -qP \"(\\brm\\s+-|\\brm\\s+/|\\brmdir\\b|shutil\\.rmtree|os\\.remove|os\\.unlink|\\bsubprocess\\b|os\\.system|\\bopen\\(.*[\\x27\\\"]w|\\bcurl\\s|\\bwget\\s|\\bpip\\s+install|\\bkill\\s|\\bpkill\\b|\\bchmod\\b|\\bchown\\b|\\bmv\\s+|\\bcp\\s+|\\bdd\\s|\\bmkfs\\b|\\bgit\\s+push|\\bgit\\s+commit|\\bgit\\s+add|\\bgit\\s+stash|\\bgit\\s+rebase|\\bgit\\s+clean|\\bgit\\s+branch\\s+-[dD]|\\bgit\\s+reset|\\bgit\\s+checkout\\s+\\.|\\bapt\\s|\\byum\\s|\\bbrew\\s+install|\\bnpm\\s+install|\\bsudo\\s|\\bdocker\\s|\\bkubectl\\s|>\\s+/|>>\\s+/)\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"allow\\\"}}\"; else printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"ask\\\",\\\"permissionDecisionReason\\\":\\\"contains destructive operation, review carefully\\\"}}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); S=$(printf \"%s\" \"$CMD\" | sed -e \"s/'\\''[^'\\'']*'\\''//g\" -e \"s/\\\"[^\\\"]*\\\"//g\"); if printf \"%s\" \"$S\" | grep -qE \"(^|[;&|(){}]|[[:space:]]do|[[:space:]]then|[[:space:]]else)[[:space:]]*timeout[[:space:]]\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"macOS has no timeout command on this host, so timeout N ... exits 127 with empty output and silently hides the real result (a remote ssh sweep can look idle when it is not). Use ssh -o ConnectTimeout=N, or gtimeout N (brew coreutils), or for a remote Linux host put timeout inside the ssh quotes.\\\"}}\"; fi'"
+          }
+        ]
       }
     ]
   },

--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -144,6 +144,15 @@
             "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); if ! echo \"$CMD\" | rg -qP \"(\\brm\\s+-|\\brm\\s+/|\\brmdir\\b|shutil\\.rmtree|os\\.remove|os\\.unlink|\\bsubprocess\\b|os\\.system|\\bopen\\(.*[\\x27\\\"]w|\\bcurl\\s|\\bwget\\s|\\bpip\\s+install|\\bkill\\s|\\bpkill\\b|\\bchmod\\b|\\bchown\\b|\\bmv\\s+|\\bcp\\s+|\\bdd\\s|\\bmkfs\\b|\\bgit\\s+push|\\bgit\\s+commit|\\bgit\\s+add|\\bgit\\s+stash|\\bgit\\s+rebase|\\bgit\\s+clean|\\bgit\\s+branch\\s+-[dD]|\\bgit\\s+reset|\\bgit\\s+checkout\\s+\\.|\\bapt\\s|\\byum\\s|\\bbrew\\s+install|\\bnpm\\s+install|\\bsudo\\s|\\bdocker\\s|\\bkubectl\\s|>\\s+/|>>\\s+/)\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"allow\\\"}}\"; else printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"ask\\\",\\\"permissionDecisionReason\\\":\\\"contains destructive operation, review carefully\\\"}}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); S=$(printf \"%s\" \"$CMD\" | sed -e \"s/'\\''[^'\\'']*'\\''//g\" -e \"s/\\\"[^\\\"]*\\\"//g\"); if printf \"%s\" \"$S\" | grep -qE \"(^|[;&|(){}]|[[:space:]]do|[[:space:]]then|[[:space:]]else)[[:space:]]*timeout[[:space:]]\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"macOS has no timeout command on this host, so timeout N ... exits 127 with empty output and silently hides the real result (a remote ssh sweep can look idle when it is not). Use ssh -o ConnectTimeout=N, or gtimeout N (brew coreutils), or for a remote Linux host put timeout inside the ssh quotes.\\\"}}\"; fi'"
+          }
+        ]
       }
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -143,6 +143,15 @@
             "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); if ! echo \"$CMD\" | rg -qP \"(\\brm\\s+-|\\brm\\s+/|\\brmdir\\b|shutil\\.rmtree|os\\.remove|os\\.unlink|\\bsubprocess\\b|os\\.system|\\bopen\\(.*[\\x27\\\"]w|\\bcurl\\s|\\bwget\\s|\\bpip\\s+install|\\bkill\\s|\\bpkill\\b|\\bchmod\\b|\\bchown\\b|\\bmv\\s+|\\bcp\\s+|\\bdd\\s|\\bmkfs\\b|\\bgit\\s+push|\\bgit\\s+commit|\\bgit\\s+add|\\bgit\\s+stash|\\bgit\\s+rebase|\\bgit\\s+clean|\\bgit\\s+branch\\s+-[dD]|\\bgit\\s+reset|\\bgit\\s+checkout\\s+\\.|\\bapt\\s|\\byum\\s|\\bbrew\\s+install|\\bnpm\\s+install|\\bsudo\\s|\\bdocker\\s|\\bkubectl\\s|>\\s+/|>>\\s+/)\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"allow\\\"}}\"; else printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"ask\\\",\\\"permissionDecisionReason\\\":\\\"contains destructive operation, review carefully\\\"}}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); S=$(printf \"%s\" \"$CMD\" | sed -e \"s/'\\''[^'\\'']*'\\''//g\" -e \"s/\\\"[^\\\"]*\\\"//g\"); if printf \"%s\" \"$S\" | grep -qE \"(^|[;&|(){}]|[[:space:]]do|[[:space:]]then|[[:space:]]else)[[:space:]]*timeout[[:space:]]\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"macOS has no timeout command on this host, so timeout N ... exits 127 with empty output and silently hides the real result (a remote ssh sweep can look idle when it is not). Use ssh -o ConnectTimeout=N, or gtimeout N (brew coreutils), or for a remote Linux host put timeout inside the ssh quotes.\\\"}}\"; fi'"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
Deny running a local timeout command from the Bash tool, since macOS has no timeout binary and the call exits 127 with empty output, which can make a live remote host sweep look idle. Remote usage kept inside the quotes stays allowed, and the hook abstains on no match so it never overrides the existing destructive-command guard.

blocked: timeout 25 ssh ultra2 nvidia-smi (macOS: exit 127, empty output)
allowed: ssh ultra2 'timeout 25 nvidia-smi', ssh -o ConnectTimeout=12 ultra2 nvidia-smi
