### PR TITLE
Enforce /simplify before every commit, not once per session

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.claude/settings-kimi.json
+++ b/.claude/settings-kimi.json
@@ -161,7 +161,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); (re.search(r\"git\\s+commit(?![\\w-])\",c) and not m.exists()) and print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}}))'"
+            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); re.search(r\"git\\s+commit(?![\\w-])\",c) and (m.unlink() if m.exists() else print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}})))'"
           }
         ]
       }

--- a/.claude/settings-minimax.json
+++ b/.claude/settings-minimax.json
@@ -161,7 +161,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); (re.search(r\"git\\s+commit(?![\\w-])\",c) and not m.exists()) and print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}}))'"
+            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); re.search(r\"git\\s+commit(?![\\w-])\",c) and (m.unlink() if m.exists() else print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}})))'"
           }
         ]
       }

--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -160,7 +160,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); (re.search(r\"git\\s+commit(?![\\w-])\",c) and not m.exists()) and print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}}))'"
+            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); re.search(r\"git\\s+commit(?![\\w-])\",c) and (m.unlink() if m.exists() else print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}})))'"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -149,7 +149,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); (re.search(r\"git\\s+commit(?![\\w-])\",c) and not m.exists()) and print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}}))'"
+            "command": "python3 -c 'import json,os,re,sys,pathlib; d=json.load(sys.stdin); c=(d.get(\"tool_input\") or {}).get(\"command\",\"\"); s=d.get(\"session_id\") or \"nosession\"; m=pathlib.Path(os.environ.get(\"TMPDIR\",\"/tmp\"))/\"simplify-guard\"/(s+\".ok\"); re.search(r\"git\\s+commit(?![\\w-])\",c) and (m.unlink() if m.exists() else print(json.dumps({\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"simplify-guard: run /simplify on the staged diff first, then retry the commit.\"}})))'"
           }
         ]
       }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "simplify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups."
 }

--- a/plugins/simplify/hooks/scripts/guard.py
+++ b/plugins/simplify/hooks/scripts/guard.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Block `git commit` until /simplify ran this session.
+"""Block `git commit` until /simplify runs. Each commit spends one /simplify.
 
-Per-session marker under TMPDIR (keyed by session_id), so a new session re-requires /simplify.
+Per-session marker under TMPDIR (keyed by session_id) is a one-shot token: /simplify mints it,
+the next commit consumes it, so every commit re-requires a fresh /simplify.
 Harness-agnostic hook contract, so Codex, which installs this plugin's /simplify, is guarded too.
 """
 import json
@@ -16,12 +17,15 @@ session_id = data.get("session_id") or "nosession"
 marker = Path(os.environ.get("TMPDIR", "/tmp")) / "simplify-guard" / f"{session_id}.ok"
 tool_input = data.get("tool_input") or {}
 
-if event == "PostToolUse":  # matcher scopes to the Skill tool; confirm it was /simplify
+if event == "PostToolUse":  # matcher scopes to the Skill tool, confirm it was /simplify
     if tool_input.get("skill") == "simplify" or tool_input.get("name") == "simplify":
         marker.parent.mkdir(parents=True, exist_ok=True)
         marker.touch()
-elif event == "PreToolUse":  # matcher scopes to Bash; self-filter to `git commit` (not commit-graph/-tree)
-    if re.search(r"git\s+commit(?![\w-])", tool_input.get("command", "")) and not marker.exists():
+elif event == "PreToolUse" and re.search(r"git\s+commit(?![\w-])", tool_input.get("command", "")):
+    # matcher scopes to Bash, self-filter to `git commit` (not commit-graph/-tree)
+    if marker.exists():
+        marker.unlink()  # spend the token: this commit uses up the pending /simplify
+    else:
         print(
             json.dumps(
                 {


### PR DESCRIPTION
The marker is now a one-shot token. /simplify mints it and the next commit spends it, so every commit re-requires a fresh /simplify instead of one unlocking the whole session.

- no new hook and no git calls, it only changes the guard branch to consume the token on an allowed commit
- a failed commit still spends the token, so the retry re-requires /simplify, which is the safe direction for this guard