### PR TITLE
Add a humanize hook that flags AI-tell wording as you write

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -351,6 +351,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "developer-tools"
+    },
+    {
+      "name": "humanize",
+      "source": {
+        "source": "local",
+        "path": "./plugins/humanize"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "developer-tools"
     }
   ]
 }

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -17,6 +17,18 @@
       "category": "developer-tools"
     },
     {
+      "name": "humanize",
+      "source": {
+        "source": "local",
+        "path": "./plugins/humanize"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "developer-tools"
+    },
+    {
       "name": "fable-advisor",
       "source": {
         "source": "local",
@@ -345,18 +357,6 @@
       "source": {
         "source": "local",
         "path": "./plugins/adhd-output-style"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "developer-tools"
-    },
-    {
-      "name": "humanize",
-      "source": {
-        "source": "local",
-        "path": "./plugins/humanize"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -447,6 +447,21 @@
       "keywords": ["output-style", "adhd", "formatting", "accessibility", "productivity"],
       "category": "developer-tools",
       "tags": ["output-style", "productivity", "accessibility"]
+    },
+    {
+      "name": "humanize",
+      "source": "./plugins/humanize",
+      "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["humanize", "writing", "markdown", "docstring", "lint"],
+      "category": "developer-tools",
+      "tags": ["writing", "lint"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,6 +24,21 @@
       "tags": ["cleanup", "refactor"]
     },
     {
+      "name": "humanize",
+      "source": "./plugins/humanize",
+      "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["humanize", "writing", "markdown", "docstring", "lint"],
+      "category": "developer-tools",
+      "tags": ["writing", "lint"]
+    },
+    {
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
@@ -447,21 +462,6 @@
       "keywords": ["output-style", "adhd", "formatting", "accessibility", "productivity"],
       "category": "developer-tools",
       "tags": ["output-style", "productivity", "accessibility"]
-    },
-    {
-      "name": "humanize",
-      "source": "./plugins/humanize",
-      "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
-      "version": "1.0.0",
-      "author": {
-        "name": "Fatih Akyon"
-      },
-      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
-      "repository": "https://github.com/fcakyon/claude-codex-settings",
-      "license": "Apache-2.0",
-      "keywords": ["humanize", "writing", "markdown", "docstring", "lint"],
-      "category": "developer-tools",
-      "tags": ["writing", "lint"]
     }
   ]
 }

--- a/.claude/settings-kimi.json
+++ b/.claude/settings-kimi.json
@@ -183,7 +183,8 @@
   "enabledPlugins": {
     "adhd-output-style@claude-settings": true,
     "intelligent-compact@claude-settings": true,
-    "github-dev@claude-settings": true
+    "github-dev@claude-settings": true,
+    "humanize@claude-settings": true
   },
   "extraKnownMarketplaces": {
     "claude-settings": {

--- a/.claude/settings-minimax.json
+++ b/.claude/settings-minimax.json
@@ -183,7 +183,8 @@
   "enabledPlugins": {
     "adhd-output-style@claude-settings": true,
     "intelligent-compact@claude-settings": true,
-    "github-dev@claude-settings": true
+    "github-dev@claude-settings": true,
+    "humanize@claude-settings": true
   },
   "extraKnownMarketplaces": {
     "claude-settings": {

--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -182,7 +182,8 @@
   "enabledPlugins": {
     "adhd-output-style@claude-settings": true,
     "intelligent-compact@claude-settings": true,
-    "github-dev@claude-settings": true
+    "github-dev@claude-settings": true,
+    "humanize@claude-settings": true
   },
   "extraKnownMarketplaces": {
     "claude-settings": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -252,7 +252,8 @@
   "enabledPlugins": {
     "adhd-output-style@claude-settings": true,
     "intelligent-compact@claude-settings": true,
-    "github-dev@claude-settings": true
+    "github-dev@claude-settings": true,
+    "humanize@claude-settings": true
   },
   "extraKnownMarketplaces": {
     "claude-settings": {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -32,5 +32,8 @@ enabled = true
 [plugins."simplify@claude-settings"]
 enabled = true
 
+[plugins."humanize@claude-settings"]
+enabled = true
+
 [plugins."ultralytics-dev@claude-settings"]
 enabled = true

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -10,6 +10,13 @@
       "license": "Apache-2.0"
     },
     {
+      "name": "humanize",
+      "source": "./plugins/humanize",
+      "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    },
+    {
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it.",
@@ -202,13 +209,6 @@
       "name": "adhd-output-style",
       "source": "./plugins/adhd-output-style",
       "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
-      "version": "1.0.0",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "humanize",
-      "source": "./plugins/humanize",
-      "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
       "version": "1.0.0",
       "license": "Apache-2.0"
     }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -204,6 +204,13 @@
       "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
       "version": "1.0.0",
       "license": "Apache-2.0"
+    },
+    {
+      "name": "humanize",
+      "source": "./plugins/humanize",
+      "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 </details>
 
 <details>
+<summary><strong>humanize</strong> - Flag AI-tell wording in your markdown, comments, and docstrings before a write lands, with plain-word swaps</summary>
+
+| Claude Code                                | Codex CLI | Gemini CLI                                            |
+| ------------------------------------------ | --------- | ----------------------------------------------------- |
+| `/plugin install humanize@claude-settings` | n/a       | `gemini extensions install --path ./plugins/humanize` |
+
+Before a Write or Edit saves, humanize scans the text and blocks the parts that read like a machine wrote them, each with a shorter human word to use instead. It only reads markdown files and, inside code, the comments and docstrings, never the code itself:
+
+- **Marks** the em-dash, section sign, and stray semicolons in prose (the en-dash stays)
+- **Stock words** like `leverage`, `seamlessly`, `vibrant`, or `game-changing`, each mapped to a plain swap
+- **Tired openers and cliches** like `in conclusion`, `a testament to`, or `aims to bridge`
+- **Filler that only grates in bulk** like `crucial` or `significant`, flagged when it piles up in one write
+
+Runs on Claude Code and Gemini, which fire a hook before a file is written. Word list draws on [Wikipedia's "Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing).
+
+**Hooks:**
+
+- [`humanize.py`](./plugins/humanize/hooks/scripts/humanize.py) - flags AI-tell marks, words, and cliches before a Write or Edit lands
+
+</details>
+
+<details>
 <summary><strong>fable-advisor</strong> - On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it</summary>
 
 | Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "humanize",
+  "version": "1.0.0",
+  "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
+  "license": "Apache-2.0"
+}

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "humanize",
+  "version": "1.0.0",
+  "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
+  "license": "Apache-2.0"
+}

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "humanize",
+  "version": "1.0.0",
+  "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions.",
+  "license": "Apache-2.0"
+}

--- a/plugins/humanize/gemini-extension.json
+++ b/plugins/humanize/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "humanize",
+  "version": "1.0.0",
+  "description": "Keep AI-tell wording out of your markdown, comments, and docstrings by flagging em-dashes, section signs, semicolons, filler words, and cliches, with plain-word suggestions."
+}

--- a/plugins/humanize/hooks/hooks.json
+++ b/plugins/humanize/hooks/hooks.json
@@ -1,0 +1,19 @@
+{
+  "description": "humanize: flag AI-tell wording in markdown, comments, and docstrings before a Write or Edit lands",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3",
+            "args": [
+              "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/humanize.py"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Flag AI-tell wording before a Write or Edit lands, so drafted text reads human.
+
+Checks markdown files whole, and in code files only the comment and docstring lines,
+never real code. Always blocks a few marks and stock words, each with a plain swap, and
+flags a wider set of common words only when they pile up. En-dash is allowed. The pile-up
+count sees one write at a time, so it is exact on a whole-file Write and partial on an Edit.
+"""
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+# always blocked on any hit, each mapped to a plain replacement
+SWAP = {
+    "leverage": "use", "utilize": "use", "plethora": "many", "myriad": "many",
+    "delve": "look at", "paradigm": "model", "tapestry": "mix", "showcase": "show",
+    "prose": "text", "realm": "area", "landscape": "field", "innovative": "new",
+    "transformative": "major", "unprecedented": "new", "consolidate": "merge",
+    "modernize": "update", "streamline": "simplify", "flexible": "adjustable",
+    "establish": "set up", "enhanced": "better", "comprehensive": "full", "optimize": "improve",
+}
+
+# always blocked cliches and filler openers, each mapped to a short fix note
+PHRASES = [
+    (r"ever[- ]evolving", "drop 'ever-evolving'"),
+    (r"fast[- ]paced world", "drop 'fast-paced world'"),
+    (r"a testament to", "say what it shows"),
+    (r"vibrant tapestry", "drop the cliche"),
+    (r"aims to explore", "say 'covers'"),
+    (r"it is important to note", "state the point"),
+    (r"as an ai language model", "drop it"),
+    (r"in conclusion", "drop it"),
+    (r"in summary", "drop it"),
+    (r"to sum up", "drop it"),
+    (r"plays? a \w+ role in shaping", "say what it does"),
+]
+
+# fine once, an AI-tell when repeated, flagged at LIMIT or more
+LIMIT = 3
+OFTEN = ["crucial", "essential", "vital", "significant", "moreover", "furthermore", "additionally", "aligns", "explore"]
+
+MARKS = {"—": "em-dash, use commas or periods", "§": "section sign", ";": "semicolon, use a period or comma"}
+SWAP_RE = re.compile(r"\b(" + "|".join(SWAP) + r")\b", re.IGNORECASE)
+OFTEN_RE = re.compile(r"\b(" + "|".join(OFTEN) + r")\b", re.IGNORECASE)
+
+MD_EXT = {".md", ".markdown", ".mdx", ".txt"}
+HASH_EXT = {".py", ".sh", ".bash", ".zsh", ".rb", ".yaml", ".yml", ".toml"}
+C_EXT = {".js", ".ts", ".jsx", ".tsx", ".c", ".cc", ".cpp", ".h", ".hpp", ".java", ".go", ".rs", ".css", ".scss", ".swift", ".kt", ".php"}
+
+
+def md_text(text):
+    """Return markdown with fenced and inline code removed."""
+    text = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    return re.sub(r"`[^`]*`", "", text)
+
+
+def hash_comments(text):
+    """Return line-start docstrings and hash comment tails from a hash-comment language."""
+    out = re.findall(r'^[ \t]*[rbuRBU]*"""(.*?)"""', text, flags=re.DOTALL | re.MULTILINE)
+    out += re.findall(r"^[ \t]*[rbuRBU]*'''(.*?)'''", text, flags=re.DOTALL | re.MULTILINE)
+    out += [m.group(1) for line in text.splitlines() if (m := re.search(r"(?:^|\s)#(.*)", line))]
+    return "\n".join(out)
+
+
+def c_comments(text):
+    """Return block comments and double-slash comment tails from a C-style language."""
+    out = re.findall(r"/\*(.*?)\*/", text, flags=re.DOTALL)
+    out += [m.group(1) for line in text.splitlines() if (m := re.search(r"(?:^|\s)//(.*)", line))]
+    return "\n".join(out)
+
+
+def checked(path, text):
+    """Return the text regions to check for the file type, empty for unknown types."""
+    ext = Path(path).suffix.lower()
+    if ext in MD_EXT:
+        return md_text(text)
+    if ext in HASH_EXT:
+        return hash_comments(text)
+    if ext in C_EXT:
+        return c_comments(text)
+    return ""
+
+
+data = json.load(sys.stdin)
+tool_input = data.get("tool_input") or {}
+chunks = [tool_input.get("content", ""), tool_input.get("new_string", "")]
+chunks += [e.get("new_string", "") for e in tool_input.get("edits", []) if isinstance(e, dict)]
+text = checked(tool_input.get("file_path", ""), "\n".join(c for c in chunks if c))
+
+notes = [f"remove {label}" for ch, label in MARKS.items() if ch in text]
+notes += [f"'{w}' to '{SWAP[w]}'" for w in dict.fromkeys(m.group(1).lower() for m in SWAP_RE.finditer(text))]
+notes += [note for pat, note in PHRASES if re.search(pat, text, re.IGNORECASE)]
+counts = Counter(m.group(1).lower() for m in OFTEN_RE.finditer(text))
+notes += [f"'{w}' used {n} times, vary it" for w, n in counts.items() if n >= LIMIT]
+
+if notes:
+    reason = "humanize: " + ", ".join(notes) + ". Applies to markdown, comments, and docstrings."
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}))

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -5,6 +5,9 @@ Checks markdown files whole, and in code files only the comment and docstring li
 never real code. Always blocks a few marks and stock words, each with a plain swap, and
 flags a wider set of common words only when they pile up. En-dash is allowed. The pile-up
 count sees one write at a time, so it is exact on a whole-file Write and partial on an Edit.
+
+Word choices draw on Wikipedia "Signs of AI writing":
+https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
 """
 import json
 import re
@@ -12,7 +15,9 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-# always blocked on any hit, each mapped to a plain replacement
+# TODO: build a companion guidance skill from that page's pitfalls, not only its word list
+
+# always blocked on any hit, each mapped to a plain swap or a short "drop it" note
 SWAP = {
     "leverage": "use", "utilize": "use", "plethora": "many", "myriad": "many",
     "delve": "look at", "paradigm": "model", "tapestry": "mix", "showcase": "show",
@@ -20,6 +25,14 @@ SWAP = {
     "transformative": "major", "unprecedented": "new", "consolidate": "merge",
     "modernize": "update", "streamline": "simplify", "flexible": "adjustable",
     "establish": "set up", "enhanced": "better", "comprehensive": "full", "optimize": "improve",
+    "unequivocally": "clearly", "symphony": "mix", "delicate": "fragile", "begrudgingly": "reluctantly",
+    "merit": "worth", "albeit": "though", "reverent": "respectful", "revolutionizing": "changing",
+    "revolutionize": "change", "crucially": "drop it", "remarkably": "drop it", "seamlessly": "drop it",
+    "manifestation": "sign", "testament": "sign", "prominent": "clear", "underscoring": "showing",
+    "symbolizing": "showing", "cultivating": "building", "fostering": "building", "encompassing": "covering",
+    "facilitating": "helping", "emphasizing": "showing", "embodying": "showing", "underlies": "drives",
+    "evoke": "stir", "enduring": "lasting", "nestled": "in", "fascinating": "notable",
+    "vibrant": "lively", "game-changing": "big", "cutting-edge": "latest",
 }
 
 # always blocked cliches and filler openers, each mapped to a short fix note
@@ -29,6 +42,11 @@ PHRASES = [
     (r"a testament to", "say what it shows"),
     (r"vibrant tapestry", "drop the cliche"),
     (r"aims to explore", "say 'covers'"),
+    (r"aims to bridge", "say what it connects"),
+    (r"foster innovation", "say what gets built"),
+    (r"measured steps", "drop the cliche"),
+    (r"practiced efficiency", "drop the cliche"),
+    (r"stark reminder", "drop the cliche"),
     (r"it is important to note", "state the point"),
     (r"as an ai language model", "drop it"),
     (r"in conclusion", "drop it"),
@@ -38,8 +56,9 @@ PHRASES = [
 ]
 
 # fine once, an AI-tell when repeated, flagged at LIMIT or more
+# 'prompted' sits here on purpose, LLM comments and docstrings use it a lot
 LIMIT = 3
-OFTEN = ["crucial", "essential", "vital", "significant", "moreover", "furthermore", "additionally", "aligns", "explore"]
+OFTEN = ["crucial", "essential", "vital", "significant", "moreover", "furthermore", "additionally", "aligns", "explore", "prompted"]
 
 MARKS = {"—": "em-dash, use commas or periods", "§": "section sign", ";": "semicolon, use a period or comma"}
 SWAP_RE = re.compile(r"\b(" + "|".join(SWAP) + r")\b", re.IGNORECASE)
@@ -90,7 +109,7 @@ chunks += [e.get("new_string", "") for e in tool_input.get("edits", []) if isins
 text = checked(tool_input.get("file_path", ""), "\n".join(c for c in chunks if c))
 
 notes = [f"remove {label}" for ch, label in MARKS.items() if ch in text]
-notes += [f"'{w}' to '{SWAP[w]}'" for w in dict.fromkeys(m.group(1).lower() for m in SWAP_RE.finditer(text))]
+notes += [f"'{w}' -> {SWAP[w]}" for w in dict.fromkeys(m.group(1).lower() for m in SWAP_RE.finditer(text))]
 notes += [note for pat, note in PHRASES if re.search(pat, text, re.IGNORECASE)]
 counts = Counter(m.group(1).lower() for m in OFTEN_RE.finditer(text))
 notes += [f"'{w}' used {n} times, vary it" for w, n in counts.items() if n >= LIMIT]


### PR DESCRIPTION
Adds a Write and Edit hook that blocks AI-tell wording before it lands, so drafted text reads human.

- always-blocks em-dashes, section signs, semicolons, cliches, and stock words, each with a plain-word suggestion
- flags common words only when they pile up (three or more in one write), so single natural uses pass through
- checks markdown files whole and, in code files, only the comment and docstring lines, so real code is untouched