### PR TITLE
Harden git-workflow guard hooks across Claude Code and Codex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "author": {
         "name": "Fatih Akyon"
       },
@@ -361,8 +361,8 @@
     {
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
-      "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
-      "version": "2.1.2",
+      "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
+      "version": "2.2.0",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -347,7 +347,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -160,7 +160,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "license": "Apache-2.0"
     },
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0"
     },
     {
@@ -166,8 +166,8 @@
     {
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
-      "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
-      "version": "2.1.2",
+      "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
+      "version": "2.2.0",
       "license": "Apache-2.0"
     },
     {

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 
 - [`simplify`](./plugins/simplify/skills/simplify/SKILL.md) - review the changed diff across four angles and apply the fixes
 
+**Hooks:**
+
+- [`guard.py`](./plugins/simplify/hooks/scripts/guard.py) - Require a /simplify run before each git commit
+
 </details>
 
 <details>
@@ -702,17 +706,18 @@ Git and GitHub automation. Run the `setup` skill after install.
 
 - [`git_commit_confirm.py`](./plugins/github-dev/hooks/scripts/git_commit_confirm.py) - Confirmation before git commit
 - [`gh_pr_create_confirm.py`](./plugins/github-dev/hooks/scripts/gh_pr_create_confirm.py) - Confirmation before gh pr create
+- [`block_ai_attribution.py`](./plugins/github-dev/hooks/scripts/block_ai_attribution.py) - Block AI attribution lines in commits and PRs
 
 </details>
 
 <details>
-<summary><strong>ultralytics-dev</strong> - Auto-formatting hooks</summary>
+<summary><strong>ultralytics-dev</strong> - Auto-formatting hooks + force-push guard</summary>
 
 | Claude Code                                             | Codex CLI                                          | Gemini CLI                                                   |
 | ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
 | `claude plugin install ultralytics-dev@claude-settings` | `codex plugin add ultralytics-dev@claude-settings` | `gemini extensions install --path ./plugins/ultralytics-dev` |
 
-Auto-formatting hooks for Python, JavaScript, Markdown, and Bash.
+Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.
 
 **Hooks:**
 
@@ -721,6 +726,7 @@ Auto-formatting hooks for Python, JavaScript, Markdown, and Bash.
 - [`prettier_formatting.py`](./plugins/ultralytics-dev/hooks/scripts/prettier_formatting.py) - JavaScript/TypeScript/CSS/JSON
 - [`markdown_formatting.py`](./plugins/ultralytics-dev/hooks/scripts/markdown_formatting.py) - Markdown formatting
 - [`bash_formatting.py`](./plugins/ultralytics-dev/hooks/scripts/bash_formatting.py) - Bash script formatting
+- [`block_force_push.py`](./plugins/ultralytics-dev/hooks/scripts/block_force_push.py) - Block force-push and rebase
 
 </details>
 

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/agents/pr-creator.md
+++ b/plugins/github-dev/agents/pr-creator.md
@@ -64,8 +64,8 @@ findings in the PR body when available.
        Punchy beats exhaustive. Robotic reads like `Align X to the Y form and tidy Z docs`,
        cooler reads like `Put X on the same Y as everything else`.
      - `-b` or `--body`: write it like a sharp teammate would, not a changelog.
-       Open on why it exists, not "This PR...".
-       Short scannable bullets, one point each, a few words, not verbose sentences.
+       One-line why it exists, not "This PR...". No second intro paragraph.
+       Three bullets max, one point each, under ~12 words. A fourth means you are over-explaining, cut it.
        Lead with the most visual proof, don't just describe it: a screenshot for UI or output changes,
        a benchmark table for results, else a `diff`, before/after, or runnable CLI snippet.
        Numbers win: put benchmarks, counts, speedups and comparisons in a markdown table.

--- a/plugins/github-dev/gemini-extension.json
+++ b/plugins/github-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "github-dev",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
 }

--- a/plugins/github-dev/hooks/hooks.json
+++ b/plugins/github-dev/hooks/hooks.json
@@ -1,10 +1,14 @@
 {
-  "description": "Git workflow confirmation hooks for GitHub operations",
+  "description": "Git workflow hooks: block AI attribution in commits and PRs, then confirm them",
   "hooks": {
     "PreToolUse": [
       {
         "matcher": "Bash",
         "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block_ai_attribution.py"
+          },
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/git_commit_confirm.py"

--- a/plugins/github-dev/hooks/scripts/block_ai_attribution.py
+++ b/plugins/github-dev/hooks/scripts/block_ai_attribution.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block git commit and gh commands that carry AI-attribution trailers.
+
+Denies the command when its message or body contains a footer such as "Claude-Session:",
+"Co-Authored-By: <assistant>", "Generated with Claude Code", or a claude.ai/code/session link, and
+tells the caller to re-issue it without that line. Reads a string command (Claude Code) and an argv
+array (Codex). The deny decision works identically on both harnesses.
+"""
+import json
+import re
+import sys
+
+ATTRIBUTION = re.compile(
+    r"Claude-Session:"
+    r"|Co-Authored-By:[ \t]*(?:Claude|Codex|ChatGPT|OpenAI|Gemini|Cursor|Copilot)"
+    r"|Generated with[^\n]*Claude Code"
+    r"|https?://claude\.ai/code/session",
+    re.IGNORECASE,
+)
+
+command = (json.load(sys.stdin).get("tool_input") or {}).get("command", "")
+text = " ".join(map(str, command)) if isinstance(command, list) else str(command)
+
+# deny only when it is a git commit or gh command that carries an attribution trailer
+if re.search(r"\bgit\b[^|&]*\bcommit\b|\bgh\b", text) and ATTRIBUTION.search(text):
+    reason = (
+        "This command carries an AI-attribution trailer (Claude-Session, Co-Authored-By an AI assistant, "
+        "'Generated with Claude Code', or a claude.ai/code/session link). Re-issue it with that line removed "
+        "from the commit message or PR body."
+    )
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}))

--- a/plugins/github-dev/hooks/scripts/gh_pr_create_confirm.py
+++ b/plugins/github-dev/hooks/scripts/gh_pr_create_confirm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """PreToolUse hook: show confirmation modal before creating GitHub PR via gh CLI."""
 import json
+import os
 import re
 import subprocess
 import sys
@@ -112,8 +113,8 @@ tool_name = input_data.get("tool_name", "")
 tool_input = input_data.get("tool_input", {})
 command = tool_input.get("command", "")
 
-# Only handle gh pr create commands
-if tool_name != "Bash" or not command.strip().startswith("gh pr create"):
+# ask is Claude Code only. Skipping elsewhere also avoids .strip() on a Codex argv list
+if os.environ.get("CLAUDECODE") != "1" or tool_name != "Bash" or not command.strip().startswith("gh pr create"):
     sys.exit(0)
 
 # Parse PR parameters

--- a/plugins/github-dev/hooks/scripts/git_commit_confirm.py
+++ b/plugins/github-dev/hooks/scripts/git_commit_confirm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """PreToolUse hook: show confirmation modal before creating git commit."""
 import json
+import os
 import re
 import subprocess
 import sys
@@ -136,8 +137,8 @@ tool_name = input_data.get("tool_name", "")
 tool_input = input_data.get("tool_input", {})
 command = tool_input.get("command", "")
 
-# Only handle git commit commands
-if tool_name != "Bash" or not command.strip().startswith("git commit"):
+# ask is Claude Code only. Skipping elsewhere also avoids .strip() on a Codex argv list
+if os.environ.get("CLAUDECODE") != "1" or tool_name != "Bash" or not command.strip().startswith("git commit"):
     sys.exit(0)
 
 # Parse commit message

--- a/plugins/github-dev/skills/create-pr/SKILL.md
+++ b/plugins/github-dev/skills/create-pr/SKILL.md
@@ -52,8 +52,8 @@ plain-language branch name rather than copying the full text.
        If recent PRs have no reviewers, skip `-r` entirely.
 
 7. **PR Body Guidelines**
-   - Open on why it exists, not "This PR...".
-   - Short scannable bullets, one point each, a few words, not verbose sentences.
+   - One-line why it exists, not "This PR...". No second intro paragraph.
+   - Three bullets max, one point each, under ~12 words. Need a fourth? You are over-explaining, cut it.
    - Lead with the most visual proof, don't just describe it: a screenshot for UI or output changes, a benchmark table for results, else a `diff`, before/after, or runnable CLI snippet.
    - Numbers win: put benchmarks, counts, speedups and comparisons in a markdown table, not a paragraph.
    - One read, one section, no headers. Plain words, no buzzwords, no test plans or file lists.

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "simplify",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups."
 }

--- a/plugins/simplify/hooks/scripts/guard.py
+++ b/plugins/simplify/hooks/scripts/guard.py
@@ -32,8 +32,9 @@ def marker():
 if event == "PostToolUse" and tool_input.get("skill") == "simplify" and (m := marker()):
     m.touch()
 elif event == "PreToolUse" and os.environ.get("CLAUDECODE") == "1":
-    # matcher scopes to Bash, self-filter to `git commit` (not commit-graph/-tree)
-    if re.search(r"git\s+commit(?![\w-])", tool_input.get("command", "")) and (m := marker()):
+    # match a real `git commit` (not commit-graph/-tree) with quoted args stripped
+    bare = re.sub(r"'[^']*'|\"[^\"]*\"", "", tool_input.get("command", ""))
+    if re.search(r"git\s+commit(?![\w-])", bare) and (m := marker()):
         if m.exists():
             m.unlink()  # spend the token: this commit uses up the pending /simplify
         else:

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.1.2",
-  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
+  "version": "2.2.0",
+  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.1.2",
-  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
+  "version": "2.2.0",
+  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.1.2",
-  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks.",
+  "version": "2.2.0",
+  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/gemini-extension.json
+++ b/plugins/ultralytics-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.1.2",
-  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash with Google-style docstrings and code quality checks."
+  "version": "2.2.0",
+  "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase."
 }

--- a/plugins/ultralytics-dev/hooks/hooks.json
+++ b/plugins/ultralytics-dev/hooks/hooks.json
@@ -1,6 +1,17 @@
 {
-  "description": "Code formatting and quality hooks for Ultralytics development",
+  "description": "Code formatting and quality hooks plus a force-push and rebase guard for Ultralytics development",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block_force_push.py"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|MultiEdit|Write",

--- a/plugins/ultralytics-dev/hooks/scripts/block_force_push.py
+++ b/plugins/ultralytics-dev/hooks/scripts/block_force_push.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block force-push and rebase, which rewrite shared history.
+
+Denies git push --force / -f / --force-with-lease and git rebase, telling the caller to add a
+follow-up commit or a fresh branch instead. Reads a string command (Claude Code) and an argv array
+(Codex). Quoted text is stripped first so a force flag mentioned inside a commit message or PR body
+does not trip the guard. The deny decision works identically on both harnesses.
+"""
+import json
+import re
+import sys
+
+command = (json.load(sys.stdin).get("tool_input") or {}).get("command", "")
+text = " ".join(map(str, command)) if isinstance(command, list) else str(command)
+# drop quoted argument bodies so a force flag inside a message or body is not matched
+bare = re.sub(r"'[^']*'|\"[^\"]*\"", "", text)
+
+force_push = re.search(r"\bgit\s+push\b", bare) and re.search(r"--force(?:-with-lease|-if-includes)?\b|(?<![\w-])-\w*f(?![\w-])", bare)
+rebase = re.search(r"\bgit\s+rebase\b", bare)
+if force_push or rebase:
+    reason = (
+        "Force-push and rebase rewrite shared history and are blocked here. Add a follow-up commit "
+        "instead of amending, or open a fresh branch. Run the rebase yourself if it is truly needed."
+    )
+    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}))

--- a/plugins/ultralytics-dev/hooks/scripts/block_force_push.py
+++ b/plugins/ultralytics-dev/hooks/scripts/block_force_push.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """PreToolUse hook: block force-push and rebase, which rewrite shared history.
 
-Denies git push --force / -f / --force-with-lease and git rebase, telling the caller to add a
-follow-up commit or a fresh branch instead. Reads a string command (Claude Code) and an argv array
-(Codex). Quoted text is stripped first so a force flag mentioned inside a commit message or PR body
-does not trip the guard. The deny decision works identically on both harnesses.
+Denies git push force forms (--force, -f, --force-with-lease, a leading + on a refspec) and git
+rebase, telling the caller to add a follow-up commit or a fresh branch instead. Reads a string
+command (Claude Code) and an argv array (Codex). Quoted text is stripped first so a force flag
+mentioned inside a commit message or PR body does not trip the guard. The deny decision works
+identically on both harnesses.
 """
 import json
 import re
@@ -15,8 +16,12 @@ text = " ".join(map(str, command)) if isinstance(command, list) else str(command
 # drop quoted argument bodies so a force flag inside a message or body is not matched
 bare = re.sub(r"'[^']*'|\"[^\"]*\"", "", text)
 
-# keep the force flag scoped to the same clause as `git push`, so a -f on another command does not trip it
-force_push = re.search(r"\bgit\s+push\b[^|&;\n]*(?:--force(?:-with-lease|-if-includes)?\b|(?<![\w-])-\w*f(?![\w-]))", bare)
+# scope the force flag to the git push clause, allowing options like -C between git and push, so a -f on
+# another command in a compound line does not trip it. A leading + on a refspec also force-pushes
+force_push = re.search(
+    r"\bgit\b[^|&;\n]*\bpush\b[^|&;\n]*(?:--force(?:-with-lease|-if-includes)?\b|(?<![\w-])-\w*f(?![\w-])|(?<![\w+])\+\w)",
+    bare,
+)
 rebase = re.search(r"\bgit\s+rebase\b", bare)
 if force_push or rebase:
     reason = (

--- a/plugins/ultralytics-dev/hooks/scripts/block_force_push.py
+++ b/plugins/ultralytics-dev/hooks/scripts/block_force_push.py
@@ -15,7 +15,8 @@ text = " ".join(map(str, command)) if isinstance(command, list) else str(command
 # drop quoted argument bodies so a force flag inside a message or body is not matched
 bare = re.sub(r"'[^']*'|\"[^\"]*\"", "", text)
 
-force_push = re.search(r"\bgit\s+push\b", bare) and re.search(r"--force(?:-with-lease|-if-includes)?\b|(?<![\w-])-\w*f(?![\w-])", bare)
+# keep the force flag scoped to the same clause as `git push`, so a -f on another command does not trip it
+force_push = re.search(r"\bgit\s+push\b[^|&;\n]*(?:--force(?:-with-lease|-if-includes)?\b|(?<![\w-])-\w*f(?![\w-]))", bare)
 rebase = re.search(r"\bgit\s+rebase\b", bare)
 if force_push or rebase:
     reason = (


### PR DESCRIPTION
Attribution footers and force-push kept slipping through. This hardens the git-workflow guards and fixes how they behave across tools.

- Deny guards block AI-attribution trailers and force-push/rebase on Claude Code and Codex
- Confirm hooks now skip non-Claude tools cleanly, simplify-guard ignores commit words in quoted text
- PR-body guidance tightened to 3 bullets max, under ~12 words