### PR TITLE
Make Sol the default and ADHD cross-tool

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -41,6 +41,18 @@
       "category": "developer-tools"
     },
     {
+      "name": "adhd-output-style",
+      "source": {
+        "source": "local",
+        "path": "./plugins/adhd-output-style"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "developer-tools"
+    },
+    {
       "name": "intelligent-compact",
       "source": {
         "source": "local",
@@ -351,18 +363,6 @@
         "authentication": "ON_INSTALL"
       },
       "category": "research"
-    },
-    {
-      "name": "adhd-output-style",
-      "source": {
-        "source": "local",
-        "path": "./plugins/adhd-output-style"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "developer-tools"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,6 +54,21 @@
       "tags": ["review", "agent"]
     },
     {
+      "name": "adhd-output-style",
+      "source": "./plugins/adhd-output-style",
+      "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["output-style", "adhd", "formatting", "accessibility", "productivity"],
+      "category": "developer-tools",
+      "tags": ["output-style", "productivity", "accessibility"]
+    },
+    {
       "name": "intelligent-compact",
       "source": "./plugins/intelligent-compact",
       "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
@@ -447,21 +462,6 @@
       "keywords": ["overleaf", "latex", "review", "comments", "academic", "writing"],
       "category": "research",
       "tags": ["research", "academic", "latex"]
-    },
-    {
-      "name": "adhd-output-style",
-      "source": "./plugins/adhd-output-style",
-      "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
-      "version": "1.0.0",
-      "author": {
-        "name": "Fatih Akyon"
-      },
-      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
-      "repository": "https://github.com/fcakyon/claude-codex-settings",
-      "license": "Apache-2.0",
-      "keywords": ["output-style", "adhd", "formatting", "accessibility", "productivity"],
-      "category": "developer-tools",
-      "tags": ["output-style", "productivity", "accessibility"]
     }
   ]
 }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
@@ -14,25 +14,25 @@ network_access = true
 [analytics]
 enabled = false
 
-[plugins."github-dev@claude-settings"]
+[plugins."simplify@claude-settings"]
 enabled = true
 
-[plugins."frontend-design-skills@claude-settings"]
+[plugins."humanize@claude-settings"]
 enabled = true
 
 [plugins."openai-office-skills@claude-settings"]
 enabled = true
 
-[plugins."agent-browser@claude-settings"]
-enabled = true
-
 [plugins."python-skills@claude-settings"]
 enabled = true
 
-[plugins."simplify@claude-settings"]
+[plugins."agent-browser@claude-settings"]
 enabled = true
 
