### PR TITLE
Require /simplify before each git commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.claude/settings-kimi.json
+++ b/.claude/settings-kimi.json
@@ -155,6 +155,26 @@
             "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); S=$(printf \"%s\" \"$CMD\" | sed -e \"s/'\\''[^'\\'']*'\\''//g\" -e \"s/\\\"[^\\\"]*\\\"//g\"); if printf \"%s\" \"$S\" | grep -qE \"(^|[;&|(){}]|[[:space:]]do|[[:space:]]then|[[:space:]]else)[[:space:]]*timeout[[:space:]]\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"macOS has no timeout command on this host, so timeout N ... exits 127 with empty output and silently hides the real result (a remote ssh sweep can look idle when it is not). Use ssh -o ConnectTimeout=N, or gtimeout N (brew coreutils), or for a remote Linux host put timeout inside the ssh quotes.\\\"}}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); (re.search(r\"git\\s+commit(?![\\w-])\",c) and not m.exists()) and print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}}))'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c 'import json,os,sys,pathlib; d=json.load(sys.stdin); ti=d.get(\"tool_input\") or {}; s=d.get(\"session_id\") or \"nosession\"; p=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"; (ti.get(\"skill\")==\"simplify\" or ti.get(\"name\")==\"simplify\") and (p.mkdir(parents=True,exist_ok=True) or (p/(s+\".ok\")).touch())'"
+          }
+        ]
       }
     ]
   },

--- a/.claude/settings-minimax.json
+++ b/.claude/settings-minimax.json
@@ -155,6 +155,26 @@
             "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); S=$(printf \"%s\" \"$CMD\" | sed -e \"s/'\\''[^'\\'']*'\\''//g\" -e \"s/\\\"[^\\\"]*\\\"//g\"); if printf \"%s\" \"$S\" | grep -qE \"(^|[;&|(){}]|[[:space:]]do|[[:space:]]then|[[:space:]]else)[[:space:]]*timeout[[:space:]]\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"macOS has no timeout command on this host, so timeout N ... exits 127 with empty output and silently hides the real result (a remote ssh sweep can look idle when it is not). Use ssh -o ConnectTimeout=N, or gtimeout N (brew coreutils), or for a remote Linux host put timeout inside the ssh quotes.\\\"}}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); (re.search(r\"git\\s+commit(?![\\w-])\",c) and not m.exists()) and print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}}))'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c 'import json,os,sys,pathlib; d=json.load(sys.stdin); ti=d.get(\"tool_input\") or {}; s=d.get(\"session_id\") or \"nosession\"; p=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"; (ti.get(\"skill\")==\"simplify\" or ti.get(\"name\")==\"simplify\") and (p.mkdir(parents=True,exist_ok=True) or (p/(s+\".ok\")).touch())'"
+          }
+        ]
       }
     ]
   },

--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -154,6 +154,26 @@
             "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); S=$(printf \"%s\" \"$CMD\" | sed -e \"s/'\\''[^'\\'']*'\\''//g\" -e \"s/\\\"[^\\\"]*\\\"//g\"); if printf \"%s\" \"$S\" | grep -qE \"(^|[;&|(){}]|[[:space:]]do|[[:space:]]then|[[:space:]]else)[[:space:]]*timeout[[:space:]]\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"macOS has no timeout command on this host, so timeout N ... exits 127 with empty output and silently hides the real result (a remote ssh sweep can look idle when it is not). Use ssh -o ConnectTimeout=N, or gtimeout N (brew coreutils), or for a remote Linux host put timeout inside the ssh quotes.\\\"}}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); (re.search(r\"git\\s+commit(?![\\w-])\",c) and not m.exists()) and print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}}))'"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c 'import json,os,sys,pathlib; d=json.load(sys.stdin); ti=d.get(\"tool_input\") or {}; s=d.get(\"session_id\") or \"nosession\"; p=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"; (ti.get(\"skill\")==\"simplify\" or ti.get(\"name\")==\"simplify\") and (p.mkdir(parents=True,exist_ok=True) or (p/(s+\".ok\")).touch())'"
