### PR TITLE
Put Claude Code on the same install CLI as everything else

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Plugins add skills, commands, and automations to your AI coding tool. Install on
 /plugin marketplace add fcakyon/claude-codex-settings
 
 # Install any plugin by name
-/plugin install simplify@claude-settings
+/plugin install fable-advisor@claude-settings
 ```
 
 </details>
@@ -98,16 +98,16 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 <details>
 <summary><strong>humanize</strong> - Flag AI-tell wording in your markdown, comments, and docstrings before a write lands, with plain-word swaps</summary>
 
-| Claude Code                                | Codex CLI | Gemini CLI                                            |
-| ------------------------------------------ | --------- | ----------------------------------------------------- |
-| `/plugin install humanize@claude-settings` | n/a       | `gemini extensions install --path ./plugins/humanize` |
+| Claude Code                                | Codex CLI                                   | Gemini CLI                                            |
+| ------------------------------------------ | ------------------------------------------- | ----------------------------------------------------- |
+| `/plugin install humanize@claude-settings` | `codex plugin add humanize@claude-settings` | `gemini extensions install --path ./plugins/humanize` |
 
-Before a Write or Edit saves, humanize scans the text and blocks the parts that read like a machine wrote them, each with a shorter human word to use instead. It only reads markdown files and, inside code, the comments and docstrings, never the code itself:
+Before a Write or Edit saves, humanize scans the new text and blocks whatever reads like a machine wrote it, each hit paired with a plain-word swap. It reads markdown files whole and, in code, only the comments and docstrings, never the code:
 
-- **Marks** the em-dash, section sign, and stray semicolons in prose (the en-dash stays)
-- **Stock words** like `leverage`, `seamlessly`, `vibrant`, or `game-changing`, each mapped to a plain swap
-- **Tired openers and cliches** like `in conclusion`, `a testament to`, or `aims to bridge`
-- **Filler that only grates in bulk** like `crucial` or `significant`, flagged when it piles up in one write
+- **3 marks**: the em-dash, section sign, and stray semicolon (the en-dash stays)
+- **53 stock words** like `leverage`, `seamlessly`, `vibrant`, `game-changing`, each mapped to a plain swap
+- **16 openers and cliches** like `in conclusion`, `a testament to`, `aims to bridge`
+- **10 pile-up words** like `crucial` or `significant`, flagged at 3+ uses in one write
 
 Runs on Claude Code and Gemini, which fire a hook before a file is written. Word list draws on [Wikipedia's "Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing).
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Plugins add skills, commands, and automations to your AI coding tool. Install on
 
 ```bash
 # Add marketplace (one time)
-/plugin marketplace add fcakyon/claude-codex-settings
+claude plugin marketplace add fcakyon/claude-codex-settings
 
 # Install any plugin by name
