### PR TITLE
Ship downloadable zips for local skill-only plugins

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -43,6 +43,12 @@ for sync_script in "$SCRIPTS_DIR"/sync-*-skills.sh; do
   [ -f "$sync_script" ] && bash "$sync_script"
 done
 
+# Local skill-only plugins have no vendor sync script, so zip their skills here for download assets
+source "$SCRIPTS_DIR/_helpers.sh"
+for skill_dir in plugins/{python-skills,adhd-output-style}/skills/*/; do
+  create_zip "$skill_dir"
+done
+
 # Collect zip files from skill directories
 ZIP_FILES=()
 while IFS= read -r -d '' f; do

--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ Cuts filler and keeps output token use down with the answer or next step first, 
 
 - [`ADHD Explanatory`](./plugins/adhd-output-style/output-styles/adhd-explanatory.md) - Low-token ADHD formatting plus educational Insight blocks while coding
 
-**Skills:**
+**Skills** (ZIP for claude.ai, Claude Code, Cursor, Codex, VS Code):
 
-- [`adhd-output-style`](./plugins/adhd-output-style/skills/adhd-output-style/SKILL.md) - Apply the same reply format in Codex, Cursor, and Gemini CLI
+| Skill                                                                                | Description                                                  | ZIP                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`adhd-output-style`](./plugins/adhd-output-style/skills/adhd-output-style/SKILL.md) | Apply the same reply format in Codex, Cursor, and Gemini CLI | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/adhd-output-style.zip) |
 
 </details>
 
@@ -255,11 +257,11 @@ Office document skills for creating and editing PDFs, Word documents, slide deck
 
 Python coding guidelines grounded in authoritative sources: PEP 8, PEP 20 (Zen of Python), Google Python Style Guide, and Brett Slatkin's "Effective Python" (3rd ed.). Covers code integration, idiomatic patterns, YAGNI anti-abstraction rules, Google-style docstrings, and 18 before/after code examples.
 
-**Skills:**
+**Skills** (ZIP for claude.ai, Claude Code, Cursor, Codex, VS Code):
 
-| Skill                                                                            | Description                                 |
-| -------------------------------------------------------------------------------- | ------------------------------------------- |
-| [`python-guidelines`](./plugins/python-skills/skills/python-guidelines/SKILL.md) | Core rules, self-tests, and reference index |
+| Skill                                                                            | Description                                 | ZIP                                                                                                                                                                       |
+| -------------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`python-guidelines`](./plugins/python-skills/skills/python-guidelines/SKILL.md) | Core rules, self-tests, and reference index | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/python-guidelines.zip) |
 
 **Reference files:**
 


### PR DESCRIPTION
python-skills and adhd-output-style were the only skill plugins with no download button, while every vendor-synced skill (react, stripe, and the rest) ships one.

- release.sh now zips both plugins' skills at release time, reusing the same `create_zip` helper the vendor sync scripts already call
- README gains ZIP badge tables for `python-guidelines` and `adhd-output-style`, matching the react-skills format
- badges resolve `releases/latest/download/*.zip`, so they go live at the next release once release.sh publishes the two new zips

```bash
for skill_dir in plugins/{python-skills,adhd-output-style}/skills/*/; do
  create_zip "$skill_dir"
done
```
