### PR TITLE
Let Cloudflare deploy both sites

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,3 @@
+{
+  "compatibility_date": "2026-07-21"
+}


### PR DESCRIPTION
Cloudflare builds finish, but deployment stops before replacing the Hello World Worker because Wrangler has no compatibility date.

- Before: A compatibility_date is required when uploading a Worker.
- Set compatibility_date to 2026-07-21 at the repository root for both connected builds.
- After for claudesettingscom and agentpluginsnet with Wrangler 4.112.0:

    ✨ Read 9 files from the assets directory /Users/fatih/dev/claude-settings/site/dist
    Total Upload: 0.38 KiB / gzip: 0.26 KiB
    No bindings found.
    --dry-run: exiting now.

Both dry runs exited with code 0.