-/plugin install fable-advisor@claude-settings
+claude plugin install fable-advisor@claude-settings
 ```
 
 </details>
@@ -83,9 +83,9 @@ ln -sfn CLAUDE.md GEMINI.md
 <details>
 <summary><strong>simplify</strong> - Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups</summary>
 
-| Claude Code                                | Codex CLI                                   | Gemini CLI                                            |
-| ------------------------------------------ | ------------------------------------------- | ----------------------------------------------------- |
-| `/plugin install simplify@claude-settings` | `codex plugin add simplify@claude-settings` | `gemini extensions install --path ./plugins/simplify` |
+| Claude Code                                      | Codex CLI                                   | Gemini CLI                                            |
+| ------------------------------------------------ | ------------------------------------------- | ----------------------------------------------------- |
+| `claude plugin install simplify@claude-settings` | `codex plugin add simplify@claude-settings` | `gemini extensions install --path ./plugins/simplify` |
 
 Run `/simplify` to review your staged or committed diff across four angles (reuse, simplification, efficiency, altitude) with parallel agents, then apply the cleanups. It reviews changed-code quality, not correctness bugs. It brings [Claude Code's built-in `/simplify`](https://code.claude.com/docs/en/code-review#review-a-diff-locally) to Codex, Cursor, and Gemini, which don't ship it natively, so all three get the same review and apply flow.
 
@@ -98,9 +98,9 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 <details>
 <summary><strong>humanize</strong> - Flag AI-tell wording in your markdown, comments, and docstrings before a write lands, with plain-word swaps</summary>
 
-| Claude Code                                | Codex CLI                                   | Gemini CLI                                            |
-| ------------------------------------------ | ------------------------------------------- | ----------------------------------------------------- |
-| `/plugin install humanize@claude-settings` | `codex plugin add humanize@claude-settings` | `gemini extensions install --path ./plugins/humanize` |
+| Claude Code                                      | Codex CLI                                   | Gemini CLI                                            |
+| ------------------------------------------------ | ------------------------------------------- | ----------------------------------------------------- |
+| `claude plugin install humanize@claude-settings` | `codex plugin add humanize@claude-settings` | `gemini extensions install --path ./plugins/humanize` |
 
 Before a Write or Edit saves, humanize scans the new text and blocks whatever reads like a machine wrote it, each hit paired with a plain-word swap. It reads markdown files whole and, in code, only the comments and docstrings, never the code:
 
@@ -120,9 +120,9 @@ Runs on Claude Code and Gemini, which fire a hook before a file is written. Word
 <details>
 <summary><strong>fable-advisor</strong> - On-demand second opinion from Claude Fable 5 to pressure-test a plan, interpretation, or risky change before you commit to it</summary>
 
-| Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |
-| ----------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
-| `/plugin install fable-advisor@claude-settings` | `codex plugin add fable-advisor@claude-settings` | `gemini extensions install --path ./plugins/fable-advisor` |
+| Claude Code                                           | Codex CLI                                        | Gemini CLI                                                 |
+| ----------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| `claude plugin install fable-advisor@claude-settings` | `codex plugin add fable-advisor@claude-settings` | `gemini extensions install --path ./plugins/fable-advisor` |
 
 Spawn a stronger Fable 5 reviewer to pressure-test a plan or conclusion before you commit, a drop-in for the built-in advisor when the Opus-main plus Fable-advisor pairing fails with a bare "unavailable" ([#73365](https://github.com/anthropics/claude-code/issues/73365)). It automatically receives the recent conversation, the same history the built-in advisor sees, so it reviews the real context instead of a hand-picked summary, and returns a skeptical review, not a rewrite.
 
@@ -135,9 +135,9 @@ Spawn a stronger Fable 5 reviewer to pressure-test a plan or conclusion before y
 <details>
 <summary><strong>intelligent-compact</strong> - Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions</summary>
 
-| Claude Code                                           | Codex CLI                                              | Gemini CLI                                                       |
-| ----------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
-| `/plugin install intelligent-compact@claude-settings` | `codex plugin add intelligent-compact@claude-settings` | `gemini extensions install --path ./plugins/intelligent-compact` |
+| Claude Code                                                 | Codex CLI                                              | Gemini CLI                                                       |
+| ----------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------- |
+| `claude plugin install intelligent-compact@claude-settings` | `codex plugin add intelligent-compact@claude-settings` | `gemini extensions install --path ./plugins/intelligent-compact` |
 
 When Claude Code auto-summarizes a long session, the default summary routinely drops the highest-signal facts. This plugin tells the summarizer to keep them:
 
@@ -157,9 +157,9 @@ Runs on every `/compact` (manual) and every auto compaction. Claude Code only; C
 <details>
 <summary><strong>claude-telemetry-hooks</strong> - Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard</summary>
 
-| Claude Code                                              | Codex CLI | Gemini CLI                                                          |
-| -------------------------------------------------------- | --------- | ------------------------------------------------------------------- |
-| `/plugin install claude-telemetry-hooks@claude-settings` | n/a       | `gemini extensions install --path ./plugins/claude-telemetry-hooks` |
+| Claude Code                                                    | Codex CLI | Gemini CLI                                                          |
+| -------------------------------------------------------------- | --------- | ------------------------------------------------------------------- |
+| `claude plugin install claude-telemetry-hooks@claude-settings` | n/a       | `gemini extensions install --path ./plugins/claude-telemetry-hooks` |
 
 Adds the two missing pieces Claude Code's telemetry needs to power a usage dashboard:
 
@@ -178,9 +178,9 @@ Per-device data is already in Claude Code's built-in OpenTelemetry stream. Pairs
 <details>
 <summary><strong>anthropic-office-skills</strong> - Official Anthropic PDF, Word, PowerPoint, Excel skills</summary>
 
-| Claude Code                                               | Codex CLI                                                  | Gemini CLI                                                           |
-| --------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------- |
-| `/plugin install anthropic-office-skills@claude-settings` | `codex plugin add anthropic-office-skills@claude-settings` | `gemini extensions install --path ./plugins/anthropic-office-skills` |
+| Claude Code                                                     | Codex CLI                                                  | Gemini CLI                                                           |
+| --------------------------------------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------- |
+| `claude plugin install anthropic-office-skills@claude-settings` | `codex plugin add anthropic-office-skills@claude-settings` | `gemini extensions install --path ./plugins/anthropic-office-skills` |
 
 **Skills CLI**
 
@@ -202,9 +202,9 @@ Official office document skills from [anthropics/skills](https://github.com/anth
 <details>
 <summary><strong>openai-office-skills</strong> - Official OpenAI PDF, Word, PowerPoint, Excel skills</summary>
 
-| Claude Code                                            | Codex CLI                                               | Gemini CLI                                                        |
-| ------------------------------------------------------ | ------------------------------------------------------- | ----------------------------------------------------------------- |
-| `/plugin install openai-office-skills@claude-settings` | `codex plugin add openai-office-skills@claude-settings` | `gemini extensions install --path ./plugins/openai-office-skills` |
+| Claude Code                                                  | Codex CLI                                               | Gemini CLI                                                        |
+| ------------------------------------------------------------ | ------------------------------------------------------- | ----------------------------------------------------------------- |
+| `claude plugin install openai-office-skills@claude-settings` | `codex plugin add openai-office-skills@claude-settings` | `gemini extensions install --path ./plugins/openai-office-skills` |
 
 **Skills CLI**
 
@@ -226,9 +226,9 @@ Official office document skills from [openai/skills](https://github.com/openai/s
 <details>
 <summary><strong>python-skills</strong> - Python best practices from PEP 8, Zen of Python, Google Style Guide, Effective Python</summary>
 
-| Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |
-| ----------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
-| `/plugin install python-skills@claude-settings` | `codex plugin add python-skills@claude-settings` | `gemini extensions install --path ./plugins/python-skills` |
+| Claude Code                                           | Codex CLI                                        | Gemini CLI                                                 |
+| ----------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| `claude plugin install python-skills@claude-settings` | `codex plugin add python-skills@claude-settings` | `gemini extensions install --path ./plugins/python-skills` |
 
 Python coding guidelines grounded in authoritative sources: PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Brett Slatkin's "Effective Python" (3rd ed.). Covers code integration, idiomatic patterns, YAGNI anti-abstraction rules, Google-style docstrings, and 18 before/after code examples.
 
@@ -250,9 +250,9 @@ Python coding guidelines grounded in authoritative sources: PEP 8, PEP 20 (Zen o
 <details>
 <summary><strong>react-skills</strong> - Official React, Next.js, and React Native best practices</summary>
 
-| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
-| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install react-skills@claude-settings` | `codex plugin add react-skills@claude-settings` | `gemini extensions install --path ./plugins/react-skills` |
+| Claude Code                                          | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `claude plugin install react-skills@claude-settings` | `codex plugin add react-skills@claude-settings` | `gemini extensions install --path ./plugins/react-skills` |
 
 **Skills CLI**
 
