### PR TITLE
Add adhd-output-style plugin for answer-first responses

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -327,6 +327,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "research"
+    },
+    {
+      "name": "adhd-output-style",
+      "source": {
+        "source": "local",
+        "path": "./plugins/adhd-output-style"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "developer-tools"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -417,6 +417,21 @@
       "keywords": ["overleaf", "latex", "review", "comments", "academic", "writing"],
       "category": "research",
       "tags": ["research", "academic", "latex"]
+    },
+    {
+      "name": "adhd-output-style",
+      "source": "./plugins/adhd-output-style",
+      "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["output-style", "adhd", "formatting", "accessibility", "productivity"],
+      "category": "developer-tools",
+      "tags": ["output-style", "productivity", "accessibility"]
     }
   ]
 }

--- a/.claude/output-styles/adhd-explanatory.md
+++ b/.claude/output-styles/adhd-explanatory.md
@@ -1,0 +1,1 @@
+../../plugins/adhd-output-style/output-styles/adhd-explanatory.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -226,10 +226,15 @@
   },
   "ultracode": false,
   "enableWorkflows": true,
-  "outputStyle": "Explanatory",
+  "outputStyle": "ADHD Explanatory",
   "model": "opus",
   "advisorModel": "claude-opus-4-8",
   "autoScrollEnabled": false,
+  "enabledPlugins": {
+    "adhd-output-style@claude-settings": true,
+    "intelligent-compact@claude-settings": true,
+    "github-dev@claude-settings": true
+  },
   "extraKnownMarketplaces": {
     "claude-settings": {
       "source": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -190,6 +190,13 @@
       "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
       "version": "1.0.0",
       "license": "Apache-2.0"
+    },
+    {
+      "name": "adhd-output-style",
+      "source": "./plugins/adhd-output-style",
+      "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -826,6 +826,21 @@ Pull reviewer comments from an Overleaf project, locate each in your local git-t
 
 </details>
 
+<details>
+<summary><strong>adhd-output-style</strong> - Answer-first replies with numbered steps, a clear next action, and short teaching notes</summary>
+
+| Claude Code                                         | Codex CLI                                                                   | Gemini CLI                                                     |
+| --------------------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `/plugin install adhd-output-style@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `adhd-output-style` | `gemini extensions install --path ./plugins/adhd-output-style` |
+
+Reformats every reply for limited working memory: the answer or next step first, numbered one-action-per-step lists, concrete time estimates, a single under-two-minute next action, and short teaching notes while coding. Enabling the plugin applies the style automatically. Output styles apply in Claude Code.
+
+**Output styles:**
+
+- [`ADHD Explanatory`](./plugins/adhd-output-style/output-styles/adhd-explanatory.md) - Answer-first ADHD formatting plus educational Insight blocks while coding
+
+</details>
+
 ---
 
 ## Configuration

--- a/plugins/adhd-output-style/.claude-plugin/plugin.json
+++ b/plugins/adhd-output-style/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "adhd-output-style",
+  "version": "1.0.0",
+  "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
+  "license": "Apache-2.0"
+}

--- a/plugins/adhd-output-style/.codex-plugin/plugin.json
+++ b/plugins/adhd-output-style/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "adhd-output-style",
+  "version": "1.0.0",
+  "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
+  "license": "Apache-2.0"
+}

--- a/plugins/adhd-output-style/.cursor-plugin/plugin.json
+++ b/plugins/adhd-output-style/.cursor-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "adhd-output-style",
+  "version": "1.0.0",
+  "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
+  "license": "Apache-2.0"
+}

--- a/plugins/adhd-output-style/gemini-extension.json
+++ b/plugins/adhd-output-style/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "adhd-output-style",
+  "version": "1.0.0",
+  "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding."
+}

--- a/plugins/adhd-output-style/output-styles/adhd-explanatory.md
+++ b/plugins/adhd-output-style/output-styles/adhd-explanatory.md
@@ -1,0 +1,39 @@
+---
+name: ADHD Explanatory
+description: Answer-first ADHD formatting plus educational Insight blocks while coding
+keep-coding-instructions: true
+force-for-plugin: true
+---
+
+Format every response for a reader with limited working memory who needs
+low-friction starts and visible progress, while still teaching. Apply to all
+interactions.
+
+## Structure (ADHD)
+
+- Open with the actionable step or the answer, not context or setup.
+- Break multi-step work into numbered lists, one action per step.
+- End with a single next action that takes under two minutes.
+- Keep secondary issues separate; do not bundle them into the main answer.
+- Restate progress each turn (e.g. "step 3 of 5"); assume prior context is lost.
+- Use concrete time estimates ("~2 min", "3 files"), never vague ones.
+- State what now works in plain terms instead of burying it in a recap.
+- Describe errors factually: cause, then fix. No alarmed language.
+- Cap lists at five items; split longer ones into priority tiers.
+- Cut preambles, recaps, and closing pleasantries. Start at the answer, stop when done.
+
+Exceptions: give full walkthroughs when asked; confirm before destructive
+actions; pause with a diagnostic question after repeated failed debugging;
+ask one clarifying question on genuine ambiguity before proceeding.
+
+## Education (Explanatory)
+
+Before and after writing code, add a short educational note using this block:
+
+`★ Insight ─────────────────────────────────────`
+[2-3 codebase-specific educational points]
+`─────────────────────────────────────────────────`
+
+Put depth here, not in the main answer. Prefer insights specific to this
+codebase or the code just written over general programming concepts. Cap at
+three points so the block stays scannable. The rest of the response stays terse.


### PR DESCRIPTION
Adds an `adhd-output-style` plugin that ships the ADHD Explanatory output style (answer-first replies, numbered steps, short teaching notes) and turns it on by default in the example config.

- The style lives once in the plugin and is symlinked into `.claude/output-styles/`, so the example `settings.json` pointer resolves with no duplication
- Also enables `intelligent-compact` and `github-dev` by default in the example config

`/plugin install adhd-output-style@claude-settings`
