### PR TITLE
add Fable Advisor plugin and refactor the advisor config

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -221,6 +221,18 @@
       "category": "deployment"
     },
     {
+      "name": "fable-advisor",
+      "source": {
+        "source": "local",
+        "path": "./plugins/fable-advisor"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "developer-tools"
+    },
+    {
       "name": "github-dev",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -284,6 +284,21 @@
       "tags": ["research", "academic", "latex"]
     },
     {
+      "name": "fable-advisor",
+      "source": "./plugins/fable-advisor",
+      "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["advisor", "second-opinion", "review", "agent", "escalation"],
+      "category": "developer-tools",
+      "tags": ["review", "agent"]
+    },
+    {
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -228,7 +228,7 @@
   "enableWorkflows": true,
   "outputStyle": "Explanatory",
   "model": "opus",
-  "advisorModel": "claude-fable-5",
+  "advisorModel": "claude-opus-4-8",
   "autoScrollEnabled": false,
   "extraKnownMarketplaces": {
     "claude-settings": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -129,6 +129,13 @@
       "license": "MIT"
     },
     {
+      "name": "fable-advisor",
+      "source": "./plugins/fable-advisor",
+      "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    },
+    {
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",

--- a/.github/scripts/validate_plugins.py
+++ b/.github/scripts/validate_plugins.py
@@ -25,6 +25,15 @@ def parse_frontmatter(content: str) -> tuple[dict | None, str]:
         return None, content
 
 
+VALID_MODEL_ALIASES = {"inherit", "sonnet", "opus", "haiku", "fable"}
+VALID_AGENT_COLORS = {"red", "blue", "green", "yellow", "purple", "orange", "pink", "cyan"}
+
+
+def is_valid_model(value: object) -> bool:
+    """Return True if value is an allowed model: a known alias, inherit, or a full claude- model ID."""
+    return isinstance(value, str) and (value in VALID_MODEL_ALIASES or value.startswith("claude-"))
+
+
 def validate_plugin_json(plugin_dir: Path) -> list[str]:
     """Validate .claude-plugin/plugin.json exists and is valid."""
     errors = []
@@ -115,9 +124,6 @@ def validate_agents(plugin_dir: Path) -> list[str]:
     if not agents_dir.exists():
         return errors
 
-    valid_models = {"inherit", "sonnet", "opus", "haiku"}
-    valid_colors = {"blue", "cyan", "green", "yellow", "magenta", "red"}
-
     for agent_file in agents_dir.iterdir():
         if not agent_file.is_file() or agent_file.suffix != ".md":
             continue
@@ -163,14 +169,14 @@ def validate_agents(plugin_dir: Path) -> list[str]:
         # Validate model field
         if "model" not in frontmatter:
             errors.append(f"{prefix}: Missing 'model' field")
-        elif frontmatter["model"] not in valid_models:
-            errors.append(f"{prefix}: 'model' must be one of {valid_models}: '{frontmatter['model']}'")
+        elif not is_valid_model(frontmatter["model"]):
+            errors.append(f"{prefix}: 'model' must be one of {sorted(VALID_MODEL_ALIASES)} or a full model ID: '{frontmatter['model']}'")
 
         # Validate color field
         if "color" not in frontmatter:
             errors.append(f"{prefix}: Missing 'color' field")
-        elif frontmatter["color"] not in valid_colors:
-            errors.append(f"{prefix}: 'color' must be one of {valid_colors}: '{frontmatter['color']}'")
+        elif frontmatter["color"] not in VALID_AGENT_COLORS:
+            errors.append(f"{prefix}: 'color' must be one of {sorted(VALID_AGENT_COLORS)}: '{frontmatter['color']}'")
 
         # Validate tools field if present
         if "tools" in frontmatter:
@@ -194,8 +200,6 @@ def validate_commands(plugin_dir: Path) -> list[str]:
     if not commands_dir.exists():
         return errors
 
-    valid_models = {"sonnet", "opus", "haiku"}
-
     for cmd_file in commands_dir.rglob("*.md"):
         prefix = f"{plugin_dir.name}/commands/{cmd_file.relative_to(commands_dir)}"
         name = cmd_file.stem
@@ -210,8 +214,8 @@ def validate_commands(plugin_dir: Path) -> list[str]:
         # Frontmatter is optional for commands
         if frontmatter:
             # Validate model if present
-            if "model" in frontmatter and frontmatter["model"] not in valid_models:
-                errors.append(f"{prefix}: 'model' must be one of {valid_models}: '{frontmatter['model']}'")
+            if "model" in frontmatter and not is_valid_model(frontmatter["model"]):
+                errors.append(f"{prefix}: 'model' must be one of {sorted(VALID_MODEL_ALIASES)} or a full model ID: '{frontmatter['model']}'")
 
             # Validate disable-model-invocation if present
             if "disable-model-invocation" in frontmatter:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,8 +164,8 @@ color: blue
 ```
 
 - `name`: kebab-case, 3-50 chars
-- `model`: inherit, sonnet, opus, haiku
-- `color`: blue, cyan, green, yellow, magenta, red
+- `model`: inherit, sonnet, opus, haiku, fable (or a full model ID like `claude-opus-4-8`)
+- `color`: red, blue, green, yellow, purple, orange, pink, cyan
 - `tools`: array of allowed tool names
 - `skills`: optional, skill name(s) to load
 

--- a/README.md
+++ b/README.md
@@ -824,6 +824,7 @@ Configuration in [`.claude/settings.json`](./.claude/settings.json):
 - **Environment**: bash working directory, telemetry disabled, MCP output limits
 - **Permissions**: bash commands, git operations, MCP tools
 - **Auto mode**: `auto` permission mode with a custom `autoMode` classifier block in [`.claude/settings.json`](./.claude/settings.json) - see the [auto mode config reference](https://code.claude.com/docs/en/auto-mode-config) for what each rule section does, and run `claude auto-mode defaults` to print the current built-in block and allow rules
+- **Advisor**: a stronger model reviews key decisions via the [advisor tool](https://code.claude.com/docs/en/advisor), paired as Opus main plus Opus advisor. Fable 5 as advisor currently fails with a bare "unavailable" ([#73365](https://github.com/anthropics/claude-code/issues/73365)), so for an on-demand Fable second opinion use the standalone `fable-advisor` plugin
 - **Plugins**: All plugins enabled
 
 </details>

--- a/plugins/fable-advisor/.claude-plugin/plugin.json
+++ b/plugins/fable-advisor/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "fable-advisor",
+  "version": "1.0.0",
+  "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
+  "license": "Apache-2.0"
+}

--- a/plugins/fable-advisor/.codex-plugin/plugin.json
+++ b/plugins/fable-advisor/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "fable-advisor",
+  "version": "1.0.0",
+  "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
+  "license": "Apache-2.0"
+}

--- a/plugins/fable-advisor/.cursor-plugin/plugin.json
+++ b/plugins/fable-advisor/.cursor-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "fable-advisor",
+  "version": "1.0.0",
+  "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
+  "license": "Apache-2.0"
+}

--- a/plugins/fable-advisor/agents/fable-advisor.md
+++ b/plugins/fable-advisor/agents/fable-advisor.md
@@ -1,0 +1,26 @@
+---
+name: fable-advisor
+description: |-
+  Second-opinion reviewer backed by Fable 5. Use this in place of the built-in advisor tool when the Fable-5 advisor is unavailable (the Opus-main + Fable-advisor pairing currently fails with a bare "unavailable", see anthropics/claude-code#73365). Spawn it before committing to an interpretation, before a large or risky change, and when a result does not fit. Pass the task, your current approach or conclusion, and the key evidence (files, commands, outputs) so it can pressure-test them. It returns a skeptical review, not a rewrite.
+model: fable
+color: purple
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+You are a stronger reviewer giving a second opinion. The main agent consulted you because it is about to commit to an approach, a conclusion, or a risky change.
+
+Pressure-test it. Do not rewrite it.
+
+## What to do
+
+1. Read the context you were given: the task, the proposed approach or conclusion, and the evidence.
+2. Verify the load-bearing claims against the actual files, commands, and outputs. Do not take the main agent's summary at face value.
+3. Look for what would make the plan or conclusion wrong: unstated assumptions, missed edge cases, a cheaper or safer alternative, evidence that points the other way.
+
+## What to return
+
+- A one-word verdict: proceed, proceed-with-changes, or reconsider.
+- The specific risks or gaps that matter, most important first, each with the concrete failure it would cause.
+- If you disagree with the conclusion, name the exact evidence that breaks it.
+
+Say nothing about parts that are already correct. Be concrete, not encouraging.

--- a/plugins/fable-advisor/gemini-extension.json
+++ b/plugins/fable-advisor/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "fable-advisor",
+  "version": "1.0.0",
+  "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it."
+}


### PR DESCRIPTION
Fable 5 as an advisor currently fails with a bare "unavailable" (anthropics/claude-code#73365), so this switches the default advisor to Opus and adds a standalone `fable-advisor` plugin for an on-demand Fable second opinion. It also updates the agent validator and docs to the current spec: `model` accepts `fable` and full model IDs, and `color` uses the official `red/blue/green/yellow/purple/orange/pink/cyan` set instead of the stale `magenta` list.

```
# in any session, ask for a Fable second opinion:
use the fable-advisor agent to pressure-test this before I commit
```