### PR TITLE
Fix wrong PR reply endpoint in resolve-pr-comments skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -302,7 +302,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -139,7 +139,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/gemini-extension.json
+++ b/plugins/github-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "github-dev",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
 }

--- a/plugins/github-dev/skills/resolve-pr-comments/SKILL.md
+++ b/plugins/github-dev/skills/resolve-pr-comments/SKILL.md
@@ -38,5 +38,5 @@ reference is provided, infer it from the current branch.
 
 5. **Never auto-submit**
    - Present all draft responses before posting them.
-   - Reply comments are posted directly with `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies -f body="..."`.
+   - Reply comments are posted directly with `gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body="..."` (the `{number}` PR number is required, the endpoint 404s without it).
    - Add a random 3-5 second delay between posted replies with `sleep $((RANDOM % 3 + 3))`.


### PR DESCRIPTION
The resolve-pr-comments skill documented the GitHub reply endpoint without the PR number, so posting a reply returned 404. This adds the PR number to the path and bumps github-dev to 2.4.1.