### PR TITLE
Show install commands for every tool, not just Codex

### DIFF
--- a/site/src/components/PluginDirectory.astro
+++ b/site/src/components/PluginDirectory.astro
@@ -1,8 +1,9 @@
 ---
 import Icon from "./Icon.astro";
-import { plugins } from "../lib/content";
+import { plugins, installTools } from "../lib/content";
 
-const initialCommand = plugins[0].codexCommand;
+const defaultTool = installTools[0];
+const initialCommand = plugins[0].claudeCommand;
 ---
 
 <div class="plugin-browser" id="browse" data-plugin-browser>
@@ -24,7 +25,10 @@ const initialCommand = plugins[0].codexCommand;
           role="listitem"
           data-plugin-row
           data-plugin={plugin.name}
-          data-command={plugin.codexCommand}
+          data-cmd-claude={plugin.claudeCommand}
+          data-cmd-codex={plugin.codexCommand}
+          data-cmd-gemini={plugin.geminiCommand}
+          data-cmd-cursor={plugin.cursorCommand}
           data-search={[
             plugin.name,
             plugin.description,
@@ -49,16 +53,37 @@ const initialCommand = plugins[0].codexCommand;
 
     <aside class="install-panel" id="install">
       <div class="install-heading">
-        <strong>Install via Codex CLI</strong>
+        <strong>Install via <span data-tool-label>{defaultTool.label}</span></strong>
         <span aria-hidden="true"><i></i><i></i><i></i></span>
       </div>
+      <div class="install-tabs" role="group" aria-label="Choose a tool">
+        {installTools.map((tool, index) => (
+          <button
+            class:list={["install-tab", { "is-active": index === 0 }]}
+            type="button"
+            aria-pressed={index === 0}
+            data-install-tab={tool.id}
+            data-marketplace={tool.marketplace}
+          >{tool.label}</button>
+        ))}
+      </div>
       <div class="install-content">
-        <p>Run this command in your terminal to install the selected plugin.</p>
-        <div class="command-line">
-          <code data-install-command>{initialCommand}</code>
-          <button class="icon-button" type="button" data-copy-command aria-label="Copy install command"><Icon name="copy" size={19} /></button>
+        <p data-install-unavailable hidden></p>
+        <div class="command-block" data-marketplace-block>
+          <span class="command-label">Add marketplace (one time)</span>
+          <div class="command-line">
+            <code data-marketplace-command>{defaultTool.marketplace}</code>
+            <button class="icon-button" type="button" data-copy-command aria-label="Copy marketplace command"><Icon name="copy" size={19} /></button>
+          </div>
         </div>
-        <p class="install-note">Select any plugin name to update the command.</p>
+        <div class="command-block" data-install-block>
+          <span class="command-label">Install plugin</span>
+          <div class="command-line">
+            <code data-install-command>{initialCommand}</code>
+            <button class="icon-button" type="button" data-copy-command aria-label="Copy install command"><Icon name="copy" size={19} /></button>
+          </div>
+        </div>
+        <p class="install-note">Pick a tab to switch tools, or a plugin name to change the command.</p>
       </div>
     </aside>
   </div>
@@ -71,9 +96,34 @@ const initialCommand = plugins[0].codexCommand;
   if (browser) {
     const search = browser.querySelector<HTMLInputElement>("[data-plugin-search]");
     const rows = [...browser.querySelectorAll<HTMLElement>("[data-plugin-row]")];
-    const command = browser.querySelector<HTMLElement>("[data-install-command]");
+    const tabs = [...browser.querySelectorAll<HTMLElement>("[data-install-tab]")];
+    const toolLabel = browser.querySelector<HTMLElement>("[data-tool-label]")!;
+    const unavailable = browser.querySelector<HTMLElement>("[data-install-unavailable]")!;
+    const marketplaceBlock = browser.querySelector<HTMLElement>("[data-marketplace-block]")!;
+    const marketplaceCommand = browser.querySelector<HTMLElement>("[data-marketplace-command]")!;
+    const installBlock = browser.querySelector<HTMLElement>("[data-install-block]")!;
+    const installCommand = browser.querySelector<HTMLElement>("[data-install-command]")!;
     const count = browser.querySelector<HTMLElement>("[data-result-count]");
     const empty = browser.querySelector<HTMLElement>("[data-empty]");
+
+    let activeRow = rows[0];
+    let activeTab = tabs[0];
+
+    const render = () => {
+      const label = activeTab.textContent || "";
+      const marketplace = activeTab.dataset.marketplace;
+      const install = activeRow.getAttribute(`data-cmd-${activeTab.dataset.installTab}`);
+
+      toolLabel.textContent = label;
+      marketplaceBlock.hidden = !install || !marketplace;
+      marketplaceCommand.textContent = marketplace ?? "";
+      installBlock.hidden = !install;
+      installCommand.textContent = install ?? "";
+      unavailable.hidden = Boolean(install);
+      unavailable.textContent = `${activeRow.dataset.plugin} is not available for ${label}.`;
+    };
+
+    render();
 
     search?.addEventListener("input", () => {
       const query = search.value.trim().toLowerCase();
@@ -93,17 +143,34 @@ const initialCommand = plugins[0].codexCommand;
       }
     });
 
-    rows.forEach((row) =>
-      row.querySelector("[data-plugin-select]")?.addEventListener("click", () => {
-        rows.forEach((item) => item.classList.toggle("is-selected", item === row));
-        if (command) command.textContent = row.dataset.command || `${row.dataset.plugin} is not available for Codex`;
+    tabs.forEach((tab) =>
+      tab.addEventListener("click", () => {
+        activeTab = tab;
+        tabs.forEach((item) => {
+          const selected = item === tab;
+          item.classList.toggle("is-active", selected);
+          item.setAttribute("aria-pressed", String(selected));
+        });
+        render();
       }),
     );
 
-    browser.querySelector("[data-copy-command]")?.addEventListener("click", async (event) => {
-      await navigator.clipboard.writeText(command?.textContent || "");
-      (event.currentTarget as HTMLElement).classList.add("is-copied");
-      setTimeout(() => (event.currentTarget as HTMLElement).classList.remove("is-copied"), 1200);
-    });
+    rows.forEach((row) =>
+      row.querySelector("[data-plugin-select]")?.addEventListener("click", () => {
+        activeRow = row;
+        rows.forEach((item) => item.classList.toggle("is-selected", item === row));
+        render();
+      }),
+    );
+
+    browser.querySelectorAll("[data-copy-command]").forEach((button) =>
+      button.addEventListener("click", async (event) => {
+        const trigger = event.currentTarget as HTMLElement;
+        const code = trigger.closest(".command-line")?.querySelector("code");
+        await navigator.clipboard.writeText(code?.textContent || "");
+        trigger.classList.add("is-copied");
+        setTimeout(() => trigger.classList.remove("is-copied"), 1200);
+      }),
+    );
   }
 </script>

--- a/site/src/lib/content.ts
+++ b/site/src/lib/content.ts
@@ -138,6 +138,15 @@ export const plugins = marketplace.plugins
       (bFeatured < 0 ? featured.length + b.index : bFeatured);
   });
 
+const marketplaceSlug = repositoryUrl.replace("https://github.com/", "");
+
+export const installTools = [
+  { id: "claude", label: "Claude Code", marketplace: `claude plugin marketplace add ${marketplaceSlug}` },
+  { id: "codex", label: "Codex CLI", marketplace: `codex plugin marketplace add ${marketplaceSlug}` },
+  { id: "gemini", label: "Gemini CLI" },
+  { id: "cursor", label: "Cursor" },
+];
+
 export const sourceDocuments = {
   claude: claudeContent,
   settings: settingsContent,

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -198,10 +198,16 @@ button.tree-row { cursor: pointer; }
 .install-heading i { width: 13px; height: 13px; border-radius: 50%; background: #ff655e; }
 .install-heading i:nth-child(2) { background: #f5c94f; }
 .install-heading i:nth-child(3) { background: #76d95b; }
-.install-content { min-height: 330px; padding: 34px 22px; }
+.install-tabs { display: flex; flex-wrap: wrap; gap: 6px; padding: 14px 22px 0; }
+.install-tab { padding: 7px 13px; border: 1px solid var(--border); border-radius: 999px; background: transparent; color: inherit; font: 600 12px var(--mono); cursor: pointer; opacity: .68; }
+.install-tab:hover { opacity: 1; }
+.install-tab.is-active { border-color: var(--accent); color: var(--accent); background: rgb(255 255 255 / 7%); opacity: 1; }
+.install-content { min-height: 330px; padding: 24px 22px 34px; }
 .install-content > p { max-width: 360px; }
-.command-line { display: flex; align-items: center; gap: 12px; margin: 28px 0; padding: 12px 12px 12px 16px; border: 1px solid var(--border); border-radius: 12px; background: #080c11; }
-.command-line code { min-width: 0; color: var(--accent); font: 11px/1.5 var(--mono); letter-spacing: -.025em; white-space: nowrap; }
+.command-block { margin: 22px 0; }
+.command-label { display: block; color: var(--muted); font: 600 11px var(--mono); letter-spacing: .05em; text-transform: uppercase; opacity: .62; }
+.command-line { display: flex; align-items: center; gap: 12px; margin: 9px 0 0; padding: 12px 12px 12px 16px; border: 1px solid var(--border); border-radius: 12px; background: #080c11; }
+.command-line code { min-width: 0; color: var(--accent); font: 11px/1.5 var(--mono); letter-spacing: -.025em; overflow-wrap: anywhere; }
 .install-note { font-size: 13px; }
 .compatibility { border-bottom: 0; }
 [data-site="plugins"] footer { border-top: 1px solid var(--border); }


### PR DESCRIPTION
The install panel on agentplugins.net only ever printed Codex commands, even though the site advertises four tools. The other three were already computed in `content.ts`, just never shown.

| before | after |
|---|---|
| ![install panel before](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.4.0/install-panel-before.png) | ![install panel after](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.4.0/install-panel-after.png) |

- marketplace setup is its own step, shown only for tools that need one (Claude, Codex)
- Gemini and Cursor show a single command, unsupported plugins say so instead of a dead command
- tabs are plain `aria-pressed` buttons, so keyboard and screen readers behave