+          }
+        ]
       }
     ]
   },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -143,6 +143,15 @@
             "command": "bash -c 'CMD=$(jq -r \".tool_input.command\"); S=$(printf \"%s\" \"$CMD\" | sed -e \"s/'\\''[^'\\'']*'\\''//g\" -e \"s/\\\"[^\\\"]*\\\"//g\"); if printf \"%s\" \"$S\" | grep -qE \"(^|[;&|(){}]|[[:space:]]do|[[:space:]]then|[[:space:]]else)[[:space:]]*timeout[[:space:]]\"; then printf \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"macOS has no timeout command on this host, so timeout N ... exits 127 with empty output and silently hides the real result (a remote ssh sweep can look idle when it is not). Use ssh -o ConnectTimeout=N, or gtimeout N (brew coreutils), or for a remote Linux host put timeout inside the ssh quotes.\\\"}}\"; fi'"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); (re.search(r\"git\\s+commit(?![\\w-])\",c) and not m.exists()) and print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}}))'"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -152,6 +161,15 @@
           {
             "type": "command",
             "command": "bash -c 'F=$(jq -r \".tool_input.file_path // empty\"); case \"$F\" in *plugins/*/hooks/scripts/*.py|*.github/scripts/*.py) if command -v ruff >/dev/null 2>&1; then ruff check \"$F\" 2>&1 || true; elif command -v uvx >/dev/null 2>&1; then uvx ruff check \"$F\" 2>&1 || true; fi ;; esac'"
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c 'import json,os,sys,pathlib; d=json.load(sys.stdin); ti=d.get(\"tool_input\") or {}; s=d.get(\"session_id\") or \"nosession\"; p=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"; (ti.get(\"skill\")==\"simplify\" or ti.get(\"name\")==\"simplify\") and (p.mkdir(parents=True,exist_ok=True) or (p/(s+\".ok\")).touch())'"
           }
         ]
       }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "simplify",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups."
 }

--- a/plugins/simplify/hooks/hooks.json
+++ b/plugins/simplify/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "simplify-guard: require /simplify before git commit (per session)",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [{ "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py\"" }]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py\"" }]
+      }
+    ]
+  }
+}

--- a/plugins/simplify/hooks/hooks.json
+++ b/plugins/simplify/hooks/hooks.json
@@ -4,13 +4,13 @@
     "PostToolUse": [
       {
         "matcher": "Skill",
-        "hooks": [{ "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py\"" }]
+        "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py"] }]
       }
     ],
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hooks": [{ "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py\"" }]
+        "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py"] }]
       }
     ]
   }

--- a/plugins/simplify/hooks/scripts/guard.py
+++ b/plugins/simplify/hooks/scripts/guard.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Block `git commit` until /simplify ran this session.
+
+Per-session marker under TMPDIR (keyed by session_id), so a new session re-requires /simplify.
+Harness-agnostic hook contract, so Codex, which installs this plugin's /simplify, is guarded too.
+"""
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+data = json.load(sys.stdin)
+event = data.get("hook_event_name", "")
+session_id = data.get("session_id") or "nosession"
+marker = Path(os.environ.get("TMPDIR", "/tmp")) / "simplify-guard" / f"{session_id}.ok"
+tool_input = data.get("tool_input") or {}
+
+if event == "PostToolUse":  # matcher scopes to the Skill tool; confirm it was /simplify
+    if tool_input.get("skill") == "simplify" or tool_input.get("name") == "simplify":
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+elif event == "PreToolUse":  # matcher scopes to Bash; self-filter to `git commit` (not commit-graph/-tree)
+    if re.search(r"git\s+commit(?![\w-])", tool_input.get("command", "")) and not marker.exists():
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": "simplify-guard: run /simplify on the staged diff first, then retry the commit.",
+                    }
+                }
+            )
+        )


### PR DESCRIPTION
Blocks `git commit` until you have run /simplify on the staged diff in the current session, so the tidy-up step stops getting skipped.

- ships two ways so it works whether or not you install the plugin: inside the simplify plugin (for Codex and Gemini) and inline in all Claude settings files
- uses only python3, no jq needed, and a per-session marker so each new session asks again
- only real commits trigger it, plumbing like `git commit-graph` and `git commit-tree` pass through