### PR TITLE
Update author on first-party plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -27,7 +27,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -42,7 +42,7 @@
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "Get a second opinion from Claude Fable 5 before big decisions.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -57,7 +57,7 @@
       "name": "adhd-output-style",
       "source": "./plugins/adhd-output-style",
       "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -72,7 +72,7 @@
       "name": "intelligent-compact",
       "source": "./plugins/intelligent-compact",
       "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -87,7 +87,7 @@
       "name": "claude-telemetry-hooks",
       "source": "./plugins/claude-telemetry-hooks",
       "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -347,7 +347,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -362,7 +362,7 @@
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -377,7 +377,7 @@
       "name": "azure-tools",
       "source": "./plugins/azure-tools",
       "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -392,7 +392,7 @@
       "name": "claude-tools",
       "source": "./plugins/claude-tools",
       "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -407,7 +407,7 @@
       "name": "gcloud-tools",
       "source": "./plugins/gcloud-tools",
       "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -422,7 +422,7 @@
       "name": "paper-search-tools",
       "source": "./plugins/paper-search-tools",
       "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -437,7 +437,7 @@
       "name": "tavily-tools",
       "source": "./plugins/tavily-tools",
       "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -452,7 +452,7 @@
       "name": "overleaf-skills",
       "source": "./plugins/overleaf-skills",
       "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-settings",
   "owner": {
-    "name": "Fatih Akyon"
+    "name": "Fatih C. Akyon"
   },
   "metadata": {
     "description": "Claude Code plugins featuring skills, slash commands, autonomous subagents, hooks, and MCP server integrations for Git workflow, code review, and plugin development.",
@@ -14,7 +14,7 @@
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
       "version": "1.1.4",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -29,7 +29,7 @@
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
       "version": "1.1.2",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -44,7 +44,7 @@
       "description": "Get a second opinion from Claude Fable 5 before big decisions.",
       "version": "1.2.0",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -59,7 +59,7 @@
       "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
       "version": "1.0.0",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -74,7 +74,7 @@
       "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
       "version": "1.0.0",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -89,7 +89,7 @@
       "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
       "version": "1.0.2",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -334,7 +334,7 @@
       "description": "Research skills for Claude Code \u2014 paper auditing, citation verification, experiment analysis, and methodology-first skills for academic workflows.",
       "version": "1.1.0",
       "author": {
-        "name": "Fatih Cagatay Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/phd-skills",
       "repository": "https://github.com/fcakyon/phd-skills",
@@ -349,7 +349,7 @@
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
       "version": "2.5.0",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -364,7 +364,7 @@
       "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
       "version": "2.2.2",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -379,7 +379,7 @@
       "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
       "version": "2.0.2",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -394,7 +394,7 @@
       "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
       "version": "2.1.0",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -409,7 +409,7 @@
       "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
       "version": "2.0.2",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -424,7 +424,7 @@
       "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
       "version": "2.0.2",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -439,7 +439,7 @@
       "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
       "version": "2.0.2",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
@@ -454,7 +454,7 @@
       "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
       "version": "1.0.0",
       "author": {
-        "name": "Fatih Akyon"
+        "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,42 +6,42 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0"
     },
     {
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0"
     },
     {
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "Get a second opinion from Claude Fable 5 before big decisions.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0"
     },
     {
       "name": "adhd-output-style",
       "source": "./plugins/adhd-output-style",
       "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     {
       "name": "intelligent-compact",
       "source": "./plugins/intelligent-compact",
       "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     {
       "name": "claude-telemetry-hooks",
       "source": "./plugins/claude-telemetry-hooks",
       "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0"
     },
     {
@@ -160,56 +160,56 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "Apache-2.0"
     },
     {
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "Apache-2.0"
     },
     {
       "name": "azure-tools",
       "source": "./plugins/azure-tools",
       "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0"
     },
     {
       "name": "claude-tools",
       "source": "./plugins/claude-tools",
       "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0"
     },
     {
       "name": "gcloud-tools",
       "source": "./plugins/gcloud-tools",
       "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0"
     },
     {
       "name": "paper-search-tools",
       "source": "./plugins/paper-search-tools",
       "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0"
     },
     {
       "name": "tavily-tools",
       "source": "./plugins/tavily-tools",
       "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0"
     },
     {
       "name": "overleaf-skills",
       "source": "./plugins/overleaf-skills",
       "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     }
   ]

--- a/plugins/adhd-output-style/.claude-plugin/plugin.json
+++ b/plugins/adhd-output-style/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "adhd-output-style",
   "version": "1.0.0",
   "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/adhd-output-style/.claude-plugin/plugin.json
+++ b/plugins/adhd-output-style/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adhd-output-style",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/adhd-output-style/.codex-plugin/plugin.json
+++ b/plugins/adhd-output-style/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "adhd-output-style",
   "version": "1.0.0",
   "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/adhd-output-style/.codex-plugin/plugin.json
+++ b/plugins/adhd-output-style/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adhd-output-style",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/adhd-output-style/.cursor-plugin/plugin.json
+++ b/plugins/adhd-output-style/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "adhd-output-style",
   "version": "1.0.0",
   "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/adhd-output-style/.cursor-plugin/plugin.json
+++ b/plugins/adhd-output-style/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "adhd-output-style",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Use fewer output tokens with short steps, quick insights, and clear next actions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/adhd-output-style/gemini-extension.json
+++ b/plugins/adhd-output-style/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "adhd-output-style",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Use fewer output tokens with short steps, quick insights, and clear next actions."
 }

--- a/plugins/azure-tools/.claude-plugin/plugin.json
+++ b/plugins/azure-tools/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "azure-tools",
   "version": "2.0.2",
   "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/azure-tools/.claude-plugin/plugin.json
+++ b/plugins/azure-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/azure-tools/.codex-plugin/plugin.json
+++ b/plugins/azure-tools/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "azure-tools",
   "version": "2.0.2",
   "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/azure-tools/.codex-plugin/plugin.json
+++ b/plugins/azure-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/azure-tools/.cursor-plugin/plugin.json
+++ b/plugins/azure-tools/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "azure-tools",
   "version": "2.0.2",
   "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/azure-tools/.cursor-plugin/plugin.json
+++ b/plugins/azure-tools/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/azure-tools/gemini-extension.json
+++ b/plugins/azure-tools/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "azure-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication."
 }

