### PR TITLE
Switch Codex install docs to two commands

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,11 +1,12 @@
-model = "gpt-5.4"
-model_reasoning_effort = "xhigh"
-model_provider = "azure"
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 web_search = "live"
 personality = "pragmatic"
 model_auto_compact_token_limit = 400000
+model_auto_compact_token_limit_scope = "body_after_prefix"
+service_tier = "default"
 
 [sandbox_workspace_write]
 network_access = true
@@ -13,8 +14,23 @@ network_access = true
 [analytics]
 enabled = false
 
-[model_providers.azure]
-name = "Azure OpenAI"
-base_url = "https://YOUR-AZURE-OPENAI.openai.azure.com/openai/v1"
-env_key = "AZURE_OPENAI_API_KEY"
-wire_api = "responses"
+[plugins."github-dev@claude-settings"]
+enabled = true
+
+[plugins."frontend-design-skills@claude-settings"]
+enabled = true
+
+[plugins."openai-office-skills@claude-settings"]
+enabled = true
+
+[plugins."agent-browser@claude-settings"]
+enabled = true
+
+[plugins."python-skills@claude-settings"]
+enabled = true
+
+[plugins."simplify@claude-settings"]
+enabled = true
+
+[plugins."ultralytics-dev@claude-settings"]
+enabled = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,9 +66,6 @@
     "[latex]": {
         "editor.wordWrap": "on"
     },
-    "[markdown]": {
-        "editor.formatOnSave": false
-    },
     "telemetry.telemetryLevel": "off",
     "git.autofetch": true,
     "diffEditor.ignoreTrimWhitespace": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,6 +66,9 @@
     "[latex]": {
         "editor.wordWrap": "on"
     },
+    "[markdown]": {
+        "editor.formatOnSave": false
+    },
     "telemetry.telemetryLevel": "off",
     "git.autofetch": true,
     "diffEditor.ignoreTrimWhitespace": false,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,7 +239,7 @@ Commands are Claude Code only. Gemini CLI uses TOML commands. Other tools use sk
 
 ```
 Claude Code: /plugin marketplace add fcakyon/claude-codex-settings
-Codex CLI:   use .agents/plugins/marketplace.json or ~/.agents/plugins/marketplace.json, restart Codex, then install from /plugins
+Codex CLI:   codex plugin marketplace add fcakyon/claude-codex-settings, then codex plugin add <name>@claude-settings
 Cursor:      import marketplace or /add-plugin
 Gemini CLI:  gemini extensions install --path ./plugins/<name>
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,21 +57,13 @@ Optionally install IDE extension:
 
 ### Codex Plugins
 
-Codex installs plugins from local marketplaces rather than a direct shell install command.
+```bash
+# Add marketplace (one time)
+codex plugin marketplace add fcakyon/claude-codex-settings
 
-#### Use This Repo in Codex
-
-1. Clone this repo locally.
-2. Open the repo in Codex. This repo already includes `.agents/plugins/marketplace.json`.
-3. If Codex was already open when you added or changed that marketplace file, restart Codex.
-4. In Codex, open `/plugins`.
-5. Choose `Claude & Codex Settings` and install the plugins you want.
-
-You do not need to create `~/.agents/plugins/marketplace.json` or copy plugin folders manually for this repo. The Codex marketplace is already part of the repository.
-
-If `Claude & Codex Settings` does not appear in `/plugins`, make sure you opened the repo root that contains `.agents/plugins/marketplace.json`, then restart Codex.
-
-For generic Codex marketplace examples and maintainer docs, see [CLAUDE.md](CLAUDE.md).
+# Install any plugin by name
+codex plugin add < plugin-name > @claude-settings
+```
 
 ### Gemini CLI
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,7 +62,7 @@ Optionally install IDE extension:
 codex plugin marketplace add fcakyon/claude-codex-settings
 
 # Install any plugin by name
-codex plugin add <plugin-name>@claude-settings
+codex plugin add simplify@claude-settings
 ```
 
 ### Gemini CLI
