### PR TITLE
Align docstring formatter with upstream ultralytics/actions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -332,7 +332,7 @@
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -153,7 +153,7 @@
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/gemini-extension.json
+++ b/plugins/ultralytics-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks."
 }

--- a/plugins/ultralytics-dev/hooks/scripts/format_python_docstrings.py
+++ b/plugins/ultralytics-dev/hooks/scripts/format_python_docstrings.py
@@ -369,15 +369,11 @@ def format_docstring(
     text = content.strip()
     has_section = any(f"{s}:" in text for s in SECTIONS)
     has_list = any(is_list_item(line) for line in text.splitlines())
-    single_ok = (
-        ("\n" not in text)
-        and not has_section
-        and not has_list
-        and (indent + len(prefix) + len(quotes) * 2 + len(text) <= width)
-    )
+    single_ok = ("\n" not in text) and not has_section and not has_list
     if single_ok:
         words = text.split()
-        if words and not words[0].startswith(("http://", "https://")) and not words[0][0].isupper():
+        core = words[0].rstrip(".") if words else ""  # ignore terminal dots so only interior ones mark identifiers
+        if core.islower() and not any(c in core for c in "_./`("):
             words[0] = words[0][0].upper() + words[0][1:]
         out = " ".join(words)
         if out and out[-1] not in ".!?":


### PR DESCRIPTION
Ports the `ultralytics-dev` docstring formatter hook to the current ultralytics/actions canonical logic and bumps the plugin to 2.1.2 across all six manifest and marketplace entries.

- Single-sentence docstrings now stay single-line past 120 columns (dropped the width cap)
- The first-word capitalization guard skips dotted or underscored tokens, so `torch.load reads a checkpoint` is left as-is while `loads a checkpoint` becomes `Loads a checkpoint.`
