### PR TITLE
Fix broken deploys by pointing wrangler configs at built assets

### DIFF
--- a/wrangler.agentplugins.jsonc
+++ b/wrangler.agentplugins.jsonc
@@ -1,4 +1,7 @@
 {
   "name": "agentpluginsnet",
-  "compatibility_date": "2026-07-21"
+  "compatibility_date": "2026-07-21",
+  "assets": {
+    "directory": "./site/dist"
+  }
 }

--- a/wrangler.claudesettings.jsonc
+++ b/wrangler.claudesettings.jsonc
@@ -1,4 +1,7 @@
 {
   "name": "claudesettingscom",
-  "compatibility_date": "2026-07-21"
+  "compatibility_date": "2026-07-21",
+  "assets": {
+    "directory": "./site/dist"
+  }
 }


### PR DESCRIPTION
The split configs (#234) only carried `name` and `compatibility_date`, so `npx wrangler deploy -c wrangler.agentplugins.jsonc` failed with "Missing entry-point to Worker script or to assets directory" and both sites stopped deploying. The old single-config setup passed the assets on the command line, the `-c` form has no such pointer.

Point each config at the Astro build output:

```diff
  {
    "name": "agentpluginsnet",
-   "compatibility_date": "2026-07-21"
+   "compatibility_date": "2026-07-21",
+   "assets": { "directory": "./site/dist" }
  }
```

Now `wrangler deploy -c <file>` is self-contained and needs no extra dashboard flags. Wrangler suggested this exact fix in the failed build log.
