### PR TITLE
Show useful Codex status details

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -14,6 +14,9 @@ network_access = true
 [analytics]
 enabled = false
 
+[tui]
+status_line = ["model-with-reasoning", "context-used", "weekly-limit", "task-progress"]
+
 [agents]
 max_threads = 8
 


### PR DESCRIPTION
The shared Codex config had no footer setup, so sessions hid useful details that Codex already provides.

```diff
+[tui]
+status_line = ["model-with-reasoning", "context-used", "weekly-limit", "task-progress"]
```

- shows the active model and reasoning level
- tracks used context and weekly usage
- keeps task progress visible
