### PR TITLE
Make shared hooks work in Codex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "author": {
         "name": "Fatih Akyon"
       },
@@ -27,7 +27,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "Fatih Akyon"
       },
@@ -362,7 +362,7 @@
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,14 +6,14 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0"
     },
     {
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0"
     },
     {
@@ -167,7 +167,7 @@
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/validate_plugins.py
+++ b/.github/scripts/validate_plugins.py
@@ -301,13 +301,18 @@ def validate_hooks(plugin_dir: Path) -> list[str]:
                                 f"{event}[{i}].hooks[{j}] should use ${{CLAUDE_PLUGIN_ROOT}}"
                             )
 
-                    # Check script exists. Shell form puts it in command, exec form in args.
+                    # Check each plugin-root path, whether shell form puts it inside command or exec form uses args.
                     refs = [cmd, *hook.get("args", [])]
                     for ref in refs:
-                        if isinstance(ref, str) and "${CLAUDE_PLUGIN_ROOT}" in ref:
-                            script_path = ref.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_dir))
-                            if not Path(script_path).exists():
-                                errors.append(f"{plugin_dir.name}/hooks/hooks.json: Script not found: {ref}")
+                        if not isinstance(ref, str):
+                            continue
+                        for relative_path in re.findall(r'\$\{CLAUDE_PLUGIN_ROOT\}(/[^"\'\s;|&]+)', ref):
+                            script_path = plugin_dir / relative_path.lstrip("/")
+                            if not script_path.exists():
+                                errors.append(
+                                    f"{plugin_dir.name}/hooks/hooks.json: Script not found: "
+                                    f"${{CLAUDE_PLUGIN_ROOT}}{relative_path}"
+                                )
 
                 elif hook_type == "prompt":
                     if "prompt" not in hook:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,27 @@ Hook types:
 
 Blocking and rewrite responses are tool-specific. Follow each tool's hook response schema.
 
-Use `${CLAUDE_PLUGIN_ROOT}` for script paths. `matcher` matches tool names (e.g., "Edit", "Bash", "mcp**tavily**tavily_search").
+Put the executable and its arguments together in `command` for shared hooks. Claude Code supports `args` as an exec
+form, but Codex does not document that field:
+
+```json
+{
+  "type": "command",
+  "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check.py\""
+}
+```
+
+Codex normalizes shell and patch calls:
+
+- `Bash` and unified `exec_command` calls provide their command in `tool_input.command`.
+- `apply_patch` provides the full patch envelope in `tool_input.command`, not a `file_path`.
+- `apply_patch` matches `apply_patch`, `Edit`, or `Write`, but still reports `tool_name: "apply_patch"`.
+- Post-write hooks that need paths must parse each `*** Add File:` or `*** Update File:` header from the patch envelope.
+
+Claude Write, Edit, and MultiEdit calls continue to provide `tool_input.file_path`.
+
+Use `${CLAUDE_PLUGIN_ROOT}` for script paths. `matcher` matches tool names such as `Edit`, `Bash`, or
+`mcp__tavily__tavily_search`.
 
 ### Commands Format
 

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/gemini-extension.json
+++ b/plugins/humanize/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "humanize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Block a curated list of AI buzzwords on every write with a hook."
 }

--- a/plugins/humanize/hooks/hooks.json
+++ b/plugins/humanize/hooks/hooks.json
@@ -3,12 +3,11 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|apply_patch|Slack__slack_(send|schedule|create_canvas|update_canvas)|Linear__save_",
+        "matcher": "Write|Edit|MultiEdit|apply_patch|Slack__slack_(send|schedule|create_canvas|update_canvas)|Linear__save_|mcp__.*(?:slack_(?:send|schedule|create_canvas|update_canvas)|linear.*save_)",
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/scripts/humanize.py"]
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/humanize.py\""
           }
         ]
       },
@@ -17,15 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/scripts/humanize.py"],
-            "if": "Bash(git commit *)"
-          },
-          {
-            "type": "command",
-            "command": "python3",
-            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/scripts/humanize.py"],
-            "if": "Bash(gh *)"
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/humanize.py\""
           }
         ]
       }

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "simplify",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups."
 }