@@ -277,9 +277,9 @@ React and frontend best practices from [vercel-labs/agent-skills](https://github
 <details>
 <summary><strong>agent-browser</strong> - Official browser automation CLI for AI agents</summary>
 
-| Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |
-| ----------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
-| `/plugin install agent-browser@claude-settings` | `codex plugin add agent-browser@claude-settings` | `gemini extensions install --path ./plugins/agent-browser` |
+| Claude Code                                           | Codex CLI                                        | Gemini CLI                                                 |
+| ----------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| `claude plugin install agent-browser@claude-settings` | `codex plugin add agent-browser@claude-settings` | `gemini extensions install --path ./plugins/agent-browser` |
 
 **Skills CLI**
 
@@ -303,9 +303,9 @@ Browser automation via CLI instead of MCP. [93% less context usage](https://medi
 <details>
 <summary><strong>frontend-design-skills</strong> - Official frontend design skills (Anthropic + OpenAI)</summary>
 
-| Claude Code                                              | Codex CLI                                                 | Gemini CLI                                                          |
-| -------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
-| `/plugin install frontend-design-skills@claude-settings` | `codex plugin add frontend-design-skills@claude-settings` | `gemini extensions install --path ./plugins/frontend-design-skills` |
+| Claude Code                                                    | Codex CLI                                                 | Gemini CLI                                                          |
+| -------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| `claude plugin install frontend-design-skills@claude-settings` | `codex plugin add frontend-design-skills@claude-settings` | `gemini extensions install --path ./plugins/frontend-design-skills` |
 
 **Skills CLI**
 
@@ -325,9 +325,9 @@ Frontend design skills from [anthropics/claude-plugins-official](https://github.
 <details>
 <summary><strong>mongodb-skills</strong> - Official MongoDB agent skills for schema design, query tuning, and Atlas Search</summary>
 
-| Claude Code                                      | Codex CLI                                         | Gemini CLI                                                  |
-| ------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
-| `/plugin install mongodb-skills@claude-settings` | `codex plugin add mongodb-skills@claude-settings` | `gemini extensions install --path ./plugins/mongodb-skills` |
+| Claude Code                                            | Codex CLI                                         | Gemini CLI                                                  |
+| ------------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
+| `claude plugin install mongodb-skills@claude-settings` | `codex plugin add mongodb-skills@claude-settings` | `gemini extensions install --path ./plugins/mongodb-skills` |
 
 **Skills CLI**
 
@@ -354,9 +354,9 @@ Official MongoDB agent skills for schema design, query tuning, Atlas Search, and
 <details>
 <summary><strong>supabase-skills</strong> - Supabase Postgres best practices, JavaScript SDK, and CLI skills</summary>
 
-| Claude Code                                       | Codex CLI                                          | Gemini CLI                                                   |
-| ------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
-| `/plugin install supabase-skills@claude-settings` | `codex plugin add supabase-skills@claude-settings` | `gemini extensions install --path ./plugins/supabase-skills` |
+| Claude Code                                             | Codex CLI                                          | Gemini CLI                                                   |
+| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| `claude plugin install supabase-skills@claude-settings` | `codex plugin add supabase-skills@claude-settings` | `gemini extensions install --path ./plugins/supabase-skills` |
 
 **Skills CLI**
 
@@ -379,9 +379,9 @@ Supabase skills covering Postgres query/schema best practices from [supabase/age
 <details>
 <summary><strong>stripe-skills</strong> - Official Stripe agent skills for payments, billing, Connect, and API upgrades</summary>
 
-| Claude Code                                     | Codex CLI                                        | Gemini CLI                                                 |
-| ----------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
-| `/plugin install stripe-skills@claude-settings` | `codex plugin add stripe-skills@claude-settings` | `gemini extensions install --path ./plugins/stripe-skills` |
+| Claude Code                                           | Codex CLI                                        | Gemini CLI                                                 |
+| ----------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
+| `claude plugin install stripe-skills@claude-settings` | `codex plugin add stripe-skills@claude-settings` | `gemini extensions install --path ./plugins/stripe-skills` |
 
 **Skills CLI**
 
@@ -404,9 +404,9 @@ Official Stripe agent skills for payment integration: API selection, Connect pla
 <details>
 <summary><strong>polar-skills</strong> - Official Polar agent skills for billing, subscriptions, and local dev environment</summary>
 
-| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
-| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install polar-skills@claude-settings` | `codex plugin add polar-skills@claude-settings` | `gemini extensions install --path ./plugins/polar-skills` |
+| Claude Code                                          | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `claude plugin install polar-skills@claude-settings` | `codex plugin add polar-skills@claude-settings` | `gemini extensions install --path ./plugins/polar-skills` |
 
 **Skills CLI**
 
@@ -428,9 +428,9 @@ Official Polar agent skills for billing system, Stripe integration, subscription
 <details>
 <summary><strong>livekit-skills</strong> - LiveKit voice AI agent development (Cloud + self-hosted)</summary>
 
-| Claude Code                                      | Codex CLI                                         | Gemini CLI                                                  |
-| ------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
-| `/plugin install livekit-skills@claude-settings` | `codex plugin add livekit-skills@claude-settings` | `gemini extensions install --path ./plugins/livekit-skills` |
+| Claude Code                                            | Codex CLI                                         | Gemini CLI                                                  |
+| ------------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
+| `claude plugin install livekit-skills@claude-settings` | `codex plugin add livekit-skills@claude-settings` | `gemini extensions install --path ./plugins/livekit-skills` |
 
 **Skills CLI**
 
@@ -451,9 +451,9 @@ Voice AI agent development with the LiveKit Agents SDK. Cloud-agnostic: supports
 <details>
 <summary><strong>cloudflare-skills</strong> - Official Cloudflare developer platform skill for Workers, R2, D1, KV, AI, and 50+ services</summary>
 
-| Claude Code                                         | Codex CLI                                            | Gemini CLI                                                     |
-| --------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
-| `/plugin install cloudflare-skills@claude-settings` | `codex plugin add cloudflare-skills@claude-settings` | `gemini extensions install --path ./plugins/cloudflare-skills` |
+| Claude Code                                               | Codex CLI                                            | Gemini CLI                                                     |
+| --------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
+| `claude plugin install cloudflare-skills@claude-settings` | `codex plugin add cloudflare-skills@claude-settings` | `gemini extensions install --path ./plugins/cloudflare-skills` |
 
 **Skills CLI**
 
@@ -474,9 +474,9 @@ Cloudflare developer platform skill with decision trees for product selection ac
 <details>
 <summary><strong>web-performance-skills</strong> - Web performance auditing with Core Web Vitals, Lighthouse, and Chrome DevTools</summary>
 
-| Claude Code                                              | Codex CLI                                                 | Gemini CLI                                                          |
-| -------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
-| `/plugin install web-performance-skills@claude-settings` | `codex plugin add web-performance-skills@claude-settings` | `gemini extensions install --path ./plugins/web-performance-skills` |
+| Claude Code                                                    | Codex CLI                                                 | Gemini CLI                                                          |
+| -------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| `claude plugin install web-performance-skills@claude-settings` | `codex plugin add web-performance-skills@claude-settings` | `gemini extensions install --path ./plugins/web-performance-skills` |
 
 **Skills CLI**
 
@@ -499,9 +499,9 @@ Bundles the `chrome-devtools` MCP server (no API key needed).
 <details>
 <summary><strong>openobserve-skills</strong> - OpenObserve REST API skill for AI agents to search logs/metrics/traces and create dashboards via curl</summary>
 
-| Claude Code                                          | Codex CLI                                             | Gemini CLI                                                      |
-| ---------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
-| `/plugin install openobserve-skills@claude-settings` | `codex plugin add openobserve-skills@claude-settings` | `gemini extensions install --path ./plugins/openobserve-skills` |
+| Claude Code                                                | Codex CLI                                             | Gemini CLI                                                      |
+| ---------------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
+| `claude plugin install openobserve-skills@claude-settings` | `codex plugin add openobserve-skills@claude-settings` | `gemini extensions install --path ./plugins/openobserve-skills` |
 
 **Skills CLI**
 
@@ -528,9 +528,9 @@ Built for AI agents: uses `curl` only, no SDK or CLI dependency. Pairs naturally
 <details>
 <summary><strong>hetzner-skills</strong> - Hetzner Cloud CLI skill for servers, networks, firewalls, load balancers, DNS, and storage</summary>
 
-| Claude Code                                      | Codex CLI                                         | Gemini CLI                                                  |
-| ------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
-| `/plugin install hetzner-skills@claude-settings` | `codex plugin add hetzner-skills@claude-settings` | `gemini extensions install --path ./plugins/hetzner-skills` |
+| Claude Code                                            | Codex CLI                                         | Gemini CLI                                                  |
+| ------------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
+| `claude plugin install hetzner-skills@claude-settings` | `codex plugin add hetzner-skills@claude-settings` | `gemini extensions install --path ./plugins/hetzner-skills` |
 
 **Skills CLI**
 
@@ -551,9 +551,9 @@ Hetzner Cloud infrastructure management via the `hcloud` CLI. Decision trees for
 <details>
 <summary><strong>dokploy-skills</strong> - Dokploy deployment skill for Dokploy Cloud and self-hosted dashboards</summary>
 
-| Claude Code                                      | Codex CLI                                         | Gemini CLI                                                  |
-| ------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
-| `/plugin install dokploy-skills@claude-settings` | `codex plugin add dokploy-skills@claude-settings` | `gemini extensions install --path ./plugins/dokploy-skills` |
+| Claude Code                                            | Codex CLI                                         | Gemini CLI                                                  |
+| ------------------------------------------------------ | ------------------------------------------------- | ----------------------------------------------------------- |
+| `claude plugin install dokploy-skills@claude-settings` | `codex plugin add dokploy-skills@claude-settings` | `gemini extensions install --path ./plugins/dokploy-skills` |
 
 **Skills CLI**
 
@@ -646,9 +646,9 @@ Academic research toolkit from [fcakyon/phd-skills](https://github.com/fcakyon/p
 <details>
 <summary><strong>github-dev</strong> - Git workflow agents + skills</summary>
 
-| Claude Code                                  | Codex CLI                                     | Gemini CLI                                              |
-| -------------------------------------------- | --------------------------------------------- | ------------------------------------------------------- |
-| `/plugin install github-dev@claude-settings` | `codex plugin add github-dev@claude-settings` | `gemini extensions install --path ./plugins/github-dev` |
+| Claude Code                                        | Codex CLI                                     | Gemini CLI                                              |
+| -------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------- |
+| `claude plugin install github-dev@claude-settings` | `codex plugin add github-dev@claude-settings` | `gemini extensions install --path ./plugins/github-dev` |
 
 **Skills CLI**
 
@@ -685,9 +685,9 @@ Git and GitHub automation. Run the `setup` skill after install.
 <details>
 <summary><strong>ultralytics-dev</strong> - Auto-formatting hooks</summary>
 
-| Claude Code                                       | Codex CLI                                          | Gemini CLI                                                   |
-| ------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
-| `/plugin install ultralytics-dev@claude-settings` | `codex plugin add ultralytics-dev@claude-settings` | `gemini extensions install --path ./plugins/ultralytics-dev` |
+| Claude Code                                             | Codex CLI                                          | Gemini CLI                                                   |
+| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| `claude plugin install ultralytics-dev@claude-settings` | `codex plugin add ultralytics-dev@claude-settings` | `gemini extensions install --path ./plugins/ultralytics-dev` |
 
 Auto-formatting hooks for Python, JavaScript, Markdown, and Bash.
 
@@ -704,9 +704,9 @@ Auto-formatting hooks for Python, JavaScript, Markdown, and Bash.
 <details>
 <summary><strong>azure-tools</strong> - Azure MCP & Skills</summary>
 
-| Claude Code                                   | Codex CLI                                      | Gemini CLI                                               |
-| --------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------- |
-| `/plugin install azure-tools@claude-settings` | `codex plugin add azure-tools@claude-settings` | `gemini extensions install --path ./plugins/azure-tools` |
+| Claude Code                                         | Codex CLI                                      | Gemini CLI                                               |
+| --------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `claude plugin install azure-tools@claude-settings` | `codex plugin add azure-tools@claude-settings` | `gemini extensions install --path ./plugins/azure-tools` |
 
 **Skills CLI**
 
@@ -732,9 +732,9 @@ npx skills add https://github.com/fcakyon/claude-codex-settings/tree/main/plugin
 <details>
 <summary><strong>claude-tools</strong> - Sync CLAUDE.md + allowlist + context refresh</summary>
 
-| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
-| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install claude-tools@claude-settings` | `codex plugin add claude-tools@claude-settings` | `gemini extensions install --path ./plugins/claude-tools` |
+| Claude Code                                          | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `claude plugin install claude-tools@claude-settings` | `codex plugin add claude-tools@claude-settings` | `gemini extensions install --path ./plugins/claude-tools` |
 
 Commands for syncing CLAUDE.md and permissions allowlist from repository, plus context refresh for long conversations.
 
@@ -753,9 +753,9 @@ Commands for syncing CLAUDE.md and permissions allowlist from repository, plus c
 <details>
 <summary><strong>gcloud-tools</strong> - GCloud MCP & Skills</summary>
 
-| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
-| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install gcloud-tools@claude-settings` | `codex plugin add gcloud-tools@claude-settings` | `gemini extensions install --path ./plugins/gcloud-tools` |
+| Claude Code                                          | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `claude plugin install gcloud-tools@claude-settings` | `codex plugin add gcloud-tools@claude-settings` | `gemini extensions install --path ./plugins/gcloud-tools` |
 
 **Skills CLI**
 
@@ -781,9 +781,9 @@ Logs, metrics, and traces. Run `/gcloud-tools:setup` after install.
 <details>
 <summary><strong>paper-search-tools</strong> - Paper Search MCP & Skills</summary>
 
-| Claude Code                                          | Codex CLI                                             | Gemini CLI                                                      |
-| ---------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
-| `/plugin install paper-search-tools@claude-settings` | `codex plugin add paper-search-tools@claude-settings` | `gemini extensions install --path ./plugins/paper-search-tools` |
+| Claude Code                                                | Codex CLI                                             | Gemini CLI                                                      |
+| ---------------------------------------------------------- | ----------------------------------------------------- | --------------------------------------------------------------- |
+| `claude plugin install paper-search-tools@claude-settings` | `codex plugin add paper-search-tools@claude-settings` | `gemini extensions install --path ./plugins/paper-search-tools` |
 
 **Skills CLI**
 
@@ -809,9 +809,9 @@ Search papers across arXiv, PubMed, IEEE, Scopus, ACM. Run `/paper-search-tools:
 <details>
 <summary><strong>tavily-tools</strong> - Tavily MCP & Skills</summary>
 
-| Claude Code                                    | Codex CLI                                       | Gemini CLI                                                |
-| ---------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| `/plugin install tavily-tools@claude-settings` | `codex plugin add tavily-tools@claude-settings` | `gemini extensions install --path ./plugins/tavily-tools` |
+| Claude Code                                          | Codex CLI                                       | Gemini CLI                                                |
+| ---------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| `claude plugin install tavily-tools@claude-settings` | `codex plugin add tavily-tools@claude-settings` | `gemini extensions install --path ./plugins/tavily-tools` |
 
 **Skills CLI**
 
@@ -843,9 +843,9 @@ Web search and content extraction. Run `/tavily-tools:setup` after install.
 <details>
 <summary><strong>overleaf-skills</strong> - Pull Overleaf review comments into your local .tex repo and apply the suggested edits</summary>
 
-| Claude Code                                       | Codex CLI                                          | Gemini CLI                                                   |
-| ------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
-| `/plugin install overleaf-skills@claude-settings` | `codex plugin add overleaf-skills@claude-settings` | `gemini extensions install --path ./plugins/overleaf-skills` |
+| Claude Code                                             | Codex CLI                                          | Gemini CLI                                                   |
+| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| `claude plugin install overleaf-skills@claude-settings` | `codex plugin add overleaf-skills@claude-settings` | `gemini extensions install --path ./plugins/overleaf-skills` |
 
 **Skills CLI**
 
@@ -865,9 +865,9 @@ Pull reviewer comments from an Overleaf project, locate each in your local git-t
 <details>
 <summary><strong>adhd-output-style</strong> - Answer-first replies with numbered steps, a clear next action, and short teaching notes</summary>
 
-| Claude Code                                         | Codex CLI                                            | Gemini CLI                                                     |
-| --------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
-| `/plugin install adhd-output-style@claude-settings` | `codex plugin add adhd-output-style@claude-settings` | `gemini extensions install --path ./plugins/adhd-output-style` |
+| Claude Code                                               | Codex CLI                                            | Gemini CLI                                                     |
+| --------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
+| `claude plugin install adhd-output-style@claude-settings` | `codex plugin add adhd-output-style@claude-settings` | `gemini extensions install --path ./plugins/adhd-output-style` |
 
 Reformats every reply for limited working memory: the answer or next step first, numbered one-action-per-step lists, concrete time estimates, a single under-two-minute next action, and short teaching notes while coding. Enabling the plugin applies the style automatically. Output styles apply in Claude Code.
 


### PR DESCRIPTION
Codex, Cursor, and Gemini each install from their own CLI. Claude Code was the odd one out, still on the in-REPL slash form, so this lines everyone up.

```diff
- /plugin install fable-advisor@claude-settings
+ claude plugin install fable-advisor@claude-settings
```

Same swap across all 30 plugin tables plus the top install block. The humanize section also gets its Codex install cell filled and real numbers instead of vibes: 3 marks, 53 words, 16 phrases, 10 pile-up words.