@@ -76,7 +76,7 @@ npm install -g @anthropic-ai/gemini-cli
 Install individual plugins:
 
 ```bash
-gemini extensions install --path ./plugins/<plugin-name>
+gemini extensions install --path ./plugins/simplify
 ```
 
 ### Required Tools

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,7 +62,7 @@ Optionally install IDE extension:
 codex plugin marketplace add fcakyon/claude-codex-settings
 
 # Install any plugin by name
-codex plugin add < plugin-name > @claude-settings
+codex plugin add <plugin-name>@claude-settings
 ```
 
 ### Gemini CLI

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Plugins add skills, commands, and automations to your AI coding tool. Install on
 /plugin marketplace add fcakyon/claude-codex-settings
 
 # Install any plugin by name
-/plugin install < plugin-name > @claude-settings
+/plugin install <plugin-name>@claude-settings
 ```
 
 </details>
@@ -46,7 +46,7 @@ Plugins add skills, commands, and automations to your AI coding tool. Install on
 codex plugin marketplace add fcakyon/claude-codex-settings
 
 # Install any plugin by name
-codex plugin add < plugin-name > @claude-settings
+codex plugin add <plugin-name>@claude-settings
 ```
 
 </details>
@@ -64,7 +64,7 @@ gemini extensions install --path ./plugins/<plugin-name>
 <summary><strong>Cursor</strong></summary>
 
 ```bash
-cursor plugin install < plugin-name > @claude-settings
+cursor plugin install <plugin-name>@claude-settings
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -41,16 +41,13 @@ Plugins add skills, commands, and automations to your AI coding tool. Install on
 <details>
 <summary><strong>Codex CLI</strong></summary>
 
-Codex installs plugins from a local marketplace rather than a direct shell install command.
+```bash
+# Add marketplace (one time)
+codex plugin marketplace add fcakyon/claude-codex-settings
 
-1. Clone this repo locally and open it in Codex.
-2. This repo already includes `.agents/plugins/marketplace.json`.
-3. If Codex was already open when you added or changed that file, restart Codex.
-4. In Codex, open `/plugins`.
-5. Choose `Claude & Codex Settings` and install the plugins you want.
-
-> This README only covers installing this marketplace.
-> For generic Codex marketplace examples and maintainer docs, see [CLAUDE.md](CLAUDE.md).
+# Install any plugin by name
+codex plugin add < plugin-name > @claude-settings
+```
 
 </details>
 
@@ -84,9 +81,9 @@ ln -sfn CLAUDE.md GEMINI.md
 <details>
 <summary><strong>simplify</strong> - Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups</summary>
 
