### PR TITLE
Make design PRs show before/after screenshots

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -347,7 +347,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -160,7 +160,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "Apache-2.0"
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,7 +368,7 @@ This repo contains config files (JSON settings, allowlist rules, hooks) rather t
 - Always name the concrete object you're acting on. "fix: add license fields" is useless (to what?). "fix: add license field to plugin manifests" tells the next reader exactly what changed
 - Keep PR bodies short: lead with why, short scannable bullets (one point each), a diff or snippet, numbers over adjectives
 - PR titles and bodies must read standalone months later: never reference session shorthand ("PR-cf", "the last orphan content PR"), only real PR numbers (`#176`)
-- Never commit images (screenshots, GIFs) into the repo. Upload them as assets on a GitHub release (`gh release upload <tag> shot.png`) and reference the `releases/download/<tag>/shot.png` URL in the PR body
+- Site design changes need before/after visuals in the PR body, never a text description of the change. Never commit visuals into the repo: upload with `gh release upload <tag> shot.png` and link the `releases/download/<tag>/shot.png` URL
 
 ## Maintenance Scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,6 +368,7 @@ This repo contains config files (JSON settings, allowlist rules, hooks) rather t
 - Always name the concrete object you're acting on. "fix: add license fields" is useless (to what?). "fix: add license field to plugin manifests" tells the next reader exactly what changed
 - Keep PR bodies short: lead with why, short scannable bullets (one point each), a diff or snippet, numbers over adjectives
 - PR titles and bodies must read standalone months later: never reference session shorthand ("PR-cf", "the last orphan content PR"), only real PR numbers (`#176`)
+- Never commit images (screenshots, GIFs) into the repo. Upload them as assets on a GitHub release (`gh release upload <tag> shot.png`) and reference the `releases/download/<tag>/shot.png` URL in the PR body
 
 ## Maintenance Scripts
 

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/agents/pr-creator.md
+++ b/plugins/github-dev/agents/pr-creator.md
@@ -66,12 +66,14 @@ findings in the PR body when available.
      - `-b` or `--body`: write it like a sharp teammate would, not a changelog.
        One-line why it exists, not "This PR...". No second intro paragraph.
        Three bullets max, one point each, under ~12 words. A fourth means you are over-explaining, cut it.
-       Lead with the most visual proof, don't just describe it: a screenshot for UI or output changes,
-       a benchmark table for results, else a `diff`, before/after, or runnable CLI snippet.
+       Lead with the most visual proof, don't just describe it. A webpage, UI, or design change MUST
+       carry before/after images in a two-column table, never text describing the change.
        Numbers win: put benchmarks, counts, speedups and comparisons in a markdown table.
-       To embed an image you can't drag-drop, commit it and link a commit-pinned raw URL that survives
-       branch deletion: `https://raw.githubusercontent.com/OWNER/REPO/COMMIT_SHA/path/to/shot.webp`
-       (full commit SHA, not the branch). Confirm `200 image/*` with `curl -sI` before embedding.
+       Never commit images into the repo. Upload to a release and link that URL:
+       `gh release upload <tag> before.png after.png --clobber`, then
+       `![before](https://github.com/OWNER/REPO/releases/download/<tag>/before.png)`.
+       Capture both shots at the same window size. Release assets serve as `application/octet-stream`,
+       so `curl -sI` looks wrong even when fine. Open the PR and confirm they render.
        One read, one section, no headers. No test plans, file lists, or line links.
      - `-a @me`: Self-assign (confirmation hook will show actual username)
      - `-r <reviewer>`: Only add if the user explicitly asks OR recent PRs by this author have reviewers.

--- a/plugins/github-dev/gemini-extension.json
+++ b/plugins/github-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "github-dev",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
 }

--- a/plugins/github-dev/hooks/hooks.json
+++ b/plugins/github-dev/hooks/hooks.json
@@ -15,6 +15,10 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/require_visual_proof.py"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/gh_pr_create_confirm.py"
           }
         ]

