### PR TITLE
Let PR bodies use short bullets again

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,7 +77,7 @@ For full Python guidelines, install and enable the `python-skills` plugin (`pyth
 
 - PR titles: NO type prefix (unlike commits) - start with capital letter + verb
 - Analyze ALL commits with `git diff <base-branch>...HEAD`, not just latest
-- PR body: open on why, show a diff or snippet, numbers over adjectives. Single section, no headers, no bullet dump
+- PR body: open on why, short scannable bullets (one point each), a diff or snippet, numbers over adjectives. Single section, no headers
 - No test plans, no changed files list, no line-number links in PR body
 - Self-assign with `-a @me`
 - Find reviewers: `gh pr list --repo <owner>/<repo> --author @me --limit 5`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,7 @@ This repo contains config files (JSON settings, allowlist rules, hooks) rather t
 - Avoid internal jargon: say "allowlist" not "permissions allowlist entries", say "settings files" not "settings.json/settings-minimax.json/settings-zai.json"
 - When listing affected files, group by purpose: "all 3 settings files" instead of naming each one
 - Always name the concrete object you're acting on. "fix: add license fields" is useless (to what?). "fix: add license field to plugin manifests" tells the next reader exactly what changed
-- Keep PR bodies short: lead with why, show a diff or snippet, numbers over adjectives, no bullet dump
+- Keep PR bodies short: lead with why, short scannable bullets (one point each), a diff or snippet, numbers over adjectives
 - PR titles and bodies must read standalone months later: never reference session shorthand ("PR-cf", "the last orphan content PR"), only real PR numbers (`#176`)
 
 ## Maintenance Scripts

--- a/plugins/github-dev/agents/pr-creator.md
+++ b/plugins/github-dev/agents/pr-creator.md
@@ -65,9 +65,10 @@ findings in the PR body when available.
        cooler reads like `Put X on the same Y as everything else`.
      - `-b` or `--body`: write it like a sharp teammate would, not a changelog.
        Open on why it exists, not "This PR...".
-       Show, don't list: a `diff`, a before/after, or a CLI snippet they can run.
+       Short scannable bullets, one point each, a few words, not verbose sentences.
+       Show it too: a `diff`, a before/after, or a CLI snippet they can run.
        Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
-       One read, one section. No headers, no bullet dump. No test plans, file lists, or line links.
+       One read, one section, no headers. No test plans, file lists, or line links.
      - `-a @me`: Self-assign (confirmation hook will show actual username)
      - `-r <reviewer>`: Only add if the user explicitly asks OR recent PRs by this author have reviewers.
        Check with: `gh pr list --repo <owner>/<repo> --author @me --limit 5 --json reviewRequests`

--- a/plugins/github-dev/skills/create-pr/SKILL.md
+++ b/plugins/github-dev/skills/create-pr/SKILL.md
@@ -53,10 +53,10 @@ plain-language branch name rather than copying the full text.
 
 7. **PR Body Guidelines**
    - Open on why it exists, not "This PR...".
-   - Show, don't list: a `diff`, a before/after, or a CLI snippet they can run.
+   - Short scannable bullets, one point each, a few words, not verbose sentences.
+   - Show it too: a `diff`, a before/after, or a CLI snippet they can run.
    - Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
-   - One read, one section. No headers, no bullet dump.
-   - Plain words, no buzzwords. No test plans, file lists, or line links.
+   - One read, one section, no headers. Plain words, no buzzwords, no test plans or file lists.
 
 ## Examples
 

--- a/plugins/github-dev/skills/update-pr-summary/SKILL.md
+++ b/plugins/github-dev/skills/update-pr-summary/SKILL.md
@@ -22,9 +22,9 @@ When explicitly invoked with extra text, treat that text as the PR number or URL
 3. **Generate the updated summary**
    - Follow the `create-pr` skill format for title and body.
    - Title: a short human headline, capital first letter, no `fix:` or `feat:` prefix. Lead with the outcome, punchy over exhaustive.
-   - Body: open on why it exists, then show it with a `diff`, a before/after, or a runnable CLI snippet.
+   - Body: open on why, then short scannable bullets (one point each) plus a `diff`, before/after, or runnable CLI snippet.
    - Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
-   - One read, one section. No headers, no bullet dump. Plain words, no buzzwords.
+   - One read, one section, no headers. Plain words, no buzzwords.
    - No test plans, file lists, or line links.
 
 4. **Apply the update**


### PR DESCRIPTION
The last PR's body came out a wall of text. The guidance banned bullets ("no bullet dump"), which fought "keep bullets short" from two messages earlier.

```diff
- One read, one section. No headers, no bullet dump.
+ Short scannable bullets, one point each, a few words.
```

Fixed in 5 files:

- create-pr skill
- pr-creator agent
- update-pr-summary skill
- `.claude/CLAUDE.md`
- root `CLAUDE.md`

This body eats its own dog food: short bullets, one point each.