-[plugins."humanize@claude-settings"]
+[plugins."frontend-design-skills@claude-settings"]
+enabled = true
+
+[plugins."github-dev@claude-settings"]
 enabled = true
 
 [plugins."ultralytics-dev@claude-settings"]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -24,6 +24,13 @@
       "license": "Apache-2.0"
     },
     {
+      "name": "adhd-output-style",
+      "source": "./plugins/adhd-output-style",
+      "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    },
+    {
       "name": "intelligent-compact",
       "source": "./plugins/intelligent-compact",
       "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
@@ -202,13 +209,6 @@
       "name": "overleaf-skills",
       "source": "./plugins/overleaf-skills",
       "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
-      "version": "1.0.0",
-      "license": "Apache-2.0"
-    },
-    {
-      "name": "adhd-output-style",
-      "source": "./plugins/adhd-output-style",
-      "description": "Answer-first replies for limited working memory: numbered steps, time estimates, a clear next action, and short teaching notes while coding.",
       "version": "1.0.0",
       "license": "Apache-2.0"
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ claude-settings/
       agents/<agent>.md                  # Claude Code + Gemini + Cursor
       hooks/hooks.json + scripts/        # Claude Code + Gemini only
       commands/<cmd>.md                  # Claude Code only
+      output-styles/<style>.md           # Claude Code only
 ```
 
 ## Cross-Tool Plugin Format Reference
@@ -234,6 +235,7 @@ Commands are Claude Code only. Gemini CLI uses TOML commands. Other tools use sk
 | Agents (`agents/<name>.md`)       | native      | config.toml | preview     | native  |
 | Hooks (`hooks/hooks.json`)        | native      | no          | native      | partial |
 | Commands (`commands/<name>.md`)   | native (MD) | no          | TOML format | no      |
+| Output styles (`output-styles/`)  | native      | no          | no          | no      |
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,15 @@ Spawn a stronger Fable 5 reviewer to pressure-test a plan or conclusion before y
 | --------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
 | `claude plugin install adhd-output-style@claude-settings` | `codex plugin add adhd-output-style@claude-settings` | `gemini extensions install --path ./plugins/adhd-output-style` |
 
-Reformats every reply for limited working memory: the answer or next step first, numbered one-action-per-step lists, concrete time estimates, a single under-two-minute next action, and short teaching notes while coding. Enabling the plugin applies the style automatically. Output styles apply in Claude Code.
+Reformats replies for limited working memory: the answer or next step first, numbered one-action-per-step lists, concrete time estimates, a single under-two-minute next action, and short teaching notes while coding. Claude Code applies the output style automatically. Codex, Cursor, and Gemini CLI expose the same instructions as an `adhd-output-style` skill because they do not support plugin output styles.
 
 **Output styles:**
 
 - [`ADHD Explanatory`](./plugins/adhd-output-style/output-styles/adhd-explanatory.md) - Answer-first ADHD formatting plus educational Insight blocks while coding
+
+**Skills:**
+
+- [`adhd-output-style`](./plugins/adhd-output-style/skills/adhd-output-style/SKILL.md) - Apply the same reply format in Codex, Cursor, and Gemini CLI
 
 </details>
 
@@ -963,7 +967,7 @@ For Codex CLI, see the recipe at [`.codex/config-minimax.toml`](./.codex/config-
 
 Configuration in [`~/.codex/config.toml`](./.codex/config.toml):
 
-- **Model**: `gpt-5.6-terra` with `model_reasoning_effort` set to "high"
+- **Model**: `gpt-5.6-sol` with `model_reasoning_effort` set to "high"
 - **Sandbox**: `workspace-write` with network access enabled
 - **Plugins**: a curated set enabled from this marketplace (`simplify`, `github-dev`, `python-skills`, and more)
 

--- a/plugins/adhd-output-style/skills/adhd-output-style/SKILL.md
+++ b/plugins/adhd-output-style/skills/adhd-output-style/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: adhd-output-style
+description: This skill should be used when the user asks for "ADHD output", "answer-first replies", "short numbered steps", "limited working memory formatting", or explicitly invokes "adhd-output-style".
+---
+
+Format every response for a reader with limited working memory who needs
+low-friction starts and visible progress, while still teaching. Apply to all
+interactions in the current task.
+
+## Structure (ADHD)
+
+- Open with the actionable step or the answer, not context or setup.
+- Break multi-step work into numbered lists, one action per step.
+- End with a single next action that takes under two minutes.
+- Keep secondary issues separate; do not bundle them into the main answer.
+- Restate progress each turn (e.g. "step 3 of 5"); assume prior context is lost.
+- Use concrete time estimates ("~2 min", "3 files"), never vague ones.
+- State what now works in plain terms instead of burying it in a recap.
+- Describe errors factually: cause, then fix. No alarmed language.
+- Cap lists at five items; split longer ones into priority tiers.
+- Cut preambles, recaps, and closing pleasantries. Start at the answer, stop when done.
+
+Exceptions: give full walkthroughs when asked; confirm before destructive
+actions; pause with a diagnostic question after repeated failed debugging;
+ask one clarifying question on genuine ambiguity before proceeding.
+
+## Education (Explanatory)
+
+Before and after writing code, add a short educational note using this block:
+
+`★ Insight ─────────────────────────────────────`
+[2-3 codebase-specific educational points]
+`─────────────────────────────────────────────────`
+
+Put depth here, not in the main answer. Prefer insights specific to this
+codebase or the code just written over general programming concepts. Cap at
+three points so the block stays scannable. The rest of the response stays terse.


### PR DESCRIPTION
Codex still favored Terra, the three marketplaces no longer matched the README order, and ADHD instructions only loaded as a Claude Code output style.

- set Codex to Sol with high reasoning
- place ADHD fourth in all 3 marketplaces
- expose ADHD as a skill in Codex, Cursor, and Gemini CLI
- keep automatic output-style behavior in Claude Code
- verify the layouts against [Claude Code](https://code.claude.com/docs/en/output-styles), [Codex](https://developers.openai.com/codex/plugins/build), [Cursor](https://cursor.com/docs/reference/plugins), and [Gemini CLI](https://github.com/google-gemini/gemini-cli/blob/main/docs/extensions/reference.md)

```diff
-model = "gpt-5.6-terra"
+model = "gpt-5.6-sol"
```