### PR TITLE
Pair each tool with a cross-model advisor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -347,7 +347,7 @@
         "path": "plugin"
       },
       "description": "Research skills for Claude Code \u2014 paper auditing, citation verification, experiment analysis, and methodology-first skills for academic workflows.",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -242,7 +242,8 @@
     "intelligent-compact@claude-settings": true,
     "github-dev@claude-settings": true,
     "humanize@claude-settings": true,
-    "simplify@claude-settings": true
+    "simplify@claude-settings": true,
+    "codex-advisor@claude-settings": true
   },
   "extraKnownMarketplaces": {
     "claude-settings": {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -43,3 +43,6 @@ enabled = true
 
 [plugins."ultralytics-dev@claude-settings"]
 enabled = true
+
+[plugins."fable-advisor@claude-settings"]
+enabled = true


### PR DESCRIPTION
A second opinion is worth more from a different model family, so each tool now reaches for the other one.

- Claude Code enables `codex-advisor`, Codex enables `fable-advisor`
- phd-skills moves to 1.3.0, the version its own repo ships
- the stale 1.1.0 pin was rolling installs backwards on update

```diff
  "simplify@claude-settings": true,
+ "codex-advisor@claude-settings": true
```
