### PR TITLE
Add a simplify skill to Codex, Cursor and Gemini CLI

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,6 +5,18 @@
   },
   "plugins": [
     {
+      "name": "simplify",
+      "source": {
+        "source": "local",
+        "path": "./plugins/simplify"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "developer-tools"
+    },
+    {
       "name": "fable-advisor",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,6 +9,21 @@
   },
   "plugins": [
     {
+      "name": "simplify",
+      "source": "./plugins/simplify",
+      "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["simplify", "cleanup", "refactor", "diff", "code-review"],
+      "category": "developer-tools",
+      "tags": ["cleanup", "refactor"]
+    },
+    {
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
@@ -302,7 +317,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,7 +58,7 @@ For full Python guidelines, install and enable the `python-skills` plugin (`pyth
 
 ### Commit Messages
 
-- Before committing, run `/simplify` on the staged diff (the actual skill, not an ad-hoc pass), apply findings, then commit. For a docs or config-text-only diff, the code-angle review is a no-op, note that and proceed
+- Run the `/simplify` skill on the staged diff before committing, then apply its findings. Docs-only diffs are a no-op
 - Format: `{type}: brief description` (max 50 chars first line)
 - Optional second line: 1 sentence with findings/motivation
 - Types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `build`

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -3,6 +3,13 @@
   "displayName": "Claude & Cursor Settings",
   "plugins": [
     {
+      "name": "simplify",
+      "source": "./plugins/simplify",
+      "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    },
+    {
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
@@ -139,7 +146,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "Apache-2.0"
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,7 +320,7 @@ See `### Description handling` (Marketplace Plugin Conventions) for the list of 
 
 ## Commit and PR Writing Style
 
-**Before every commit, run `/simplify` on the staged diff, apply what it flags, then commit. Invoke the actual skill, not an ad-hoc cleanup pass. For a docs or config-text-only diff with no code or scripts, the code-angle review is a no-op, note that and proceed.**
+**Run the `/simplify` skill on the staged diff before every commit, then apply its findings. Docs-only diffs are a no-op.**
 
 This repo contains config files (JSON settings, allowlist rules, hooks) rather than application code. Commit messages and PR descriptions should be written in plain language that anyone can understand, not just Claude Code plugin developers.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ ln -sfn CLAUDE.md GEMINI.md
 ## Plugins
 
 <details>
+<summary><strong>simplify</strong> - Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups</summary>
+
+| Claude Code                                | Codex CLI                                                          | Gemini CLI                                            |
+| ------------------------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------- |
+| `/plugin install simplify@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `simplify` | `gemini extensions install --path ./plugins/simplify` |
+
+Run `/simplify` to review your staged or committed diff across four angles (reuse, simplification, efficiency, altitude) with parallel agents, then apply the cleanups. It reviews changed-code quality, not correctness bugs, and gives Codex and Cursor the same review and apply flow that Claude Code has built in.
+
+**Skills:**
+
+- [`simplify`](./plugins/simplify/skills/simplify/SKILL.md) - review the changed diff across four angles and apply the fixes
+
+</details>
+
+<details>
 <summary><strong>fable-advisor</strong> - On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it</summary>
 
 | Claude Code                                     | Codex CLI                                                               | Gemini CLI                                                 |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ ln -sfn CLAUDE.md GEMINI.md
 | ------------------------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------- |
 | `/plugin install simplify@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `simplify` | `gemini extensions install --path ./plugins/simplify` |
 
-Run `/simplify` to review your staged or committed diff across four angles (reuse, simplification, efficiency, altitude) with parallel agents, then apply the cleanups. It reviews changed-code quality, not correctness bugs, and gives Codex and Cursor the same review and apply flow that Claude Code has built in.
+Run `/simplify` to review your staged or committed diff across four angles (reuse, simplification, efficiency, altitude) with parallel agents, then apply the cleanups. It reviews changed-code quality, not correctness bugs. It brings [Claude Code's built-in `/simplify`](https://code.claude.com/docs/en/code-review#review-a-diff-locally) to Codex, Cursor, and Gemini, which don't ship it natively, so all three get the same review and apply flow.
 
 **Skills:**
 

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/gemini-extension.json
+++ b/plugins/github-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "github-dev",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
 }

--- a/plugins/github-dev/skills/commit-staged/SKILL.md
+++ b/plugins/github-dev/skills/commit-staged/SKILL.md
@@ -14,6 +14,8 @@ points in the commit message body instead of relying on the diff alone.
 
 ## Process
 
+**First, run the `/simplify` skill on the staged diff and apply its findings before committing. Docs-only diffs are a no-op.**
+
 1. **Preferred execution**
    - If subagents are available, use `github-dev:commit-creator` for the full workflow.
    - Pass along any extra invocation text as additional context.

--- a/plugins/github-dev/skills/create-pr/SKILL.md
+++ b/plugins/github-dev/skills/create-pr/SKILL.md
@@ -13,6 +13,8 @@ plain-language branch name rather than copying the full text.
 
 ## Process
 
+**First, run the `/simplify` skill on the staged diff and apply its findings before committing. Docs-only diffs are a no-op.**
+
 1. **Preferred execution**
    - If subagents are available, use `github-dev:pr-creator` for the full workflow.
    - Pass along any extra invocation text plus session findings and motivation as additional context.

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "simplify",
+  "version": "1.0.0",
+  "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
+  "license": "Apache-2.0"
+}

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "simplify",
+  "version": "1.0.0",
+  "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
+  "license": "Apache-2.0"
+}

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "simplify",
+  "version": "1.0.0",
+  "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
+  "license": "Apache-2.0"
+}

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "simplify",
+  "version": "1.0.0",
+  "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups."
+}

--- a/plugins/simplify/skills/simplify/SKILL.md
+++ b/plugins/simplify/skills/simplify/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: simplify
+description: This skill should be used when the user asks to "simplify", "clean up the diff", "run simplify", "simplify the changes", "review changed code for cleanup", or explicitly invokes "/simplify". Reviews the changed code across reuse, simplification, efficiency, and altitude with parallel agents, then applies the fixes. Not for correctness bugs.
+---
+
+# Simplify
+
+`/simplify → 4 cleanup agents in parallel → apply the fixes`
+
+You are improving the quality of the changed code, not hunting for bugs. Review it for reuse, simplification, efficiency, and altitude issues, then fix what you find. Do not look for correctness bugs, that is what `/code-review` is for.
+
+## Phase 0 — Gather the diff
+
+Run `git diff @{upstream}...HEAD` (or `git diff main...HEAD` / `git diff HEAD~1` if there's no upstream) to get the unified diff under review. If there are uncommitted changes, or the range diff is empty, also run `git diff HEAD` and include the working-tree changes in scope, the review often runs before the commit. If a PR number, branch name, or file path was passed as an argument, review that target instead. Treat this diff as the review scope.
+
+## Phase 1 — Review (4 cleanup agents in parallel)
+
+Launch **4 independent review agents** via the Agent tool, all in a single message so they run concurrently. Pass each agent the diff and one of the four angles below. Each returns its findings with `file`, `line`, a one-line `summary`, and the concrete cost (what is duplicated, wasted, or harder to maintain).
+
+### Reuse
+
+Flag new code that re-implements something the codebase already has. Grep shared/utility modules and files adjacent to the change, and name the existing helper to call instead.
+
+### Simplification
+
+Flag unnecessary complexity the diff adds: redundant or derivable state, copy-paste with slight variation, deep nesting, dead code left behind. Name the simpler form that does the same job.
+
+### Efficiency
+
+Flag wasted work the diff introduces: redundant computation or repeated I/O, independent operations run sequentially, blocking work added to startup or hot paths. Also flag long-lived objects built from closures or captured environments, they keep the entire enclosing scope alive for the object's lifetime (a memory leak when that scope holds large values). Prefer a class/struct that copies only the fields it needs. Name the cheaper alternative.
+
+### Altitude
+
+Check that each change is implemented at the right depth, not as a fragile bandaid. Special cases layered on shared infrastructure are a sign the fix isn't deep enough, prefer generalizing the underlying mechanism over adding special cases.
+
+## Phase 2 — Apply the fixes
+
+Wait for all four agents to complete, dedup findings that point at the same line or mechanism, and fix each remaining one directly. Skip any finding whose fix would change intended behavior, require changes well outside the reviewed diff, or that you judge to be a false positive, note the skip rather than arguing with it. Finish with a brief summary of what was fixed and what was skipped (or confirm the code was already clean).


### PR DESCRIPTION
`/simplify` is one of Claude Code's sharpest built-in skills: it fans out four review agents in parallel (reuse, simplification, efficiency, altitude) and cleans up your diff before you commit. Codex, Cursor, and Gemini never had it. Now they do.

- New `simplify` plugin that reproduces the exact four-angle review and apply flow for Codex, Cursor, and Gemini
- Wires `/simplify` into the `commit-staged` and `create-pr` skills so every commit gets a cleanup pass first
- Records the run-before-every-commit rule in both CLAUDE.md files

`/plugin install simplify@claude-settings`
