### PR TITLE
Catch AI buzzwords in files written from the terminal

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/gemini-extension.json
+++ b/plugins/humanize/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "humanize",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook."
 }

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -3,9 +3,8 @@
 
 Scans markdown whole, code files only in comments and docstrings, shell only in commit and PR text
 plus heredoc bodies that cat or tee writes to a file, patches only in added lines, and MCP calls
-only in message fields. Always
-blocks a few marks and stock words with a plain swap, and flags common words only when they pile
-up. En-dash is allowed.
+only in message fields. Always blocks a few marks and stock words with a plain swap, and flags
+common words only when they pile up. En-dash is allowed.
 
 Words draw on Wikipedia "Signs of AI writing": https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
 """
@@ -72,7 +71,7 @@ FIELD_FLAGS = {"-f", "-F", "--field", "--raw-field"}
 # only cat and tee put a heredoc body in a file unchanged, python or sed in front of it rewrites the text
 SEPARATOR = re.compile(r"\|\||&&|[\n;|&]")
 CAT_TEE = re.compile(r"^\s*(cat|tee)\b(.*)$", re.DOTALL)
-REDIRECT = re.compile(r"(?<![0-9&])>>?[ \t]*['\"]?([^\s'\"|&;<>]+)")
+REDIRECT = re.compile(r"(?<![0-9&])>>?[ \t]*(\"[^\"]*\"|'[^']*'|[^\s'\"|&;<>]+)")
 
 # MCP input keys that carry human-facing message text, checked as markdown
 TEXT_KEYS = {"body", "text", "markdown_text", "content", "description", "title",
@@ -131,7 +130,7 @@ def heredoc_writes(command):
         targets = REDIRECT.findall(head)
         if writer.group(1) == "tee":
             targets += [a for a in REDIRECT.sub(" ", writer.group(2)).split() if not a.startswith("-")]
-        out += [checked(t, body) for t in targets]
+        out += [checked(t.strip("\"'"), body) for t in targets]
     return "\n".join(p for p in out if p)
 
 

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Block AI buzzwords before a write, shell, or tool call lands, so text reads human.
 
-Scans markdown whole, code files only in comments and docstrings, Bash and gh only in commit,
-PR, and comment text, patches only in added lines, and MCP calls only in message fields. Always
+Scans markdown whole, code files only in comments and docstrings, shell only in commit and PR text
+plus heredoc bodies that cat or tee writes to a file, patches only in added lines, and MCP calls
+only in message fields. Always
 blocks a few marks and stock words with a plain swap, and flags common words only when they pile
 up. En-dash is allowed.
 
@@ -64,8 +65,14 @@ MARKS = {"—": "em-dash, use commas or periods", "§": "section sign", ";": "se
 SWAP_RE = re.compile(r"\b(" + "|".join(SWAP) + r")\b", re.IGNORECASE)
 OFTEN_RE = re.compile(r"\b(" + "|".join(OFTEN) + r")\b", re.IGNORECASE)
 
-HEREDOC = re.compile(r"<<-?\s*[\"']?([A-Za-z_]\w*)[\"']?\r?\n(.*?)\r?\n[ \t]*\1\b", re.DOTALL)
+# groups are the delimiter, the rest of the opening line, and the body
+HEREDOC = re.compile(r"<<-?[ \t]*[\"']?([A-Za-z_]\w*)[\"']?([^\n]*)\r?\n(.*?)\r?\n[ \t]*\1[ \t]*$", re.DOTALL | re.MULTILINE)
 FIELD_FLAGS = {"-f", "-F", "--field", "--raw-field"}
+
+# only cat and tee put a heredoc body in a file unchanged, python or sed in front of it rewrites the text
+SEPARATOR = re.compile(r"\|\||&&|[\n;|&]")
+CAT_TEE = re.compile(r"^\s*(cat|tee)\b(.*)$", re.DOTALL)
+REDIRECT = re.compile(r"(?<![0-9&])>>?[ \t]*['\"]?([^\s'\"|&;<>]+)")
 
 # MCP input keys that carry human-facing message text, checked as markdown
 TEXT_KEYS = {"body", "text", "markdown_text", "content", "description", "title",
@@ -109,13 +116,32 @@ def checked(path, text):
     return ""
 
 
+def heredocs(command):
+    """Yield each heredoc body paired with the simple command that opens it."""
+    for m in HEREDOC.finditer(command):
+        yield SEPARATOR.split(command[: m.start()])[-1] + SEPARATOR.split(m.group(2))[0], m.group(3)
+
+
+def heredoc_writes(command):
+    """Return checkable text from heredoc bodies that cat or tee writes to a file, routed per target."""
+    out = []
+    for head, body in heredocs(command):
+        if not (writer := CAT_TEE.match(head)):
+            continue
+        targets = REDIRECT.findall(head)
+        if writer.group(1) == "tee":
+            targets += [a for a in REDIRECT.sub(" ", writer.group(2)).split() if not a.startswith("-")]
+        out += [checked(t, body) for t in targets]
+    return "\n".join(p for p in out if p)
+
+
 def bash_text(command):
     """Return commit, PR, and comment message text from a git-commit or gh command, else empty."""
     git_commit = re.search(r"\bgit\b[^|&]*\bcommit\b", command)
     gh = re.search(r"\bgh\b", command)
     if not (git_commit or gh):
         return ""
-    parts = [m.group(2) for m in HEREDOC.finditer(command)]
+    parts = [body for head, body in heredocs(command) if re.search(r"\b(?:git|gh)\b", head)]
     stripped = HEREDOC.sub(" ", command)
     flags = {"-m", "--message"} if git_commit else set()
     if gh:
@@ -165,7 +191,7 @@ def extract(tool, tool_input):
     if tool.startswith("mcp__"):
         return md_text(mcp_text(tool_input))
     if tool == "Bash":
-        return md_text(bash_text(command))
+        return "\n".join(p for p in (md_text(bash_text(command)), heredoc_writes(command)) if p)
     if tool == "apply_patch":
         return patch_text(command)
     chunks = [tool_input.get("content", ""), tool_input.get("new_string", "")]


### PR DESCRIPTION
The humanize hook blocks AI-slop words and stray marks before they reach a file. It only ever looked at edits made with the editor tools, plus commit and PR message text. Anything written straight from the terminal, like `cat > notes.md <<'EOF'`, skipped the check completely, so the same sentence was blocked one way and waved through the other.

- text written from the terminal now goes through the same routing as an editor write, so a `.md` target is read as markdown and a `.py` target only in its comments and docstrings
- only `cat` and `tee` count, because they copy the text into the file untouched. `python - <<PY > report.md` sends a program, not text, and scanning that would block every `import json; print(1)`
- commit and PR message text is now tied to the command it belongs to, so a program sharing a line with `gh` no longer gets read as a message
- a target with a space in it, like `cat > "my notes.md"`, now resolves to the real filename instead of stopping at the space
- 24 checks pass, 28 lines added and 3 removed

```
cat > x.md <<'EOF'      before: allowed   after: blocked
tee x.md <<'EOF'        before: allowed   after: blocked
python - <<PY > x.md    before: allowed   after: allowed
```

Deliberately still uncovered: `sed -i`, `echo`, `printf`, and files written by a Python script, where the final text never appears verbatim in the command. Catching those means tracing what the program does, which a pattern match cannot do, and the editor tools already cover normal writing.
