### PR TITLE
Block commit types outside the allowed set

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -347,7 +347,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "author": {
         "name": "Fatih Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -160,7 +160,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0"
     },
     {

--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ Git and GitHub automation. Run the `setup` skill after install.
 - [`git_commit_confirm.py`](./plugins/github-dev/hooks/scripts/git_commit_confirm.py) - Confirmation before git commit
 - [`gh_pr_create_confirm.py`](./plugins/github-dev/hooks/scripts/gh_pr_create_confirm.py) - Confirmation before gh pr create
 - [`block_ai_attribution.py`](./plugins/github-dev/hooks/scripts/block_ai_attribution.py) - Block AI attribution lines in commits and PRs
+- [`block_commit_type.py`](./plugins/github-dev/hooks/scripts/block_commit_type.py) - Block commit types outside the allowed set
 
 </details>
 

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution.",
   "license": "Apache-2.0"
 }

--- a/plugins/github-dev/gemini-extension.json
+++ b/plugins/github-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "github-dev",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "GitHub and Git workflow skills and agents for commits, PRs, code review, and PR comment resolution."
 }

--- a/plugins/github-dev/hooks/hooks.json
+++ b/plugins/github-dev/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Git workflow hooks: block AI attribution in commits and PRs, then confirm them",
+  "description": "Git workflow hooks: block AI attribution and unsupported commit types, then confirm commits and PRs",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,6 +8,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block_ai_attribution.py"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block_commit_type.py"
           },
           {
             "type": "command",

--- a/plugins/github-dev/hooks/scripts/block_commit_type.py
+++ b/plugins/github-dev/hooks/scripts/block_commit_type.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block commit types outside the set the commit-staged skill lists."""
+import json
+import re
+import sys
+
+TYPES = ("feat", "fix", "refactor", "docs", "style", "test", "build")
+
+raw = (json.load(sys.stdin).get("tool_input") or {}).get("command", "")
+argv = [str(a) for a in raw] if isinstance(raw, list) else None
+text = " ".join(argv) if argv else str(raw)
+
+if not re.search(r"(?:^|&&|\|\||;|\n)\s*git\s+(?:-C\s+\S+\s+)?commit\b", text):
+    sys.exit(0)
+
+message = ""
+if argv:
+    # Codex hands over an argv array, where the message is its own element and carries no quotes
+    for i, arg in enumerate(argv):
+        if arg.startswith("--message="):
+            message = arg.split("=", 1)[1]
+            break
+        if arg in ("-m", "--message") and i + 1 < len(argv):
+            message = argv[i + 1]
+            break
+else:
+    # A heredoc body wins when present, otherwise take the first -m value. The quote is captured
+    # and backreferenced so an apostrophe inside a double-quoted message does not end it early.
+    heredoc = re.search(r"<<\s*'?EOF'?\s*\n(.*?)\n\s*EOF", text, re.DOTALL)
+    if heredoc:
+        message = heredoc.group(1)
+    else:
+        quoted = re.findall(r"""(?:-m|--message)[=\s]+("|')(.*?)\1""", text, re.DOTALL)
+        message = quoted[0][1] if quoted else ""
+
+if not message:
+    sys.exit(0)
+
+subject = next((line.strip() for line in message.splitlines() if line.strip()), "")
+if not subject or re.match(rf"^(?:{'|'.join(TYPES)}): \S", subject):
+    sys.exit(0)
+
+used = subject.split(":", 1)[0][:20]
+reason = (
+    f'"{used}" is not an allowed commit type. Use one of {", ".join(TYPES)}, '
+    "written as type then a colon then a brief description. Pick the type that fits and commit again."
+)
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }
+    )
+)


### PR DESCRIPTION
The commit-staged skill lists seven allowed types, but nothing enforced them, so `chore:` slipped into three commits today.

- denies any commit type outside the seven
- catches chained commands the existing confirm hook misses
- 15 tests: heredocs, apostrophes, `--amend`, Codex argv arrays

```
$ git add -A && git commit -m "chore: bump versions"
"chore" is not an allowed commit type. Use one of feat, fix, refactor, docs,
style, test, build, written as type then a colon then a brief description.
Pick the type that fits and commit again.
```

A commit with no `-m` passes, since the subject lives in the editor where the hook cannot see it. That also lets a conflicted merge keep git's generated subject.
