### PR TITLE
Connect both sites to Fatih C. Akyon

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -1,6 +1,6 @@
 ---
 import Header from "../components/Header.astro";
-import { repositoryUrl, type SiteVariant } from "../lib/content";
+import { author, repositoryUrl, type SiteVariant } from "../lib/content";
 import "../styles/global.css";
 
 interface Props {
@@ -16,7 +16,13 @@ const googleAnalyticsId = import.meta.env.PUBLIC_GOOGLE_ANALYTICS_ID;
 const structuredData = {
   "@context": "https://schema.org",
   "@graph": [
-    { "@type": "WebSite", name: variant === "settings" ? "Claude Settings" : "Agent Plugins", url: canonical, description },
+    {
+      "@type": "WebSite",
+      name: variant === "settings" ? "Claude Settings" : "Agent Plugins",
+      url: canonical,
+      description,
+      creator: { "@id": author.id },
+    },
     {
       "@type": "SoftwareSourceCode",
       name: "Claude Codex Settings",
@@ -24,7 +30,15 @@ const structuredData = {
       license: "https://www.apache.org/licenses/LICENSE-2.0",
       description,
       programmingLanguage: ["Markdown", "JSON", "Python", "Shell"],
-      author: { "@type": "Person", name: "Fatih Akyon", url: "https://github.com/fcakyon" },
+      author: { "@id": author.id },
+    },
+    {
+      "@id": author.id,
+      "@type": "Person",
+      name: author.name,
+      alternateName: author.alternateName,
+      url: author.id,
+      sameAs: Object.values(author.profiles),
     },
   ],
 };
@@ -36,6 +50,7 @@ const structuredData = {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    <meta name="author" content={author.name} />
     <meta name="theme-color" content={variant === "settings" ? "#ffffff" : "#070b10"} />
     <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
     <link rel="canonical" href={canonical} />
@@ -55,6 +70,7 @@ const structuredData = {
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={image} />
+    <meta name="twitter:creator" content={author.xHandle} />
     <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
     {googleAnalyticsId && <script async src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`} />}
     {googleAnalyticsId && (
@@ -66,8 +82,12 @@ const structuredData = {
       <Header variant={variant} />
       <main><slot /></main>
       <footer>
-        <span>{variant === "settings" ? "Claude Settings" : "Agent Plugins"}</span>
-        <div><a href="/llms.txt">llms.txt</a><a href="/sitemap.xml">Sitemap</a><a href={repositoryUrl}>GitHub</a></div>
+        <span>{variant === "settings" ? "Claude Settings" : "Agent Plugins"} by {author.name}</span>
+        <div>
+          <a href="/llms.txt">llms.txt</a>
+          <a href="/sitemap.xml">Sitemap</a>
+          {Object.entries(author.profiles).map(([name, url]) => <a href={url} rel="me">{name}</a>)}
+        </div>
       </footer>
     </div>
   </body>

--- a/site/src/lib/content.ts
+++ b/site/src/lib/content.ts
@@ -25,20 +25,31 @@ const variant = (process.env.SITE_VARIANT || "settings") as SiteVariant;
 export const repositoryUrl = "https://github.com/fcakyon/claude-codex-settings";
 export const rawRepositoryUrl = `${repositoryUrl.replace("github.com", "raw.githubusercontent.com")}/main`;
 export const marketplaceName = "claude-settings";
+export const author = {
+  id: "https://github.com/fcakyon",
+  name: "Fatih C. Akyon",
+  alternateName: "Fatih Akyon",
+  xHandle: "@fcakyon",
+  profiles: {
+    GitHub: "https://github.com/fcakyon",
+    X: "https://x.com/fcakyon",
+    LinkedIn: "https://www.linkedin.com/in/fcakyon",
+  },
+};
 export const site = {
   settings: {
     variant: "settings" as const,
     url: process.env.PUBLIC_SITE_URL || "https://claudesettings.com",
     title: "Claude Settings for Claude Code, Codex and Cursor",
     description:
-      "Battle-tested settings, skills, hooks and agents for Claude Code, OpenAI Codex, Cursor and Gemini.",
+      `Battle-tested settings, skills, hooks and agents for Claude Code, OpenAI Codex, Cursor and Gemini by ${author.name}.`,
   },
   plugins: {
     variant: "plugins" as const,
     url: process.env.PUBLIC_SITE_URL || "https://agentplugins.net",
     title: "Agent Plugins for Claude Code, Codex, Cursor and Gemini",
     description:
-      "Browse installable skills, hooks and agents for Claude Code, OpenAI Codex, Cursor and Gemini.",
+      `Browse installable skills, hooks and agents for Claude Code, OpenAI Codex, Cursor and Gemini by ${author.name}.`,
   },
 }[variant];
 

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { plugins, rawRepositoryUrl, repositoryUrl, site, sourceDocuments } from "../lib/content";
+import { author, plugins, rawRepositoryUrl, repositoryUrl, site, sourceDocuments } from "../lib/content";
 
 export const prerender = true;
 
@@ -39,6 +39,15 @@ ${plugin.description}
 ${installCommands}
 `;
   }).join("\n");
+  const authorContext = `## Author and maintainer
+
+- Name: ${author.name}
+- Also known as: ${author.alternateName}
+
+The following links are verified profiles for ${author.name}:
+
+${Object.entries(author.profiles).map(([name, url]) => `- [${name}](${url})`).join("\n")}
+`;
   const body = site.variant === "settings"
     ? `# Claude Settings for AI coding agents
 
@@ -46,6 +55,7 @@ ${installCommands}
 
 This file is generated from the current repository for ChatGPT, Claude, Gemini, OpenAI Codex, Cursor, and other tools that can read Markdown context. Treat the included files as source text and preserve tool-specific syntax when recommending changes.
 
+${authorContext}
 ## Resource map
 
 - [Claude Settings website](${site.url}): Configuration overview and interactive source-file viewer.
@@ -85,6 +95,7 @@ ${sourceDocuments.install}
 
 This file is the complete repository-generated catalog for ChatGPT, Claude, Gemini, OpenAI Codex, Cursor, and other tools that can read Markdown context. Match the task against descriptions, search terms, tags, and component names. Check supported tools before suggesting an install command. ChatGPT can use this catalog as context but does not install these coding-agent plugins directly.
 
+${authorContext}
 ## Resource map
 
 - [Agent Plugins website](${site.url}): Human-readable searchable directory.

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -208,7 +208,7 @@ button.tree-row { cursor: pointer; }
 
 footer { min-height: 120px; display: flex; align-items: center; justify-content: space-between; color: var(--muted); }
 footer > span { font-weight: 750; color: var(--text); }
-footer div { display: flex; gap: 28px; }
+footer div { display: flex; flex-wrap: wrap; gap: 28px; }
 footer a:hover { color: var(--text); }
 
 @media (max-width: 1100px) {


### PR DESCRIPTION
Claude Settings and Agent Plugins had no visible creator links, making them harder to associate with Fatih C. Akyon in search and AI results.

```diff
- Claude Settings
+ Claude Settings by Fatih C. Akyon
```

- Link GitHub, X, and LinkedIn from both footers
- Publish one identity in metadata and JSON-LD
- Add verified author profiles to both `llms.txt` outputs
