### PR TITLE
Stop Cloudflare's recurring Worker rename PRs

### DIFF
--- a/wrangler.agentplugins.jsonc
+++ b/wrangler.agentplugins.jsonc
@@ -1,0 +1,4 @@
+{
+  "name": "agentpluginsnet",
+  "compatibility_date": "2026-07-21"
+}

--- a/wrangler.claudesettings.jsonc
+++ b/wrangler.claudesettings.jsonc
@@ -1,0 +1,4 @@
+{
+  "name": "claudesettingscom",
+  "compatibility_date": "2026-07-21"
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,3 +1,0 @@
-{
-  "compatibility_date": "2026-07-21","name": "agentpluginsnet"
-}


### PR DESCRIPTION
Cloudflare's workers-and-pages app keeps opening rename PRs like #231 because one shared `wrangler.jsonc` (name `agentpluginsnet`) is read by two Workers. The `claudesettingscom` Worker sees a name mismatch on every build and opens a PR. Merging it just flips the mismatch to the other Worker, so it never stops.

Fix: one config per Worker with matching names.

```diff
- wrangler.jsonc                 name: agentpluginsnet   (shared by both)
+ wrangler.claudesettings.jsonc  name: claudesettingscom
+ wrangler.agentplugins.jsonc    name: agentpluginsnet
```

One-time dashboard step, in each Worker's Build settings, set the deploy command:
- claudesettingscom, `npx wrangler deploy -c wrangler.claudesettings.jsonc`
- agentpluginsnet, `npx wrangler deploy -c wrangler.agentplugins.jsonc`

Then the config name matches each Worker, the auto-PRs stop, and #231 can be closed. Verified against Cloudflare's monorepo builds docs (separate config plus per-Worker deploy command).
