### PR TITLE
Fix Codex hook support instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ claude-settings/
       gemini-extension.json              # Gemini CLI manifest
       skills/<skill>/SKILL.md            # universal across all tools
       agents/<agent>.md                  # Claude Code + Gemini + Cursor
-      hooks/hooks.json + scripts/        # Claude Code + Gemini only
+      hooks/hooks.json + scripts/        # Claude Code + Codex CLI + Gemini
       commands/<cmd>.md                  # Claude Code only
       output-styles/<style>.md           # Claude Code only
 ```
@@ -53,6 +53,7 @@ Docs:
 
 - Claude Code: https://code.claude.com/docs/en/plugins-reference
 - Codex CLI: https://developers.openai.com/codex/plugins/build/
+- Codex CLI hooks: https://learn.chatgpt.com/docs/hooks
 - Cursor: https://cursor.com/docs/reference/plugins
 - Gemini CLI: https://geminicli.com/docs/extensions/reference/
 - AGENTS.md spec: https://agents.md/
@@ -208,12 +209,16 @@ Path: `hooks/hooks.json`
 }
 ```
 
-Events: PreToolUse, PostToolUse, Stop, SubagentStart, SubagentStop, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification.
+Codex events: PreToolUse, PermissionRequest, PostToolUse, PreCompact, PostCompact, UserPromptSubmit,
+SubagentStart, SubagentStop, Stop, and SessionStart. Other tools may support additional events.
 
 Hook types:
 
-- `command`: runs a script. Script reads JSON from stdin, exit 0 = pass, exit 2 = block.
-- `prompt`: injects a prompt into the conversation.
+- `command`: runs a script that reads JSON from stdin.
+- `prompt`: supported by Claude Code and Gemini. Codex parses it but skips it.
+- `agent`: Codex parses it but skips it.
+
+Blocking and rewrite responses are tool-specific. Follow each tool's hook response schema.
 
 Use `${CLAUDE_PLUGIN_ROOT}` for script paths. `matcher` matches tool names (e.g., "Edit", "Bash", "mcp**tavily**tavily_search").
 
@@ -238,7 +243,7 @@ Commands are Claude Code only. Gemini CLI uses TOML commands. Other tools use sk
 | --------------------------------- | ----------- | ----------- | ----------- | ------- |
 | Skills (`skills/<name>/SKILL.md`) | native      | native      | native      | native  |
 | Agents (`agents/<name>.md`)       | native      | config.toml | preview     | native  |
-| Hooks (`hooks/hooks.json`)        | native      | no          | native      | partial |
+| Hooks (`hooks/hooks.json`)        | native      | native      | native      | partial |
 | Commands (`commands/<name>.md`)   | native (MD) | no          | TOML format | no      |
 | Output styles (`output-styles/`)  | native      | no          | no          | no      |
 


### PR DESCRIPTION
Codex now supports lifecycle hooks, but the repo guide still marked them unsupported. That sent hook debugging in the wrong direction.

- marks hooks native for Codex CLI
- lists the current Codex hook events
- notes that Codex runs command handlers and skips prompt and agent handlers
- links the official Codex hook reference

Before: Hooks | Codex CLI: no
After: Hooks | Codex CLI: native