--- a/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "claude-telemetry-hooks",
   "version": "1.0.2",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "claude-telemetry-hooks",
   "version": "1.0.2",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "claude-telemetry-hooks",
   "version": "1.0.2",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
+++ b/plugins/claude-telemetry-hooks/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-telemetry-hooks/gemini-extension.json
+++ b/plugins/claude-telemetry-hooks/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "claude-telemetry-hooks",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Track per-device Claude Code usage, rejection reasons, and per-session stats from a single dashboard."
 }

--- a/plugins/claude-tools/.claude-plugin/plugin.json
+++ b/plugins/claude-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tools",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-tools/.claude-plugin/plugin.json
+++ b/plugins/claude-tools/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "claude-tools",
   "version": "2.1.0",
   "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/claude-tools/.codex-plugin/plugin.json
+++ b/plugins/claude-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tools",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-tools/.codex-plugin/plugin.json
+++ b/plugins/claude-tools/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "claude-tools",
   "version": "2.1.0",
   "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/claude-tools/.cursor-plugin/plugin.json
+++ b/plugins/claude-tools/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tools",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-tools/.cursor-plugin/plugin.json
+++ b/plugins/claude-tools/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "claude-tools",
   "version": "2.1.0",
   "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/claude-tools/gemini-extension.json
+++ b/plugins/claude-tools/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "claude-tools",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Commands for syncing CLAUDE.md, permissions allowlist, and refreshing context. Hooks for marketplace-to-plugin sync."
 }