-| Claude Code                                | Codex CLI                                                          | Gemini CLI                                            |
-| ------------------------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------- |
-| `/plugin install simplify@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `simplify` | `gemini extensions install --path ./plugins/simplify` |
+| Claude Code                                | Codex CLI                                   | Gemini CLI                                            |
+| ------------------------------------------ | ------------------------------------------- | ----------------------------------------------------- |
+| `/plugin install simplify@claude-settings` | `codex plugin add simplify@claude-settings` | `gemini extensions install --path ./plugins/simplify` |
 
 Run `/simplify` to review your staged or committed diff across four angles (reuse, simplification, efficiency, altitude) with parallel agents, then apply the cleanups. It reviews changed-code quality, not correctness bugs. It brings [Claude Code's built-in `/simplify`](https://code.claude.com/docs/en/code-review#review-a-diff-locally) to Codex, Cursor, and Gemini, which don't ship it natively, so all three get the same review and apply flow.
 
@@ -99,9 +96,9 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 <details>
 <summary><strong>fable-advisor</strong> - On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it</summary>
 
-| Claude Code                                     | Codex CLI                                                               | Gemini CLI                                                 |
-| ----------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `/plugin install fable-advisor@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `fable-advisor` | `gemini extensions install --path ./plugins/fable-advisor` |
+| Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |
+| ----------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| `/plugin install fable-advisor@claude-settings` | `codex plugin add fable-advisor@claude-settings` | `gemini extensions install --path ./plugins/fable-advisor` |
 
 Spawn a stronger Fable 5 reviewer to pressure-test a plan or conclusion before you commit, a drop-in for the built-in advisor when the Opus-main plus Fable-advisor pairing fails with a bare "unavailable" ([#73365](https://github.com/anthropics/claude-code/issues/73365)). It automatically receives the recent conversation, the same history the built-in advisor sees, so it reviews the real context instead of a hand-picked summary, and returns a skeptical review, not a rewrite.
 
@@ -114,9 +111,9 @@ Spawn a stronger Fable 5 reviewer to pressure-test a plan or conclusion before y
 <details>
 <summary><strong>intelligent-compact</strong> - Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions</summary>
 
-| Claude Code                                           | Codex CLI                                                                     | Gemini CLI                                                       |
-| ----------------------------------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `/plugin install intelligent-compact@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `intelligent-compact` | `gemini extensions install --path ./plugins/intelligent-compact` |
+| Claude Code                                           | Codex CLI                                              | Gemini CLI                                                       |
+| ----------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
+| `/plugin install intelligent-compact@claude-settings` | `codex plugin add intelligent-compact@claude-settings` | `gemini extensions install --path ./plugins/intelligent-compact` |
 
 When Claude Code auto-summarizes a long session, the default summary routinely drops the highest-signal facts. This plugin tells the summarizer to keep them:
 
@@ -157,9 +154,9 @@ Per-device data is already in Claude Code's built-in OpenTelemetry stream. Pairs
 <details>
 <summary><strong>anthropic-office-skills</strong> - Official Anthropic PDF, Word, PowerPoint, Excel skills</summary>
 
-| Claude Code                                               | Codex CLI                                                                         | Gemini CLI                                                           |
-| --------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `/plugin install anthropic-office-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `anthropic-office-skills` | `gemini extensions install --path ./plugins/anthropic-office-skills` |
+| Claude Code                                               | Codex CLI                                                  | Gemini CLI                                                           |
+| --------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------- |
+| `/plugin install anthropic-office-skills@claude-settings` | `codex plugin add anthropic-office-skills@claude-settings` | `gemini extensions install --path ./plugins/anthropic-office-skills` |
 
 **Skills CLI**
 
@@ -181,9 +178,9 @@ Official office document skills from [anthropics/skills](https://github.com/anth
 <details>
 <summary><strong>openai-office-skills</strong> - Official OpenAI PDF, Word, PowerPoint, Excel skills</summary>
 
-| Claude Code                                            | Codex CLI                                                                      | Gemini CLI                                                        |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
-| `/plugin install openai-office-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `openai-office-skills` | `gemini extensions install --path ./plugins/openai-office-skills` |
+| Claude Code                                            | Codex CLI                                               | Gemini CLI                                                        |
+| ------------------------------------------------------ | ------------------------------------------------------- | ----------------------------------------------------------------- |
+| `/plugin install openai-office-skills@claude-settings` | `codex plugin add openai-office-skills@claude-settings` | `gemini extensions install --path ./plugins/openai-office-skills` |
 
 **Skills CLI**
 
@@ -205,9 +202,9 @@ Official office document skills from [openai/skills](https://github.com/openai/s
 <details>
 <summary><strong>python-skills</strong> - Python best practices from PEP 8, Zen of Python, Google Style Guide, Effective Python</summary>
 
-| Claude Code                                     | Codex CLI                                                               | Gemini CLI                                                 |
-| ----------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `/plugin install python-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `python-skills` | `gemini extensions install --path ./plugins/python-skills` |
+| Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |
+| ----------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| `/plugin install python-skills@claude-settings` | `codex plugin add python-skills@claude-settings` | `gemini extensions install --path ./plugins/python-skills` |
 
 Python coding guidelines grounded in authoritative sources: PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Brett Slatkin's "Effective Python" (3rd ed.). Covers code integration, idiomatic patterns, YAGNI anti-abstraction rules, Google-style docstrings, and 18 before/after code examples.
 
@@ -229,9 +226,9 @@ Python coding guidelines grounded in authoritative sources: PEP 8, PEP 20 (Zen o
 <details>
 <summary><strong>react-skills</strong> - Official React, Next.js, and React Native best practices</summary>
 
-| Claude Code                                    | Codex CLI                                                              | Gemini CLI                                                |
-| ---------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install react-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `react-skills` | `gemini extensions install --path ./plugins/react-skills` |
+| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `/plugin install react-skills@claude-settings` | `codex plugin add react-skills@claude-settings` | `gemini extensions install --path ./plugins/react-skills` |
 
 **Skills CLI**
 
@@ -256,9 +253,9 @@ React and frontend best practices from [vercel-labs/agent-skills](https://github
 <details>
 <summary><strong>agent-browser</strong> - Official browser automation CLI for AI agents</summary>
 
-| Claude Code                                     | Codex CLI                                                               | Gemini CLI                                                 |
-| ----------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `/plugin install agent-browser@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `agent-browser` | `gemini extensions install --path ./plugins/agent-browser` |
+| Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |
+| ----------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| `/plugin install agent-browser@claude-settings` | `codex plugin add agent-browser@claude-settings` | `gemini extensions install --path ./plugins/agent-browser` |
 
 **Skills CLI**
 
@@ -282,9 +279,9 @@ Browser automation via CLI instead of MCP. [93% less context usage](https://medi
 <details>
 <summary><strong>frontend-design-skills</strong> - Official frontend design skills (Anthropic + OpenAI)</summary>
 
-| Claude Code                                              | Codex CLI                                                                        | Gemini CLI                                                          |
-| -------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `/plugin install frontend-design-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `frontend-design-skills` | `gemini extensions install --path ./plugins/frontend-design-skills` |
+| Claude Code                                              | Codex CLI                                                 | Gemini CLI                                                          |
+| -------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| `/plugin install frontend-design-skills@claude-settings` | `codex plugin add frontend-design-skills@claude-settings` | `gemini extensions install --path ./plugins/frontend-design-skills` |
 
 **Skills CLI**
 
@@ -304,9 +301,9 @@ Frontend design skills from [anthropics/claude-plugins-official](https://github.
 <details>
 <summary><strong>mongodb-skills</strong> - Official MongoDB agent skills for schema design, query tuning, and Atlas Search</summary>
 
-| Claude Code                                      | Codex CLI                                                                | Gemini CLI                                                  |
-| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| `/plugin install mongodb-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `mongodb-skills` | `gemini extensions install --path ./plugins/mongodb-skills` |
+| Claude Code                                      | Codex CLI                                         | Gemini CLI                                                  |
+| ------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
+| `/plugin install mongodb-skills@claude-settings` | `codex plugin add mongodb-skills@claude-settings` | `gemini extensions install --path ./plugins/mongodb-skills` |
 
 **Skills CLI**
 
@@ -333,9 +330,9 @@ Official MongoDB agent skills for schema design, query tuning, Atlas Search, and
 <details>
 <summary><strong>supabase-skills</strong> - Supabase Postgres best practices, JavaScript SDK, and CLI skills</summary>
 
-| Claude Code                                       | Codex CLI                                                                 | Gemini CLI                                                   |
-| ------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `/plugin install supabase-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `supabase-skills` | `gemini extensions install --path ./plugins/supabase-skills` |
+| Claude Code                                       | Codex CLI                                          | Gemini CLI                                                   |
+| ------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| `/plugin install supabase-skills@claude-settings` | `codex plugin add supabase-skills@claude-settings` | `gemini extensions install --path ./plugins/supabase-skills` |
 
 **Skills CLI**
 
@@ -358,9 +355,9 @@ Supabase skills covering Postgres query/schema best practices from [supabase/age
 <details>
 <summary><strong>stripe-skills</strong> - Official Stripe agent skills for payments, billing, Connect, and API upgrades</summary>
 
-| Claude Code                                     | Codex CLI                                                               | Gemini CLI                                                 |
-| ----------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `/plugin install stripe-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `stripe-skills` | `gemini extensions install --path ./plugins/stripe-skills` |
+| Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |
+| ----------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| `/plugin install stripe-skills@claude-settings` | `codex plugin add stripe-skills@claude-settings` | `gemini extensions install --path ./plugins/stripe-skills` |
 
 **Skills CLI**
 
@@ -383,9 +380,9 @@ Official Stripe agent skills for payment integration: API selection, Connect pla
 <details>
 <summary><strong>polar-skills</strong> - Official Polar agent skills for billing, subscriptions, and local dev environment</summary>
 
-| Claude Code                                    | Codex CLI                                                              | Gemini CLI                                                |
-| ---------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install polar-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `polar-skills` | `gemini extensions install --path ./plugins/polar-skills` |
+| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `/plugin install polar-skills@claude-settings` | `codex plugin add polar-skills@claude-settings` | `gemini extensions install --path ./plugins/polar-skills` |
 
 **Skills CLI**
 
@@ -407,9 +404,9 @@ Official Polar agent skills for billing system, Stripe integration, subscription
 <details>
 <summary><strong>livekit-skills</strong> - LiveKit voice AI agent development (Cloud + self-hosted)</summary>
 
-| Claude Code                                      | Codex CLI                                                                | Gemini CLI                                                  |
-| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| `/plugin install livekit-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `livekit-skills` | `gemini extensions install --path ./plugins/livekit-skills` |
+| Claude Code                                      | Codex CLI                                         | Gemini CLI                                                  |
+| ------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
+| `/plugin install livekit-skills@claude-settings` | `codex plugin add livekit-skills@claude-settings` | `gemini extensions install --path ./plugins/livekit-skills` |
 
 **Skills CLI**
 
@@ -430,9 +427,9 @@ Voice AI agent development with the LiveKit Agents SDK. Cloud-agnostic: supports
 <details>
 <summary><strong>cloudflare-skills</strong> - Official Cloudflare developer platform skill for Workers, R2, D1, KV, AI, and 50+ services</summary>
 
-| Claude Code                                         | Codex CLI                                                                   | Gemini CLI                                                     |
-| --------------------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `/plugin install cloudflare-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `cloudflare-skills` | `gemini extensions install --path ./plugins/cloudflare-skills` |
+| Claude Code                                         | Codex CLI                                            | Gemini CLI                                                     |
+| --------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
+| `/plugin install cloudflare-skills@claude-settings` | `codex plugin add cloudflare-skills@claude-settings` | `gemini extensions install --path ./plugins/cloudflare-skills` |
 
 **Skills CLI**
 
@@ -453,9 +450,9 @@ Cloudflare developer platform skill with decision trees for product selection ac
 <details>
 <summary><strong>web-performance-skills</strong> - Web performance auditing with Core Web Vitals, Lighthouse, and Chrome DevTools</summary>
 
-| Claude Code                                              | Codex CLI                                                                        | Gemini CLI                                                          |
-| -------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `/plugin install web-performance-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `web-performance-skills` | `gemini extensions install --path ./plugins/web-performance-skills` |
+| Claude Code                                              | Codex CLI                                                 | Gemini CLI                                                          |
+| -------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| `/plugin install web-performance-skills@claude-settings` | `codex plugin add web-performance-skills@claude-settings` | `gemini extensions install --path ./plugins/web-performance-skills` |
 
 **Skills CLI**
 
@@ -478,9 +475,9 @@ Bundles the `chrome-devtools` MCP server (no API key needed).
 <details>
 <summary><strong>openobserve-skills</strong> - OpenObserve REST API skill for AI agents to search logs/metrics/traces and create dashboards via curl</summary>
 
-| Claude Code                                          | Codex CLI                                                                    | Gemini CLI                                                      |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `/plugin install openobserve-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `openobserve-skills` | `gemini extensions install --path ./plugins/openobserve-skills` |
+| Claude Code                                          | Codex CLI                                             | Gemini CLI                                                      |
+| ---------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
+| `/plugin install openobserve-skills@claude-settings` | `codex plugin add openobserve-skills@claude-settings` | `gemini extensions install --path ./plugins/openobserve-skills` |
 
 **Skills CLI**
 
@@ -507,9 +504,9 @@ Built for AI agents: uses `curl` only, no SDK or CLI dependency. Pairs naturally
 <details>
 <summary><strong>hetzner-skills</strong> - Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, and storage</summary>
 
-| Claude Code                                      | Codex CLI                                                                | Gemini CLI                                                  |
-| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| `/plugin install hetzner-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `hetzner-skills` | `gemini extensions install --path ./plugins/hetzner-skills` |
+| Claude Code                                      | Codex CLI                                         | Gemini CLI                                                  |
+| ------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
+| `/plugin install hetzner-skills@claude-settings` | `codex plugin add hetzner-skills@claude-settings` | `gemini extensions install --path ./plugins/hetzner-skills` |
 
 **Skills CLI**
 
@@ -530,9 +527,9 @@ Hetzner Cloud infrastructure management via the `hcloud` CLI. Decision trees for
 <details>
 <summary><strong>dokploy-skills</strong> - Dokploy deployment skill for Dokploy Cloud and self-hosted dashboards</summary>
 
-| Claude Code                                      | Codex CLI                                                                | Gemini CLI                                                  |
-| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| `/plugin install dokploy-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `dokploy-skills` | `gemini extensions install --path ./plugins/dokploy-skills` |
+| Claude Code                                      | Codex CLI                                         | Gemini CLI                                                  |
+| ------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
+| `/plugin install dokploy-skills@claude-settings` | `codex plugin add dokploy-skills@claude-settings` | `gemini extensions install --path ./plugins/dokploy-skills` |
 
 **Skills CLI**
 
@@ -625,9 +622,9 @@ Academic research toolkit from [fcakyon/phd-skills](https://github.com/fcakyon/p
 <details>
 <summary><strong>github-dev</strong> - Git workflow agents + skills</summary>
 
-| Claude Code                                  | Codex CLI                                                            | Gemini CLI                                              |
-| -------------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------- |
-| `/plugin install github-dev@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `github-dev` | `gemini extensions install --path ./plugins/github-dev` |
+| Claude Code                                  | Codex CLI                                     | Gemini CLI                                              |
+| -------------------------------------------- | --------------------------------------------- | ------------------------------------------------------- |
+| `/plugin install github-dev@claude-settings` | `codex plugin add github-dev@claude-settings` | `gemini extensions install --path ./plugins/github-dev` |
 
 **Skills CLI**
 
@@ -664,9 +661,9 @@ Git and GitHub automation. Run the `setup` skill after install.
 <details>
 <summary><strong>ultralytics-dev</strong> - Auto-formatting hooks</summary>
 
-| Claude Code                                       | Codex CLI                                                                 | Gemini CLI                                                   |
-| ------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `/plugin install ultralytics-dev@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `ultralytics-dev` | `gemini extensions install --path ./plugins/ultralytics-dev` |
+| Claude Code                                       | Codex CLI                                          | Gemini CLI                                                   |
+| ------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| `/plugin install ultralytics-dev@claude-settings` | `codex plugin add ultralytics-dev@claude-settings` | `gemini extensions install --path ./plugins/ultralytics-dev` |
 
 Auto-formatting hooks for Python, JavaScript, Markdown, and Bash.
 
@@ -683,9 +680,9 @@ Auto-formatting hooks for Python, JavaScript, Markdown, and Bash.
 <details>
 <summary><strong>azure-tools</strong> - Azure MCP & Skills</summary>
 
-| Claude Code                                   | Codex CLI                                                             | Gemini CLI                                               |
-| --------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------- |
-| `/plugin install azure-tools@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `azure-tools` | `gemini extensions install --path ./plugins/azure-tools` |
+| Claude Code                                   | Codex CLI                                      | Gemini CLI                                               |
+| --------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `/plugin install azure-tools@claude-settings` | `codex plugin add azure-tools@claude-settings` | `gemini extensions install --path ./plugins/azure-tools` |
 
 **Skills CLI**
 
@@ -711,9 +708,9 @@ npx skills add https://github.com/fcakyon/claude-codex-settings/tree/main/plugin
 <details>
 <summary><strong>claude-tools</strong> - Sync CLAUDE.md + allowlist + context refresh</summary>
 
-| Claude Code                                    | Codex CLI                                                              | Gemini CLI                                                |
-| ---------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install claude-tools@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `claude-tools` | `gemini extensions install --path ./plugins/claude-tools` |
+| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `/plugin install claude-tools@claude-settings` | `codex plugin add claude-tools@claude-settings` | `gemini extensions install --path ./plugins/claude-tools` |
 
 Commands for syncing CLAUDE.md and permissions allowlist from repository, plus context refresh for long conversations.
 
@@ -732,9 +729,9 @@ Commands for syncing CLAUDE.md and permissions allowlist from repository, plus c
 <details>
 <summary><strong>gcloud-tools</strong> - GCloud MCP & Skills</summary>
 
-| Claude Code                                    | Codex CLI                                                              | Gemini CLI                                                |
-| ---------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install gcloud-tools@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `gcloud-tools` | `gemini extensions install --path ./plugins/gcloud-tools` |
+| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `/plugin install gcloud-tools@claude-settings` | `codex plugin add gcloud-tools@claude-settings` | `gemini extensions install --path ./plugins/gcloud-tools` |
 
 **Skills CLI**
 
@@ -760,9 +757,9 @@ Logs, metrics, and traces. Run `/gcloud-tools:setup` after install.
 <details>
 <summary><strong>paper-search-tools</strong> - Paper Search MCP & Skills</summary>
 
-| Claude Code                                          | Codex CLI                                                                    | Gemini CLI                                                      |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `/plugin install paper-search-tools@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `paper-search-tools` | `gemini extensions install --path ./plugins/paper-search-tools` |
+| Claude Code                                          | Codex CLI                                             | Gemini CLI                                                      |
+| ---------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
+| `/plugin install paper-search-tools@claude-settings` | `codex plugin add paper-search-tools@claude-settings` | `gemini extensions install --path ./plugins/paper-search-tools` |
 
 **Skills CLI**
 
@@ -788,9 +785,9 @@ Search papers across arXiv, PubMed, IEEE, Scopus, ACM. Run `/paper-search-tools:
 <details>
 <summary><strong>tavily-tools</strong> - Tavily MCP & Skills</summary>
 
-| Claude Code                                    | Codex CLI                                                              | Gemini CLI                                                |
-| ---------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install tavily-tools@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `tavily-tools` | `gemini extensions install --path ./plugins/tavily-tools` |
+| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `/plugin install tavily-tools@claude-settings` | `codex plugin add tavily-tools@claude-settings` | `gemini extensions install --path ./plugins/tavily-tools` |
 
 **Skills CLI**
 
@@ -822,9 +819,9 @@ Web search and content extraction. Run `/tavily-tools:setup` after install.
 <details>
 <summary><strong>overleaf-skills</strong> - Pull Overleaf review comments into your local .tex repo and apply the suggested edits</summary>
 
-| Claude Code                                       | Codex CLI                                                                 | Gemini CLI                                                   |
-| ------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `/plugin install overleaf-skills@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `overleaf-skills` | `gemini extensions install --path ./plugins/overleaf-skills` |
+| Claude Code                                       | Codex CLI                                          | Gemini CLI                                                   |
+| ------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| `/plugin install overleaf-skills@claude-settings` | `codex plugin add overleaf-skills@claude-settings` | `gemini extensions install --path ./plugins/overleaf-skills` |
 
 **Skills CLI**
 
@@ -844,9 +841,9 @@ Pull reviewer comments from an Overleaf project, locate each in your local git-t
 <details>
 <summary><strong>adhd-output-style</strong> - Answer-first replies with numbered steps, a clear next action, and short teaching notes</summary>
 
-| Claude Code                                         | Codex CLI                                                                   | Gemini CLI                                                     |
-| --------------------------------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `/plugin install adhd-output-style@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `adhd-output-style` | `gemini extensions install --path ./plugins/adhd-output-style` |
+| Claude Code                                         | Codex CLI                                            | Gemini CLI                                                     |
+| --------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
+| `/plugin install adhd-output-style@claude-settings` | `codex plugin add adhd-output-style@claude-settings` | `gemini extensions install --path ./plugins/adhd-output-style` |
 
 Reformats every reply for limited working memory: the answer or next step first, numbered one-action-per-step lists, concrete time estimates, a single under-two-minute next action, and short teaching notes while coding. Enabling the plugin applies the style automatically. Output styles apply in Claude Code.
 
@@ -942,9 +939,9 @@ For Codex CLI, see the recipe at [`.codex/config-minimax.toml`](./.codex/config-
 
 Configuration in [`~/.codex/config.toml`](./.codex/config.toml):
 
-- **Model**: `gpt-5.4` with `model_reasoning_effort` set to "high"
-- **Provider**: Azure via `responses` API surface
-- **Auth**: Project-specific base URL with `env_key` authentication
+- **Model**: `gpt-5.6-terra` with `model_reasoning_effort` set to "high"
+- **Sandbox**: `workspace-write` with network access enabled
+- **Plugins**: a curated set enabled from this marketplace (`simplify`, `github-dev`, `python-skills`, and more)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Plugins add skills, commands, and automations to your AI coding tool. Install on
 /plugin marketplace add fcakyon/claude-codex-settings
 
 # Install any plugin by name
-/plugin install <plugin-name>@claude-settings
+/plugin install simplify@claude-settings
 ```
 
 </details>
@@ -46,7 +46,7 @@ Plugins add skills, commands, and automations to your AI coding tool. Install on
 codex plugin marketplace add fcakyon/claude-codex-settings
 
 # Install any plugin by name
-codex plugin add <plugin-name>@claude-settings
+codex plugin add simplify@claude-settings
 ```
 
 </details>
@@ -55,7 +55,8 @@ codex plugin add <plugin-name>@claude-settings
 <summary><strong>Gemini CLI</strong></summary>
 
 ```bash
-gemini extensions install --path ./plugins/<plugin-name>
+# Install any plugin by name
+gemini extensions install --path ./plugins/simplify
 ```
 
 </details>
@@ -64,7 +65,8 @@ gemini extensions install --path ./plugins/<plugin-name>
 <summary><strong>Cursor</strong></summary>
 
 ```bash
-cursor plugin install <plugin-name>@claude-settings
+# Install any plugin by name
+cursor plugin install simplify@claude-settings
 ```
 
 </details>


### PR DESCRIPTION
Replace the clone-and-`/plugins` Codex flow with the two-command marketplace install across the README, INSTALL, and dev guide, and refresh the example `.codex/config.toml` (drop the Azure provider, align the model, add enabled plugins).

```
codex plugin marketplace add fcakyon/claude-codex-settings
codex plugin add <plugin-name>@claude-settings
```