--- a/plugins/github-dev/hooks/scripts/require_visual_proof.py
+++ b/plugins/github-dev/hooks/scripts/require_visual_proof.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: make design PRs carry before/after images hosted on a release.
+
+Denies `gh pr create` and `gh pr edit` when the command writes an inline body and either that body
+embeds a raw.githubusercontent image, which only works once the image is committed into the repo, or
+the branch changes a webpage or stylesheet and the body carries no image at all. Reads a string
+command (Claude Code) and an argv array (Codex). Lets the command through when git cannot list the
+branch files.
+"""
+import json
+import re
+import sys
+
+SEGMENT = re.compile(r"[\n;]|&&|\|\||\|")
+DESIGN = re.compile(r"\.(astro|css|scss|sass|less|html|vue|svelte)$")
+IMAGE = re.compile(r"!\[|<img\b", re.IGNORECASE)
+# only a raw.githubusercontent URL used as an image, not one merely named in a title
+COMMITTED_IMAGE = re.compile(r"(?:!\[[^\]]*\]\([^)]*|<img\b[^>]*)raw\.githubusercontent\.com", re.IGNORECASE)
+RECIPE = (
+    "Upload them to a release and link that URL: `gh release upload <tag> before.png after.png --clobber`, "
+    "then `![before](https://github.com/OWNER/REPO/releases/download/<tag>/before.png)`."
+)
+
+data = json.load(sys.stdin)
+command = (data.get("tool_input") or {}).get("command", "")
+text = " ".join(map(str, command)) if isinstance(command, list) else str(command)
+
+# anchor per command segment so `cd site && gh pr create` matches but `gh issue comment -b "pr create"` does not
+if not any(part.strip().startswith(("gh pr create", "gh pr edit")) for part in SEGMENT.split(text)):
+    sys.exit(0)
+
+# only a command writing an inline body can be judged, label or reviewer edits carry none
+if not re.search(r"(^|\s)(-b|--body)(\s|=)", text):
+    sys.exit(0)
+
+# the body text is unreadable here when it comes from a file or a substitution, and `gh pr edit <number>`
+# retargets a PR whose branch this checkout may not be on
+if "--body-file" in text or ("$(" in text and "<<" not in text) or re.search(r"gh pr edit\s+\d", text):
+    sys.exit(0)
+
+import subprocess  # noqa: E402  deferred, this hook runs on every Bash call and reaches here on almost none
+
+# rev-parse of a missing origin/HEAD exits non-zero, leaving no files and letting the command through
+changed = "" if IMAGE.search(text) else subprocess.run(
+    ["git", "-C", data.get("cwd") or ".", "diff", "--name-only", "origin/HEAD...HEAD"],
+    capture_output=True,
+    text=True,
+    timeout=5,
+).stdout
+design = [path for path in changed.split() if DESIGN.search(path)]
+
+if COMMITTED_IMAGE.search(text):
+    reason = f"This PR body links a raw.githubusercontent.com image, which only renders once that image is committed into the repo. {RECIPE}"
+elif design:
+    reason = (
+        f"This branch changes design files ({', '.join(design[:3])}) but the PR body has no before/after image. "
+        f"Screenshot the page on the base branch and on this branch at the same window size, then put the pair in a "
+        f"two-column table. {RECIPE}"
+    )
+else:
+    sys.exit(0)
+
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}))

--- a/plugins/github-dev/skills/create-pr/SKILL.md
+++ b/plugins/github-dev/skills/create-pr/SKILL.md
@@ -54,10 +54,15 @@ plain-language branch name rather than copying the full text.
 7. **PR Body Guidelines**
    - One-line why it exists, not "This PR...". No second intro paragraph.
    - Three bullets max, one point each, under ~12 words. Need a fourth? You are over-explaining, cut it.
-   - Lead with the most visual proof, don't just describe it: a screenshot for UI or output changes, a benchmark table for results, else a `diff`, before/after, or runnable CLI snippet.
+   - Lead with the most visual proof, don't just describe it. A webpage, UI, or design change MUST carry before/after images in a two-column table, never text describing the change. Benchmarks get a table, anything else gets a `diff` or runnable CLI snippet.
    - Numbers win: put benchmarks, counts, speedups and comparisons in a markdown table, not a paragraph.
    - One read, one section, no headers. Plain words, no buzzwords, no test plans or file lists.
-   - **Embedding images**: you can't drag-drop, so commit the image and reference it with a commit-pinned raw URL that survives the branch being deleted: `https://raw.githubusercontent.com/OWNER/REPO/COMMIT_SHA/path/to/shot.webp` (full commit SHA, never the branch name). Confirm it returns `200 image/*` with `curl -sI` before embedding, then put a before/after pair side by side in a two-column table.
+   - **Embedding images**: never commit them into the repo. Upload to a release and link that URL, which outlives the branch:
+     ```bash
+     gh release upload <tag> before.png after.png --clobber
+     # ![before](https://github.com/OWNER/REPO/releases/download/<tag>/before.png)
+     ```
+     Capture both shots at the same window size so the pair is comparable. Release assets serve as `application/octet-stream`, so `curl -sI` looks wrong even when fine. Open the PR and confirm the images render.
 
 ## Examples
 
@@ -84,17 +89,15 @@ Point it at a folder and a few models and it stitches the panels together, so yo
 `ultrannotate compare --source ./images --models sam3.pt,yoloe-26x-seg.pt --phrases "person,car"`
 ```
 
-### Screenshot and benchmark table
+### Design change, before and after
 
 ```
-Link shares showed no thumbnail because the preview image had expired. Each site now serves its own screenshot.
+The install panel only ever printed Codex commands, even though the site lists four tools.
 
 | before | after |
 |---|---|
-| no preview, redirect to an expired URL | ![new preview](https://raw.githubusercontent.com/fcakyon/claude-codex-settings/9bedce4/site/public/og-settings.webp) |
+| ![before](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.4.0/install-panel-before.png) | ![after](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.4.0/install-panel-after.png) |
 
-| format | size | shows in whatsapp |
-|---|---|---|
-| png | 1.8 MB | no |
-| webp lossless | 87 KB | yes |
+- marketplace setup is its own step, shown only for tools that need one
+- unsupported plugins say so instead of a dead command
 ```

--- a/plugins/github-dev/skills/update-pr-summary/SKILL.md
+++ b/plugins/github-dev/skills/update-pr-summary/SKILL.md
@@ -22,7 +22,7 @@ When explicitly invoked with extra text, treat that text as the PR number or URL
 3. **Generate the updated summary**
    - Follow the `create-pr` skill format for title and body.
    - Title: a short human headline, capital first letter, no `fix:` or `feat:` prefix. Lead with the outcome, punchy over exhaustive.
-   - Body: open on why, then short scannable bullets (one point each). Lead with the most visual proof: a screenshot for UI or output changes, a benchmark table for results, else a `diff`, before/after, or runnable CLI snippet. See the `create-pr` skill for embedding images with a commit-pinned raw URL.
+   - Body: open on why, then short scannable bullets (one point each). Lead with the most visual proof. A webpage, UI, or design change MUST carry before/after images in a two-column table, never text describing the change. See the `create-pr` skill for uploading them to a release.
    - Numbers win: put benchmarks, counts, speedups and comparisons in a markdown table.
    - One read, one section, no headers. Plain words, no buzzwords.
    - No test plans, file lists, or line links.


### PR DESCRIPTION
A UI change described in text makes reviewers guess what it looks like. The create-pr skill was the cause, not the cure: it said to **commit the image** and listed a screenshot as one option among several, so #253 first shipped with a text-only body and an attempt to commit screenshots.

Guidance is now a requirement, and a hook enforces it:

```
gh pr create -b "text about the redesign"
-> denied: branch changes design files (src/App.css) but the body has no before/after image
```

- fires on 5 of the last 30 merged PRs, the 25 plugin and docs PRs pass untouched
- matches markup and styles only, so a `.tsx` test file or `package-lock.json` never triggers it
- images go to a release, never into the repo