### PR TITLE
Prioritize visuals in generated PR descriptions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -347,7 +347,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -160,7 +160,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/agents/pr-creator.md
+++ b/plugins/github-dev/agents/pr-creator.md
@@ -66,8 +66,12 @@ findings in the PR body when available.
      - `-b` or `--body`: write it like a sharp teammate would, not a changelog.
        Open on why it exists, not "This PR...".
        Short scannable bullets, one point each, a few words, not verbose sentences.
-       Show it too: a `diff`, a before/after, or a CLI snippet they can run.
-       Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
+       Lead with the most visual proof, don't just describe it: a screenshot for UI or output changes,
+       a benchmark table for results, else a `diff`, before/after, or runnable CLI snippet.
+       Numbers win: put benchmarks, counts, speedups and comparisons in a markdown table.
+       To embed an image you can't drag-drop, commit it and link a commit-pinned raw URL that survives
+       branch deletion: `https://raw.githubusercontent.com/OWNER/REPO/COMMIT_SHA/path/to/shot.webp`
+       (full commit SHA, not the branch). Confirm `200 image/*` with `curl -sI` before embedding.
        One read, one section, no headers. No test plans, file lists, or line links.
      - `-a @me`: Self-assign (confirmation hook will show actual username)
      - `-r <reviewer>`: Only add if the user explicitly asks OR recent PRs by this author have reviewers.

--- a/plugins/github-dev/gemini-extension.json
+++ b/plugins/github-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "github-dev",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
 }

--- a/plugins/github-dev/skills/create-pr/SKILL.md
+++ b/plugins/github-dev/skills/create-pr/SKILL.md
@@ -54,9 +54,10 @@ plain-language branch name rather than copying the full text.
 7. **PR Body Guidelines**
    - Open on why it exists, not "This PR...".
    - Short scannable bullets, one point each, a few words, not verbose sentences.
-   - Show it too: a `diff`, a before/after, or a CLI snippet they can run.
-   - Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
+   - Lead with the most visual proof, don't just describe it: a screenshot for UI or output changes, a benchmark table for results, else a `diff`, before/after, or runnable CLI snippet.
+   - Numbers win: put benchmarks, counts, speedups and comparisons in a markdown table, not a paragraph.
    - One read, one section, no headers. Plain words, no buzzwords, no test plans or file lists.
+   - **Embedding images**: you can't drag-drop, so commit the image and reference it with a commit-pinned raw URL that survives the branch being deleted: `https://raw.githubusercontent.com/OWNER/REPO/COMMIT_SHA/path/to/shot.webp` (full commit SHA, never the branch name). Confirm it returns `200 image/*` with `curl -sI` before embedding, then put a before/after pair side by side in a two-column table.
 
 ## Examples
 
@@ -81,4 +82,19 @@ Add a compare command for side-by-side model runs
 Point it at a folder and a few models and it stitches the panels together, so you can eyeball which one wins without juggling tabs.
 
 `ultrannotate compare --source ./images --models sam3.pt,yoloe-26x-seg.pt --phrases "person,car"`
+```
+
+### Screenshot and benchmark table
+
+```
+Link shares showed no thumbnail because the preview image had expired. Each site now serves its own screenshot.
+
+| before | after |
+|---|---|
+| no preview, redirect to an expired URL | ![new preview](https://raw.githubusercontent.com/fcakyon/claude-codex-settings/9bedce4/site/public/og-settings.webp) |
+
+| format | size | shows in whatsapp |
+|---|---|---|
+| png | 1.8 MB | no |
+| webp lossless | 87 KB | yes |
 ```

--- a/plugins/github-dev/skills/update-pr-summary/SKILL.md
+++ b/plugins/github-dev/skills/update-pr-summary/SKILL.md
@@ -22,8 +22,8 @@ When explicitly invoked with extra text, treat that text as the PR number or URL
 3. **Generate the updated summary**
    - Follow the `create-pr` skill format for title and body.
    - Title: a short human headline, capital first letter, no `fix:` or `feat:` prefix. Lead with the outcome, punchy over exhaustive.
-   - Body: open on why, then short scannable bullets (one point each) plus a `diff`, before/after, or runnable CLI snippet.
-   - Numbers win: benchmarks, counts, speedups, comparisons over adjectives.
+   - Body: open on why, then short scannable bullets (one point each). Lead with the most visual proof: a screenshot for UI or output changes, a benchmark table for results, else a `diff`, before/after, or runnable CLI snippet. See the `create-pr` skill for embedding images with a commit-pinned raw URL.
+   - Numbers win: put benchmarks, counts, speedups and comparisons in a markdown table.
    - One read, one section, no headers. Plain words, no buzzwords.
    - No test plans, file lists, or line links.
 


### PR DESCRIPTION
PR bodies land better when the picture is in them, but the create-pr skill and pr-creator agent only ever suggested a `diff` or CLI snippet and gave no way to embed an image. #232 had to work that out by hand.

Now they lead with the most visual proof and spell out the embed trick:

```diff
- Show it too: a `diff`, a before/after, or a CLI snippet they can run.
+ Lead with the most visual proof: a screenshot for UI, a benchmark table for results, else a diff/CLI.
```

- screenshots and benchmark tables ranked first, ahead of diffs and text
- concrete how-to: commit the image, link a commit-pinned raw URL, verify `200 image/*` before embedding
- same guidance across create-pr, pr-creator, and update-pr-summary
- github-dev 2.4.2 to 2.4.3 so `claude plugin update` ships it
