### PR TITLE
Bump checkout and setup-node to v7

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/ruff-action@v3
         with:
           src: "plugins/*/hooks/scripts .github/scripts"

--- a/.github/workflows/site-refresh.yml
+++ b/.github/workflows/site-refresh.yml
@@ -27,7 +27,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Check whether a deploy is due
         id: check
         env:
@@ -41,7 +41,7 @@ jobs:
           echo "Last deploy was $(( age / 3600 ))h ago"
           echo "due=$([ $age -ge 86400 ] || [ "${{ inputs.force }}" = "true" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           [ -n "$CLOUDFLARE_API_TOKEN" ] || echo "::warning::CLOUDFLARE_API_TOKEN is unset, nothing will deploy"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         if: steps.check.outputs.due == 'true' && env.CLOUDFLARE_API_TOKEN != ''
         with:
           node-version: 22

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -29,8 +29,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -32,7 +32,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Every workflow run printed a deprecation warning: `actions/checkout@v4` and `actions/setup-node@v4` target Node 20, which runners already force onto Node 24.

- 5 `checkout@v4` and 2 `setup-node@v4` pins moved to `@v7`, across all 4 workflows
- latest stable at time of change: checkout v7.0.1, setup-node v7.0.0, both carrying a `v7` major tag
- `setup-python@v5` in validate-plugins is untouched, it raises no warning yet

```diff
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
```