### PR TITLE
Scope the simplify-guard token per worktree

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "simplify",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups."
 }

--- a/plugins/simplify/hooks/scripts/guard.py
+++ b/plugins/simplify/hooks/scripts/guard.py
@@ -1,39 +1,50 @@
 #!/usr/bin/env python3
 """Block `git commit` until /simplify runs. Each commit spends one /simplify.
 
-Per-session marker under TMPDIR (keyed by session_id) is a one-shot token: /simplify mints it,
-the next commit consumes it, so every commit re-requires a fresh /simplify.
-Harness-agnostic hook contract, so Codex, which installs this plugin's /simplify, is guarded too.
+The marker lives in the per-worktree git dir (`git rev-parse --git-dir`): /simplify reviews the
+staged diff and the index is per-worktree, so the token is minted and spent in the same worktree
+any session or subagent commits from. /simplify mints via the Skill tool, which only Claude Code
+fires, so the commit deny is scoped to Claude Code, other harnesses that can never mint are not
+blocked.
 """
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
 data = json.load(sys.stdin)
 event = data.get("hook_event_name", "")
-session_id = data.get("session_id") or "nosession"
-marker = Path(os.environ.get("TMPDIR", "/tmp")) / "simplify-guard" / f"{session_id}.ok"
 tool_input = data.get("tool_input") or {}
 
-if event == "PostToolUse":  # matcher scopes to the Skill tool, confirm it was /simplify
-    if tool_input.get("skill") == "simplify" or tool_input.get("name") == "simplify":
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.touch()
-elif event == "PreToolUse" and re.search(r"git\s+commit(?![\w-])", tool_input.get("command", "")):
+
+def marker():
+    git_dir = subprocess.run(
+        ["git", "-C", data.get("cwd") or ".", "rev-parse", "--path-format=absolute", "--git-dir"],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return Path(git_dir) / "simplify-guard.ok" if git_dir else None
+
+
+# PostToolUse matcher scopes to the Skill tool, confirm it was /simplify
+if event == "PostToolUse" and tool_input.get("skill") == "simplify" and (m := marker()):
+    m.touch()
+elif event == "PreToolUse" and os.environ.get("CLAUDECODE") == "1":
     # matcher scopes to Bash, self-filter to `git commit` (not commit-graph/-tree)
-    if marker.exists():
-        marker.unlink()  # spend the token: this commit uses up the pending /simplify
-    else:
-        print(
-            json.dumps(
-                {
-                    "hookSpecificOutput": {
-                        "hookEventName": "PreToolUse",
-                        "permissionDecision": "deny",
-                        "permissionDecisionReason": "simplify-guard: run /simplify on the staged diff first, then retry the commit.",
+    if re.search(r"git\s+commit(?![\w-])", tool_input.get("command", "")) and (m := marker()):
+        if m.exists():
+            m.unlink()  # spend the token: this commit uses up the pending /simplify
+        else:
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PreToolUse",
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": "simplify-guard: run /simplify on the staged diff first, then retry the commit.",
+                        }
                     }
-                }
+                )
             )
-        )


### PR DESCRIPTION
The simplify-guard hook stored its "already ran /simplify" marker in a temp file named after the session id. A commit made from a subagent or a second session has a different session id, so it never found the marker and got blocked right after /simplify ran, which is the "breaks agent sessions" problem.

- key the marker on the per-worktree git dir (`git rev-parse --git-dir`) instead of the session, so any session or subagent committing from the same working tree shares one token
- per-worktree is the right scope: each worktree has its own staging area and /simplify reviews the staged diff, so a repo-wide marker would let one worktree's /simplify wave through another worktree's unrelated commit
- only block on Claude Code, the one tool that can actually mint the token. Codex and Gemini never fire the mint event, so blocking them was a permanent lockout, and it also crashed on Codex's list-style command
- drops the temp-dir path, the no-session fallback, and one nesting level

```diff
-marker = Path(TMPDIR) / "simplify-guard" / f"{session_id}.ok"
+git_dir = git("rev-parse", "--path-format=absolute", "--git-dir")
+marker = Path(git_dir) / "simplify-guard.ok"
```

Verified against a real worktree repo: a same-tree subagent commit passes, a worktree that never ran /simplify is denied, and the Codex and outside-a-repo paths no longer misfire. Net 39 added, 28 removed.
