### PR TITLE
Document ruff and prettier as formatter prerequisites

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,6 +125,8 @@ uv tool install ruff
 npm install -g prettier@3.6.2 prettier-plugin-sh
 ```
 
+> Verify both are on PATH: `ruff --version && prettier --version`. The formatting hooks skip quietly when a tool is missing, so files that never get formatted usually mean one of these is not installed.
+
 ## Post-Installation Setup
 
 ### Create Shared Agent Guidance

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,7 +125,7 @@ uv tool install ruff
 npm install -g prettier@3.6.2 prettier-plugin-sh
 ```
 
-> Verify both are on PATH: `ruff --version && prettier --version`. The formatting hooks skip quietly when a tool is missing, so files that never get formatted usually mean one of these is not installed.
+> Verify both are on PATH: `ruff --version && npx prettier --version`. The Python, prettier, and bash hooks exit without a message when a tool is missing, so nothing gets formatted and nothing warns you.
 
 ## Post-Installation Setup
 

--- a/README.md
+++ b/README.md
@@ -730,6 +730,8 @@ Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard t
 - [`bash_formatting.py`](./plugins/ultralytics-dev/hooks/scripts/bash_formatting.py) - Bash script formatting
 - [`block_force_push.py`](./plugins/ultralytics-dev/hooks/scripts/block_force_push.py) - Block force-push and rebase
 
+Install `ruff` and `prettier` first ([setup](INSTALL.md#code-quality-tools)). Without them the hooks skip quietly and nothing gets formatted.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -730,7 +730,7 @@ Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard t
 - [`bash_formatting.py`](./plugins/ultralytics-dev/hooks/scripts/bash_formatting.py) - Bash script formatting
 - [`block_force_push.py`](./plugins/ultralytics-dev/hooks/scripts/block_force_push.py) - Block force-push and rebase
 
-Install `ruff` and `prettier` first ([setup](INSTALL.md#code-quality-tools)). Without them the hooks skip quietly and nothing gets formatted.
+Install `ruff` and `prettier` first ([setup](INSTALL.md#code-quality-tools)).
 
 </details>
 


### PR DESCRIPTION
The `ultralytics-dev` formatting hooks call `shutil.which()` and `sys.exit(0)` when the tool is absent, so a machine without ruff installed runs the hooks on every edit and formats nothing, with no error anywhere. That is exactly what happened locally: ruff was never installed, and the Python hook had been a no-op the whole time.

- INSTALL.md already listed `uv tool install ruff`, so this adds the missing verification step rather than a new install line
- verify command uses `npx prettier --version`, not `prettier --version`, because the hooks gate on `shutil.which('npx')` and invoke prettier through npx
- README plugin block gets a one-line pointer to the setup section, no duplicated behavioral claim to drift
- scoped to the Python, prettier, and bash hooks, which exit silently. The markdown hook prints its own `ERROR` lines and is not covered by the claim

```
> Verify both are on PATH: `ruff --version && npx prettier --version`.
```

4 lines added across 2 files.