### PR TITLE
Move fable-advisor to the top of the plugin list

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,6 +5,18 @@
   },
   "plugins": [
     {
+      "name": "fable-advisor",
+      "source": {
+        "source": "local",
+        "path": "./plugins/fable-advisor"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "developer-tools"
+    },
+    {
       "name": "intelligent-compact",
       "source": {
         "source": "local",
@@ -219,18 +231,6 @@
         "authentication": "ON_INSTALL"
       },
       "category": "deployment"
-    },
-    {
-      "name": "fable-advisor",
-      "source": {
-        "source": "local",
-        "path": "./plugins/fable-advisor"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "developer-tools"
     },
     {
       "name": "github-dev",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,21 @@
   },
   "plugins": [
     {
+      "name": "fable-advisor",
+      "source": "./plugins/fable-advisor",
+      "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["advisor", "second-opinion", "review", "agent", "escalation"],
+      "category": "developer-tools",
+      "tags": ["review", "agent"]
+    },
+    {
       "name": "intelligent-compact",
       "source": "./plugins/intelligent-compact",
       "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
@@ -282,21 +297,6 @@
       "keywords": ["research", "academic", "phd", "paper-writing", "citations", "experiments", "latex"],
       "category": "research",
       "tags": ["research", "academic", "latex"]
-    },
-    {
-      "name": "fable-advisor",
-      "source": "./plugins/fable-advisor",
-      "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
-      "version": "1.0.0",
-      "author": {
-        "name": "Fatih Akyon"
-      },
-      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
-      "repository": "https://github.com/fcakyon/claude-codex-settings",
-      "license": "Apache-2.0",
-      "keywords": ["advisor", "second-opinion", "review", "agent", "escalation"],
-      "category": "developer-tools",
-      "tags": ["review", "agent"]
     },
     {
       "name": "github-dev",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -3,6 +3,13 @@
   "displayName": "Claude & Cursor Settings",
   "plugins": [
     {
+      "name": "fable-advisor",
+      "source": "./plugins/fable-advisor",
+      "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    },
+    {
       "name": "intelligent-compact",
       "source": "./plugins/intelligent-compact",
       "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
@@ -127,13 +134,6 @@
       "description": "Dokploy deployment skill for Dokploy Cloud, self-hosted dashboard, Docker Compose, databases, domains, remote servers, and Dokploy CLI workflows.",
       "version": "1.0.0",
       "license": "MIT"
-    },
-    {
-      "name": "fable-advisor",
-      "source": "./plugins/fable-advisor",
-      "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
-      "version": "1.0.0",
-      "license": "Apache-2.0"
     },
     {
       "name": "github-dev",

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ ln -sfn CLAUDE.md GEMINI.md
 ## Plugins
 
 <details>
+<summary><strong>fable-advisor</strong> - On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it</summary>
+
+| Claude Code                                     | Codex CLI                                                               | Gemini CLI                                                 |
+| ----------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `/plugin install fable-advisor@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `fable-advisor` | `gemini extensions install --path ./plugins/fable-advisor` |
+
+Spawn a stronger Fable 5 reviewer to pressure-test a plan or conclusion before you commit, a drop-in for the built-in advisor when the Opus-main plus Fable-advisor pairing fails with a bare "unavailable" ([#73365](https://github.com/anthropics/claude-code/issues/73365)). It checks your load-bearing claims against the actual files and returns a skeptical review, not a rewrite.
+
+**Agents:**
+
+- [`fable-advisor`](./plugins/fable-advisor/agents/fable-advisor.md) - Fable 5 second-opinion reviewer, pass it the task, your approach, and the evidence
+
+</details>
+
+<details>
 <summary><strong>intelligent-compact</strong> - Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions</summary>
 
 | Claude Code                                           | Codex CLI                                                                     | Gemini CLI                                                       |
@@ -824,7 +839,7 @@ Configuration in [`.claude/settings.json`](./.claude/settings.json):
 - **Environment**: bash working directory, telemetry disabled, MCP output limits
 - **Permissions**: bash commands, git operations, MCP tools
 - **Auto mode**: `auto` permission mode with a custom `autoMode` classifier block in [`.claude/settings.json`](./.claude/settings.json) - see the [auto mode config reference](https://code.claude.com/docs/en/auto-mode-config) for what each rule section does, and run `claude auto-mode defaults` to print the current built-in block and allow rules
-- **Advisor**: a stronger model reviews key decisions via the [advisor tool](https://code.claude.com/docs/en/advisor), paired as Opus main plus Opus advisor. Fable 5 as advisor currently fails with a bare "unavailable" ([#73365](https://github.com/anthropics/claude-code/issues/73365)), so for an on-demand Fable second opinion use the standalone `fable-advisor` plugin
+- **Advisor**: a stronger model reviews key decisions via the [advisor tool](https://code.claude.com/docs/en/advisor), paired as Opus main plus Opus advisor. Fable 5 as advisor currently fails with a bare "unavailable" ([#73365](https://github.com/anthropics/claude-code/issues/73365)), so for an on-demand Fable second opinion use the standalone [`fable-advisor`](./plugins/fable-advisor) plugin
 - **Plugins**: All plugins enabled
 
 </details>


### PR DESCRIPTION
Lists the `fable-advisor` plugin first in each marketplace so it heads the README plugin catalog above `intelligent-compact`, and links the advisor note to the plugin so it is clickable.

```
/plugin install fable-advisor@claude-settings
```