--- a/plugins/simplify/hooks/hooks.json
+++ b/plugins/simplify/hooks/hooks.json
@@ -4,13 +4,13 @@
     "PostToolUse": [
       {
         "matcher": "Skill",
-        "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py"] }]
+        "hooks": [{ "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py\"" }]
       }
     ],
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hooks": [{ "type": "command", "command": "python3", "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py"] }]
+        "hooks": [{ "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py\"" }]
       }
     ]
   }

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/gemini-extension.json
+++ b/plugins/ultralytics-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase."
 }

--- a/plugins/ultralytics-dev/hooks/hooks.json
+++ b/plugins/ultralytics-dev/hooks/hooks.json
@@ -18,27 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "file_path=$(jq -r '.tool_input.file_path // empty' 2>/dev/null); if [[ -n \"$file_path\" && -f \"$file_path\" ]]; then case \"$file_path\" in *.py|*.js|*.jsx|*.ts|*.tsx) if [[ \"$OSTYPE\" == \"darwin\"* ]]; then sed -i '' 's/^[[:space:]]*$//g' \"$file_path\" 2>/dev/null || true; else sed -i 's/^[[:space:]]*$//g' \"$file_path\" 2>/dev/null || true; fi ;; esac; fi"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/format_python_docstrings.py"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/python_code_quality.py"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/prettier_formatting.py"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/markdown_formatting.py"
-          },
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/bash_formatting.py"
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/post_write.py\""
           }
         ]
       }

--- a/plugins/ultralytics-dev/hooks/scripts/post_write.py
+++ b/plugins/ultralytics-dev/hooks/scripts/post_write.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Run file formatters for every path changed by a write tool."""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+FORMATTERS = {
+    ".py": ("format_python_docstrings.py", "python_code_quality.py"),
+    ".md": ("markdown_formatting.py",),
+    ".sh": ("bash_formatting.py",),
+    ".bash": ("bash_formatting.py",),
+    **{
+        suffix: ("prettier_formatting.py",)
+        for suffix in (
+            ".js",
+            ".jsx",
+            ".ts",
+            ".tsx",
+            ".css",
+            ".less",
+            ".scss",
+            ".json",
+            ".yml",
+            ".yaml",
+            ".html",
+            ".vue",
+            ".svelte",
+        )
+    },
+}
+
+
+def changed_paths(data: dict) -> list[str]:
+    """Return changed file paths from Claude writes or Codex patches.
+
+    Args:
+        data (dict): Hook input payload.
+
+    Returns:
+        (list[str]): Changed file paths.
+    """
+    tool_input = data.get("tool_input") or {}
+    if file_path := tool_input.get("file_path"):
+        return [file_path]
+    return re.findall(
+        r"^\*\*\* (?:Add|Update) File: (.+?)\s*$",
+        tool_input.get("command", ""),
+        re.MULTILINE,
+    )
+
+
+def main() -> None:
+    """Run each formatter with one normalized file path."""
+    data = json.load(sys.stdin)
+    messages = []
+    for file_path in dict.fromkeys(changed_paths(data)):
+        payload = json.dumps(
+            {
+                **data,
+                "tool_input": {
+                    **(data.get("tool_input") or {}),
+                    "file_path": file_path,
+                },
+            }
+        )
+        for formatter in FORMATTERS.get(Path(file_path).suffix.lower(), ()):
+            result = subprocess.run(
+                [sys.executable, str(Path(__file__).with_name(formatter))],
+                input=payload,
+                capture_output=True,
+                text=True,
+            )
+            messages.extend(
+                part for part in (result.stdout.strip(), result.stderr.strip()) if part
+            )
+    if messages:
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PostToolUse",
+                        "additionalContext": "\n".join(messages),
+                    }
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Codex loaded several shared hooks but skipped their scripts or lost paths from apply_patch, so enforcement and formatting could silently fail.

- Use one portable command form across Codex and Claude Code.
- Normalize Claude file paths and multi-file Codex patch envelopes.
- Cover Codex Slack and Linear writes and sync three patch releases.