### PR TITLE
Sharpen the agent's PR voice and coding principles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,22 +2,29 @@
 
 Guidance for Claude Code and other AI tools. Structured around [Andrej Karpathy's observations on LLM coding pitfalls](https://x.com/karpathy/status/2015883857489522876): surface assumptions, don't overcomplicate, make surgical changes, verify before moving on.
 
-## AI Guidance
+## Core Principles
 
-**Do what was asked. Nothing more, nothing less.**
+**Do what was asked. Nothing more, nothing less.** This year is 2026.
 
-This year is 2026. Never use words like "consolidate", "modernize", "streamline", "flexible", "delve", "establish", "enhanced", "comprehensive", "optimize" or em-dashes (--) in docstrings, commit messages, or comments.
+**Delete > Replace > Add.** Before any change, answer in order: what can I delete, what can I replace, and only then, what must I add?
 
-- Reflect on tool results before acting. Use thinking to plan and iterate, then take the best next action.
+- **Guard nothing, relocate the trigger.** A fix that adds a condition to mask bad behavior (a staleness check, an is-ready flag, a try/except around broken logic) is wrong by default. Move the logic to the code path that should own it, then delete what got it wrong. No defensive programming unless you state the motivation and the user approves.
+- **Bugfixes are net-negative by default.** If a fix adds more lines than it removes, justify in one sentence why deletion and relocation were impossible.
+- **Search before creating.** The helper probably exists, so grep the project first. Fold duplicates into one shared utility. Three similar lines beat a helper nobody else calls.
+- **Deletion beats caution.** Broken or duplicated code kept "to be safe" is the regression. Understand what you remove, then remove it.
+- **This guidance is code: additions require deletions.** To add a rule, remove or merge one.
+
+Ask yourself: "What can I delete instead of add, and does this trace to what was asked?"
+
+## Working Rules
+
+- Reflect on tool results before acting, then plan and take the best next action.
 - Run independent operations in parallel.
 - Verify your solution before finishing.
-- Never create files unless necessary. Prefer editing. Never create docs (*.md, README) unless explicitly asked.
-- Reuse existing code. Simplify. Make targeted changes, not sweeping ones.
+- Never create files unless necessary. Prefer editing. Never create docs (*.md, README) unless asked.
 - Prefer `rg` over `grep`.
-- No defensive programming unless you state the motivation and the user approves.
 - When updating code, check related code in the same and other files for consistency.
-
-Ask yourself: "Does every change I'm making trace directly to what was asked?"
+- Never use `consolidate`, `modernize`, `streamline`, `flexible`, `delve`, `establish`, `enhanced`, `comprehensive`, `optimize`, or em-dashes in docstrings, commit messages, or comments.
 
 ## MCP Tools
 
@@ -70,7 +77,7 @@ For full Python guidelines, install and enable the `python-skills` plugin (`pyth
 
 - PR titles: NO type prefix (unlike commits) - start with capital letter + verb
 - Analyze ALL commits with `git diff <base-branch>...HEAD`, not just latest
-- PR body: single section, no headers, 1-2 sentences + usage snippet
+- PR body: open on why, show a diff or snippet, numbers over adjectives. Single section, no headers, no bullet dump
 - No test plans, no changed files list, no line-number links in PR body
 - Self-assign with `-a @me`
 - Find reviewers: `gh pr list --repo <owner>/<repo> --author @me --limit 5`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,7 @@ This repo contains config files (JSON settings, allowlist rules, hooks) rather t
 - Avoid internal jargon: say "allowlist" not "permissions allowlist entries", say "settings files" not "settings.json/settings-minimax.json/settings-zai.json"
 - When listing affected files, group by purpose: "all 3 settings files" instead of naming each one
 - Always name the concrete object you're acting on. "fix: add license fields" is useless (to what?). "fix: add license field to plugin manifests" tells the next reader exactly what changed
-- Keep PR bodies short: 2-3 bullet points explaining the user-visible behavior change
+- Keep PR bodies short: lead with why, show a diff or snippet, numbers over adjectives, no bullet dump
 - PR titles and bodies must read standalone months later: never reference session shorthand ("PR-cf", "the last orphan content PR"), only real PR numbers (`#176`)
 
 ## Maintenance Scripts

--- a/plugins/github-dev/agents/pr-creator.md
+++ b/plugins/github-dev/agents/pr-creator.md
@@ -59,39 +59,41 @@ findings in the PR body when available.
      - PR message must describe the complete changeset across all commits, not just the latest commit
      - Focus on what changed (ignore unstaged changes) from the perspective of someone reviewing the entire branch
    - Create PR with `gh pr create` using:
-     - `-t` or `--title`: Start with capital letter + verb, NO type prefix.
-       Use plain language. Avoid jargon and repo shorthand unless an exact command or tool name is needed.
-     - `-b` or `--body`: Single section (no headers if possible). Very concise.
-       Use plain language and simple words.
-       Few bullet points + 1 CLI/usage snippet for easier try,
-       or simple before/after snippet if applicable.
-       No test plans, no changed file lists, no line-number links.
+     - `-t` or `--title`: a short human headline, capital first letter, no type prefix.
+       Lead with the outcome in plain words, one idea not a list of everything the branch touched.
+       Punchy beats exhaustive. Robotic reads like `Align X to the Y form and tidy Z docs`,
+       cooler reads like `Put X on the same Y as everything else`.
+     - `-b` or `--body`: write it like a sharp teammate would, not a changelog.
+       Open on why it exists, not "This PR...".
+       Show, don't list: a `diff`, a before/after, or a CLI snippet they can run.
+       Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
+       One read, one section. No headers, no bullet dump. No test plans, file lists, or line links.
      - `-a @me`: Self-assign (confirmation hook will show actual username)
      - `-r <reviewer>`: Only add if the user explicitly asks OR recent PRs by this author have reviewers.
        Check with: `gh pr list --repo <owner>/<repo> --author @me --limit 5 --json reviewRequests`
        If recent PRs have no reviewers, skip `-r` entirely.
-   - Example 1 — CLI snippet:
+       Example, why-first with a diff:
 
-     ```
-     Add compare command for side-by-side model comparison
+````
+Codex, Cursor, and Gemini each install from their own CLI. Claude Code was the odd one out on the in-REPL slash form, so this lines everyone up.
 
-     - Run multiple models on same images with `--models` and `--phrases` flags
-     - Horizontal panel concatenation with model name headers
+```diff
+- /plugin install fable-advisor@claude-settings
++ claude plugin install fable-advisor@claude-settings
+```
 
-     `ultrannotate compare --source ./images --models sam3.pt,yoloe-26x-seg.pt --phrases "person,car"`
-     ```
+Same swap across all 30 plugin tables. No behavior change, just one house style everywhere.
+````
 
-   - Example 2 — before/after:
+Example, CLI snippet:
 
-     ```
-     Inline single-use variables in compare_models
+```
+Add a compare command for side-by-side model runs
 
-     - xyxy2xywhn handles empty arrays, guard unnecessary
-     - Use function reference for draw dispatch
+Point it at a folder and a few models and it stitches the panels together, so you can eyeball which one wins without juggling tabs.
 
-     Before: `boxes = result.get(...); ops.xyxy2xywhn(boxes, ...)`
-     After: `ops.xyxy2xywhn(result.get(...), ...)`
-     ```
+`ultrannotate compare --source ./images --models sam3.pt,yoloe-26x-seg.pt --phrases "person,car"`
+```
 
 ## Tool Usage:
 

--- a/plugins/github-dev/skills/create-pr/SKILL.md
+++ b/plugins/github-dev/skills/create-pr/SKILL.md
@@ -40,41 +40,45 @@ plain-language branch name rather than copying the full text.
 6. **Create PR**
    - Use `gh` for GitHub operations and `git` only for local branch management
    - Use `github-dev:pr-creator` or `gh pr create` with parameters:
-     - `-t` (title): Start with capital letter, use verb, NO "fix:" or "feat:" prefix
-       Use plain language. Avoid jargon and internal shorthand unless a command or tool name is needed.
-     - `-b` (body): Brief summary + bullet points with inline markdown links
+     - `-t` (title): a short human headline, capital first letter, no `fix:` or `feat:` prefix.
+       Lead with the outcome in plain words, one idea not a list of everything the branch touched.
+       Punchy beats exhaustive. A title is a headline, not a summary.
+       Robotic: `Align Claude Code install commands to the CLI form and tidy humanize docs`
+       Cooler: `Put Claude Code on the same install CLI as everything else`
+     - `-b` (body): write it like a sharp teammate would, not a changelog. See PR Body Guidelines below.
      - `-a @me` (self-assign)
      - `-r <reviewer>`: Only add if the user explicitly asks OR recent PRs by this author have reviewers.
        Check with: `gh pr list --repo <owner>/<repo> --author @me --limit 5 --json reviewRequests`
        If recent PRs have no reviewers, skip `-r` entirely.
 
 7. **PR Body Guidelines**
-   - Single section, no headers if possible. Very concise
-   - Use plain language. Avoid jargon and buzzwords unless an exact command or tool name is needed.
-   - Few bullet points + 1 CLI/usage snippet or simple before/after snippet
-   - No test plans, no changed file lists, no line-number links
+   - Open on why it exists, not "This PR...".
+   - Show, don't list: a `diff`, a before/after, or a CLI snippet they can run.
+   - Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
+   - One read, one section. No headers, no bullet dump.
+   - Plain words, no buzzwords. No test plans, file lists, or line links.
 
 ## Examples
 
-### CLI snippet:
+### Why-first with a diff
+
+````
+Codex, Cursor, and Gemini each install from their own CLI. Claude Code was the odd one out on the in-REPL slash form, so this lines everyone up.
+
+```diff
+- /plugin install fable-advisor@claude-settings
++ claude plugin install fable-advisor@claude-settings
+```
+
+Same swap across all 30 plugin tables. No behavior change, just one house style everywhere.
+````
+
+### CLI snippet
 
 ```
-Add compare command for side-by-side model comparison
+Add a compare command for side-by-side model runs
 
-- Run multiple models on same images with `--models` and `--phrases` flags
-- Horizontal panel concatenation with model name headers
+Point it at a folder and a few models and it stitches the panels together, so you can eyeball which one wins without juggling tabs.
 
 `ultrannotate compare --source ./images --models sam3.pt,yoloe-26x-seg.pt --phrases "person,car"`
-```
-
-### Before/after:
-
-```
-Inline single-use variables in compare_models
-
-- xyxy2xywhn handles empty arrays, guard unnecessary
-- Use function reference for draw dispatch
-
-Before: `boxes = result.get(...); ops.xyxy2xywhn(boxes, ...)`
-After: `ops.xyxy2xywhn(result.get(...), ...)`
 ```

--- a/plugins/github-dev/skills/update-pr-summary/SKILL.md
+++ b/plugins/github-dev/skills/update-pr-summary/SKILL.md
@@ -21,11 +21,11 @@ When explicitly invoked with extra text, treat that text as the PR number or URL
 
 3. **Generate the updated summary**
    - Follow the `create-pr` skill format for title and body.
-   - Start the title with a capital letter and a verb, with no `fix:` or `feat:` prefix.
-   - Use plain language. Avoid jargon and internal shorthand unless an exact command or tool name is needed.
-   - Keep the body to a single short section.
-   - Include 1-2 sentences, a few bullets, and one usage snippet or before/after example when helpful.
-   - Do not include test plans, changed file lists, or line-number links.
+   - Title: a short human headline, capital first letter, no `fix:` or `feat:` prefix. Lead with the outcome, punchy over exhaustive.
+   - Body: open on why it exists, then show it with a `diff`, a before/after, or a runnable CLI snippet.
+   - Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
+   - One read, one section. No headers, no bullet dump. Plain words, no buzzwords.
+   - No test plans, file lists, or line links.
 
 4. **Apply the update**
    - Use `gh pr edit <pr> --title "..." --body "..."`.


### PR DESCRIPTION
The PR generator wrote changelog-robot bodies, and our core rules only whispered "reuse, simplify".

```diff
- `-b` (body): Brief summary + bullet points
+ `-b` (body): write it like a sharp teammate
```

Now baked in:

- Why-first bodies, numbers over adjectives
- Delete > Replace > Add
- Guard nothing, then relocate the trigger
- Bugfixes net-negative by default
- Core Principles from ultralytics AGENTS.md
- 5 files, one voice