--- a/plugins/fable-advisor/.claude-plugin/plugin.json
+++ b/plugins/fable-advisor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/.claude-plugin/plugin.json
+++ b/plugins/fable-advisor/.claude-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "fable-advisor",
   "version": "1.2.0",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "agents": "./claude-agents/fable-advisor.md",
   "hooks": "./claude-hooks/hooks.json",
   "license": "Apache-2.0"

--- a/plugins/fable-advisor/.codex-plugin/plugin.json
+++ b/plugins/fable-advisor/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/.codex-plugin/plugin.json
+++ b/plugins/fable-advisor/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "fable-advisor",
   "version": "1.2.0",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/fable-advisor/.cursor-plugin/plugin.json
+++ b/plugins/fable-advisor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/.cursor-plugin/plugin.json
+++ b/plugins/fable-advisor/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "fable-advisor",
   "version": "1.2.0",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/fable-advisor/gemini-extension.json
+++ b/plugins/fable-advisor/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "fable-advisor",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Get a second opinion from Claude Fable 5 before big decisions."
 }

--- a/plugins/gcloud-tools/.claude-plugin/plugin.json
+++ b/plugins/gcloud-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcloud-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/gcloud-tools/.claude-plugin/plugin.json
+++ b/plugins/gcloud-tools/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "gcloud-tools",
   "version": "2.0.2",
   "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/gcloud-tools/.codex-plugin/plugin.json
+++ b/plugins/gcloud-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcloud-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/gcloud-tools/.codex-plugin/plugin.json
+++ b/plugins/gcloud-tools/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "gcloud-tools",
   "version": "2.0.2",
   "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/gcloud-tools/.cursor-plugin/plugin.json
+++ b/plugins/gcloud-tools/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcloud-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/gcloud-tools/.cursor-plugin/plugin.json
+++ b/plugins/gcloud-tools/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "gcloud-tools",
   "version": "2.0.2",
   "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/gcloud-tools/gemini-extension.json
+++ b/plugins/gcloud-tools/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "gcloud-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Google Cloud Observability MCP for logs, metrics, and traces with best practices skill."
 }

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "github-dev",
   "version": "2.5.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "github-dev",
   "version": "2.5.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "github-dev",
   "version": "2.5.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/github-dev/gemini-extension.json
+++ b/plugins/github-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "github-dev",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
 }

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "humanize",
   "version": "1.1.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "humanize",
   "version": "1.1.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "humanize",
   "version": "1.1.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/humanize/gemini-extension.json
+++ b/plugins/humanize/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "humanize",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Block a curated list of AI buzzwords on every write with a hook."
 }

--- a/plugins/intelligent-compact/.claude-plugin/plugin.json
+++ b/plugins/intelligent-compact/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "intelligent-compact",
   "version": "1.0.0",
   "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/intelligent-compact/.claude-plugin/plugin.json
+++ b/plugins/intelligent-compact/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "intelligent-compact",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/intelligent-compact/.codex-plugin/plugin.json
+++ b/plugins/intelligent-compact/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "intelligent-compact",
   "version": "1.0.0",
   "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/intelligent-compact/.codex-plugin/plugin.json
+++ b/plugins/intelligent-compact/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "intelligent-compact",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/intelligent-compact/.cursor-plugin/plugin.json
+++ b/plugins/intelligent-compact/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "intelligent-compact",
   "version": "1.0.0",
   "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/intelligent-compact/.cursor-plugin/plugin.json
+++ b/plugins/intelligent-compact/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "intelligent-compact",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/intelligent-compact/gemini-extension.json
+++ b/plugins/intelligent-compact/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "intelligent-compact",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Stop Claude Code from forgetting file paths, root causes, and open questions when it auto-summarizes long sessions."
 }

--- a/plugins/overleaf-skills/.claude-plugin/plugin.json
+++ b/plugins/overleaf-skills/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "overleaf-skills",
   "version": "1.0.0",
   "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/overleaf-skills/.claude-plugin/plugin.json
