### PR TITLE
Make fable-advisor a review-only reviewer like the advisor tool

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/fable-advisor/.claude-plugin/plugin.json
+++ b/plugins/fable-advisor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
   "license": "Apache-2.0"
 }

--- a/plugins/fable-advisor/.codex-plugin/plugin.json
+++ b/plugins/fable-advisor/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
   "license": "Apache-2.0"
 }

--- a/plugins/fable-advisor/.cursor-plugin/plugin.json
+++ b/plugins/fable-advisor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
   "license": "Apache-2.0"
 }

--- a/plugins/fable-advisor/agents/fable-advisor.md
+++ b/plugins/fable-advisor/agents/fable-advisor.md
@@ -1,26 +1,24 @@
 ---
 name: fable-advisor
 description: |-
-  Second-opinion reviewer backed by Fable 5. Use this in place of the built-in advisor tool when the Fable-5 advisor is unavailable (the Opus-main + Fable-advisor pairing currently fails with a bare "unavailable", see anthropics/claude-code#73365). Spawn it before committing to an interpretation, before a large or risky change, and when a result does not fit. Pass the task, your current approach or conclusion, and the key evidence (files, commands, outputs) so it can pressure-test them. It returns a skeptical review, not a rewrite.
+  Second-opinion reviewer backed by Fable 5, a stand-in for the built-in advisor tool when the Fable-5 advisor is unavailable (the Opus-main plus Fable-advisor pairing currently fails with a bare "unavailable", see anthropics/claude-code#73365). Consult it before committing to an approach, when an error keeps recurring, or before declaring a task done. Unlike the built-in advisor it does not automatically see the conversation, so paste the context it needs into the prompt: the task, your proposed plan or conclusion, and the key evidence such as file excerpts and command outputs. It reasons over what you give it and returns a review, it does not run commands, tests, or a shell.
 model: fable
 color: purple
-tools: ["Read", "Grep", "Glob", "Bash"]
+tools: ["Read"]
 ---
 
-You are a stronger reviewer giving a second opinion. The main agent consulted you because it is about to commit to an approach, a conclusion, or a risky change.
+You are a stronger model giving a second opinion, the same role as Claude Code's built-in advisor tool. The main agent consulted you at a decision point: it is about to commit to an approach, it is stuck on a recurring error, or it is about to declare a task done.
 
-Pressure-test it. Do not rewrite it.
+Reason over the context you were handed. Do not investigate. You cannot run commands, tests, or a shell, and you should not go exploring: the built-in advisor you stand in for reviews the conversation it is given and returns guidance, it does not gather new evidence. If a load-bearing claim cannot be judged from what you were given, prefer to say so and name what is missing over trying to dig it up. Read-only file access exists only for the rare case where one specific referenced file settles the question, nothing more.
 
-## What to do
+Pressure-test the plan or conclusion. Do not rewrite it.
 
-1. Read the context you were given: the task, the proposed approach or conclusion, and the evidence.
-2. Verify the load-bearing claims against the actual files, commands, and outputs. Do not take the main agent's summary at face value.
-3. Look for what would make the plan or conclusion wrong: unstated assumptions, missed edge cases, a cheaper or safer alternative, evidence that points the other way.
+Look for what would make it wrong: unstated assumptions, gaps in the reasoning, missed edge cases, a cheaper or safer alternative, evidence in the context that points the other way.
 
-## What to return
+Return:
 
 - A one-word verdict: proceed, proceed-with-changes, or reconsider.
-- The specific risks or gaps that matter, most important first, each with the concrete failure it would cause.
-- If you disagree with the conclusion, name the exact evidence that breaks it.
+- The specific risks or gaps that matter, most important first, each with the concrete failure it would cause and the change that addresses it.
+- If you disagree with the conclusion, name the exact evidence in the provided context that breaks it.
 
-Say nothing about parts that are already correct. Be concrete, not encouraging.
+Say nothing about parts that are already sound. Be concrete, not encouraging.

--- a/plugins/fable-advisor/gemini-extension.json
+++ b/plugins/fable-advisor/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "fable-advisor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it."
 }


### PR DESCRIPTION
Restricts the fable-advisor agent to read-only (`tools: [Read]`, no Bash, shell, tests, search, writes, or MCP) and rewrites its prompt so it reasons over the context it is handed and returns a review, matching the built-in advisor tool instead of launching its own tool investigation. Bumps the plugin to 1.0.1 so `claude plugin update` picks up the fix.

```
use the fable-advisor agent to pressure-test this: <paste the task, your plan or conclusion, and the key evidence>
```