+++ b/plugins/overleaf-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overleaf-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/overleaf-skills/.codex-plugin/plugin.json
+++ b/plugins/overleaf-skills/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "overleaf-skills",
   "version": "1.0.0",
   "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/overleaf-skills/.codex-plugin/plugin.json
+++ b/plugins/overleaf-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overleaf-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/overleaf-skills/.cursor-plugin/plugin.json
+++ b/plugins/overleaf-skills/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "overleaf-skills",
   "version": "1.0.0",
   "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/overleaf-skills/.cursor-plugin/plugin.json
+++ b/plugins/overleaf-skills/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "overleaf-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/overleaf-skills/gemini-extension.json
+++ b/plugins/overleaf-skills/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "overleaf-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Pull review comments from an Overleaf project, map them to local .tex files, and apply edits in your git-tracked repo."
 }

--- a/plugins/paper-search-tools/.claude-plugin/plugin.json
+++ b/plugins/paper-search-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-search-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/paper-search-tools/.claude-plugin/plugin.json
+++ b/plugins/paper-search-tools/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "paper-search-tools",
   "version": "2.0.2",
   "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/paper-search-tools/.codex-plugin/plugin.json
+++ b/plugins/paper-search-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-search-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/paper-search-tools/.codex-plugin/plugin.json
+++ b/plugins/paper-search-tools/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "paper-search-tools",
   "version": "2.0.2",
   "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/paper-search-tools/.cursor-plugin/plugin.json
+++ b/plugins/paper-search-tools/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-search-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/paper-search-tools/.cursor-plugin/plugin.json
+++ b/plugins/paper-search-tools/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "paper-search-tools",
   "version": "2.0.2",
   "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/paper-search-tools/gemini-extension.json
+++ b/plugins/paper-search-tools/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "paper-search-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Academic paper search MCP for arXiv, PubMed, IEEE, Scopus, ACM, and more. Requires Docker."
 }

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "simplify",
   "version": "1.1.4",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "simplify",
   "version": "1.1.4",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "simplify",
   "version": "1.1.4",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "simplify",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Review your changed code for reuse, redundancy, wasted work, and over-engineering, then apply the cleanups."
 }

--- a/plugins/tavily-tools/.claude-plugin/plugin.json
+++ b/plugins/tavily-tools/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "tavily-tools",
   "version": "2.0.2",
   "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/tavily-tools/.claude-plugin/plugin.json
+++ b/plugins/tavily-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tavily-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/tavily-tools/.codex-plugin/plugin.json
+++ b/plugins/tavily-tools/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "tavily-tools",
   "version": "2.0.2",
   "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/tavily-tools/.codex-plugin/plugin.json
+++ b/plugins/tavily-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tavily-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/tavily-tools/.cursor-plugin/plugin.json
+++ b/plugins/tavily-tools/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "tavily-tools",
   "version": "2.0.2",
   "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/tavily-tools/.cursor-plugin/plugin.json
+++ b/plugins/tavily-tools/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tavily-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/tavily-tools/gemini-extension.json
+++ b/plugins/tavily-tools/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "tavily-tools",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Tavily web search and content extraction MCP with hooks and skills for optimal tool selection."
 }

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "ultralytics-dev",
   "version": "2.2.2",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/ultralytics-dev/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.codex-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "ultralytics-dev",
   "version": "2.2.2",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/ultralytics-dev/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.cursor-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "ultralytics-dev",
   "version": "2.2.2",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
   "license": "Apache-2.0"
 }

--- a/plugins/ultralytics-dev/gemini-extension.json
+++ b/plugins/ultralytics-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase."
 }


### PR DESCRIPTION
The marketplace claimed you as author of 16 plugins, but the manifests themselves said nothing.

- adds `author: Fatih C. Akyon` to 42 manifests across 14 plugins, one spelling everywhere
- patch bump on each, CI requires one when a plugin's files change