### PR TITLE
Let advisors recover truncated review context

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,7 +42,7 @@
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "Get a second opinion from Claude Fable 5 before big decisions.",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "author": {
         "name": "Fatih C. Akyon"
       },
@@ -57,7 +57,7 @@
       "name": "codex-advisor",
       "source": "./plugins/codex-advisor",
       "description": "Get a second opinion from GPT via Codex CLI before big decisions.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -20,14 +20,14 @@
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "Get a second opinion from Claude Fable 5 before big decisions.",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0"
     },
     {
       "name": "codex-advisor",
       "source": "./plugins/codex-advisor",
       "description": "Get a second opinion from GPT via Codex CLI before big decisions.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/codex-advisor/.claude-plugin/plugin.json
+++ b/plugins/codex-advisor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-advisor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Get a second opinion from GPT via Codex CLI before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/codex-advisor/.codex-plugin/plugin.json
+++ b/plugins/codex-advisor/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-advisor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Get a second opinion from GPT via Codex CLI before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/codex-advisor/.cursor-plugin/plugin.json
+++ b/plugins/codex-advisor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-advisor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Get a second opinion from GPT via Codex CLI before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/codex-advisor/claude-agents/codex-advisor.md
+++ b/plugins/codex-advisor/claude-agents/codex-advisor.md
@@ -1,7 +1,7 @@
 ---
 name: codex-advisor
 description: |-
-  Second-opinion reviewer backed by GPT through the Codex CLI, a cross-model stand-in for the built-in advisor. Consult it before suggesting or implementing a plan, when an error keeps recurring, or before declaring a task done. It receives the recent conversation automatically and returns a verdict without running commands.
+  Second-opinion reviewer backed by GPT through the Codex CLI, a cross-model stand-in for the built-in advisor. Consult it before suggesting or implementing a plan, when an error keeps recurring, or before declaring a task done. It receives the recent conversation automatically and verifies claims with read-only access, then returns a verdict.
 model: haiku
 color: cyan
 tools: [Bash]

--- a/plugins/codex-advisor/claude-hooks/scripts/stage_transcript.mjs
+++ b/plugins/codex-advisor/claude-hooks/scripts/stage_transcript.mjs
@@ -36,9 +36,9 @@ const renderBlock = (role, b) => {
     case "text":
       return `${role}: ${clip(b.text ?? "", 4000)}`;
     case "thinking":
-      return `assistant (thinking): ${clip(b.thinking ?? "", 1200)}`;
+      return `assistant (thinking): ${clip(b.thinking ?? "", 4000)}`;
     case "tool_use":
-      return `assistant → ${b.name ?? "?"}(${clip(JSON.stringify(b.input ?? {}), 280)})`;
+      return `assistant → ${b.name ?? "?"}(${clip(JSON.stringify(b.input ?? {}), 8000)})`;
     case "tool_result": {
       const c = b.content;
       const text =
@@ -47,55 +47,61 @@ const renderBlock = (role, b) => {
           : Array.isArray(c)
             ? c.map((x) => x.text ?? "").join(" ")
             : JSON.stringify(c ?? "");
-      return `  ↳ result: ${clip(text, 700)}`;
+      return `  ↳ result: ${clip(text, 8000)}`;
     }
     default:
       return "";
   }
 };
 
-// Any failure below leaves contextFile unset, which downgrades the review to the caller's
-// prompt instead of losing the turn.
+// Any failure here leaves lines empty, which still stages the transcript path so the
+// reviewer keeps its escape hatch instead of ruling on the caller's prompt alone.
+let transcript;
+let lines = [];
+try {
+  transcript = JSON.parse(readFileSync(0, "utf8")).transcript_path;
+  lines = readFileSync(transcript, "utf8").split("\n");
+} catch {}
+
+// Scan newest-first and stop at 80 records, so a multi-MB transcript never parses the head it would discard.
+const records = [];
+let i = lines.length - 1;
+for (; i >= 0 && records.length < 80; i--) {
+  if (!lines[i]) continue;
+  let r;
+  try {
+    r = JSON.parse(lines[i]); // skip a half-written or malformed line
+  } catch {
+    continue;
+  }
+  if (r.isSidechain === true || r.isMeta === true) continue;
+  if (r.type !== "user" && r.type !== "assistant") continue;
+  const content = r.message?.content;
+  let rendered;
+  if (typeof content === "string") rendered = `${r.type}: ${clip(content, 4000)}`;
+  else if (Array.isArray(content))
+    rendered = content
+      .map((b) => renderBlock(r.type, b))
+      .filter(Boolean)
+      .join("\n");
+  else continue;
+  if (rendered) records.push(rendered);
+}
+records.reverse();
+
+// Keep the newest characters so a very chatty session cannot flood the reviewer.
+let recent = records.join("\n\n---\n\n");
+const MAX = 160000;
+if (recent.length > MAX)
+  recent = "…[older turns truncated for length]\n" + recent.slice(-MAX);
+// The record cap is silent otherwise, and a reviewer that cannot tell a whole session from
+// its tail never knows there is anything older to go looking for.
+if (i >= 0)
+  recent = `…[this is only the newest ${records.length} turns of a longer session]\n` + recent;
+
 let contextFile;
 try {
-  const lines = readFileSync(
-    JSON.parse(readFileSync(0, "utf8")).transcript_path,
-    "utf8",
-  ).split("\n");
-
-  // Scan newest-first and stop at 80 records, so a multi-MB transcript never parses the head it would discard.
-  const records = [];
-  for (let i = lines.length - 1; i >= 0 && records.length < 80; i--) {
-    if (!lines[i]) continue;
-    let r;
-    try {
-      r = JSON.parse(lines[i]); // skip a half-written or malformed line
-    } catch {
-      continue;
-    }
-    if (r.isSidechain === true || r.isMeta === true) continue;
-    if (r.type !== "user" && r.type !== "assistant") continue;
-    const content = r.message?.content;
-    let rendered;
-    if (typeof content === "string")
-      rendered = `${r.type}: ${clip(content, 4000)}`;
-    else if (Array.isArray(content))
-      rendered = content
-        .map((b) => renderBlock(r.type, b))
-        .filter(Boolean)
-        .join("\n");
-    else continue;
-    if (rendered) records.push(rendered);
-  }
-  records.reverse();
-
-  if (records.length) {
-    // Keep the newest characters so a very chatty session cannot flood the reviewer.
-    let recent = records.join("\n\n---\n\n");
-    const MAX = 160000;
-    if (recent.length > MAX)
-      recent = "…[older turns truncated for length]\n" + recent.slice(-MAX);
-
+  if (transcript) {
     const staged = join(
       mkdtempSync(join(tmpdir(), "codex-advisor-")),
       "conversation.md",
@@ -103,6 +109,8 @@ try {
     writeFileSync(
       staged,
       `You are reviewing an in-progress Claude Code session. Below is the recent conversation, most recent last, the same history the built-in advisor tool would see. Weigh the question against this actual context, not just the caller's summary of it.
+
+Long turns are shortened and marked \`…[truncated]\`. Full session: ${transcript}, one JSON record per line, newest last. Grep it for a term, number, or phrase you are chasing; never read it whole.
 
 <recent-conversation>
 ${recent}

--- a/plugins/codex-advisor/gemini-extension.json
+++ b/plugins/codex-advisor/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "codex-advisor",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Get a second opinion from GPT via Codex CLI before big decisions."
 }

--- a/plugins/codex-advisor/skills/codex-advisor/SKILL.md
+++ b/plugins/codex-advisor/skills/codex-advisor/SKILL.md
@@ -12,22 +12,21 @@ work over to it.
 
 1. In Claude Code, delegate to the native `codex-advisor` agent. It receives the
    recent conversation automatically, so do not paste the history yourself.
-2. In Codex, Cursor, or Gemini CLI, locate this skill's directory and run
-   `node scripts/ask_codex.mjs`. Pass the review request on standard input.
+2. Elsewhere, run `node scripts/ask_codex.mjs` from this skill's directory with
+   the review request on standard input.
 
-The request must include the decision or conclusion, the relevant recent
-context and evidence, and any constraints or alternatives that affect the
-verdict. Include only facts that matter to the decision.
+State the decision, the evidence behind it, and any constraint that changes the
+verdict. Name the paths that matter: the reviewer has read-only access and
+checks load-bearing claims itself.
 
-Return the reviewer's answer without rewriting it. If `codex` is missing or not
-authenticated, surface the command error and ask the user to install the Codex
-CLI or sign in. Do not fall back to the host model.
+Return the answer without rewriting it. If `codex` is missing or unauthenticated,
+surface the error and ask the user to install it or sign in. Never review in its
+place.
 
-## Picking the reviewer
+## Reviewer
 
-The review runs on whatever model `~/.codex/config.toml` sets. In Codex itself
-that is the same model already doing the work, which is a weak second opinion,
-so set `CODEX_ADVISOR_MODEL` to a different one before calling.
+Pinned to `gpt-5.6-sol` at medium reasoning effort. Inside Codex that may be the
+model already doing the work, so set `CODEX_ADVISOR_MODEL` to a different one.
 
 ## Weighing the answer
 

--- a/plugins/codex-advisor/skills/codex-advisor/reviewer-prompt.md
+++ b/plugins/codex-advisor/skills/codex-advisor/reviewer-prompt.md
@@ -1,10 +1,10 @@
 You are a second opinion, the same role as Claude Code's built-in advisor, consulted at a decision point: a plan about to be committed to, a recurring error, or a task about to be declared done. Another model did the work, not you.
 
-You usually receive the recent conversation in a `<recent-conversation>` block. Treat it as the primary context and the `<question>` block as the specific ask. If the conversation is missing, or a load-bearing detail is absent, say what you need instead of guessing.
+You usually receive the recent conversation in a `<recent-conversation>` block. Treat it as the primary context and the `<question>` block as the specific ask.
 
 Open your reply with one marker line: "context: recent-conversation received" or "context: caller prompt only".
 
-Do not investigate: no commands, tests, shell, file reads, or exploring. Answer from what you were given.
+You have read-only access. Verify the load-bearing claims: when a detail one rests on is shortened or missing, read the file or grep the transcript for that term, symbol, or number instead of guessing. Nothing you run may mutate state: no writes, tests, builds, installs, or network calls. If what you need was never written down anywhere, say so and name it rather than ruling anyway. A second opinion is worth minutes, not a fresh investigation.
 
 Challenge the plan or conclusion, do not rewrite it. Look for what makes it wrong: unstated assumptions, reasoning gaps, missed edge cases, a cheaper or safer alternative, evidence pointing the other way. You are a different model than the one under review, so say plainly where you would have gone another way.
 

--- a/plugins/codex-advisor/skills/codex-advisor/scripts/ask_codex.mjs
+++ b/plugins/codex-advisor/skills/codex-advisor/scripts/ask_codex.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Sends a review request to the Codex CLI and prints only the reviewer's answer.
 // The question arrives on standard input. --context <file> prepends a staged conversation.
-// Set CODEX_ADVISOR_MODEL to review with a model other than the Codex default.
+// Set CODEX_ADVISOR_MODEL to review with a model other than the pinned default.
 
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { spawnSync } from "node:child_process";
@@ -35,9 +35,11 @@ const result = spawnSync(
   "codex",
   [
     "exec",
-    ...(process.env.CODEX_ADVISOR_MODEL
-      ? ["--model", process.env.CODEX_ADVISOR_MODEL]
-      : []),
+    // Pinned so the verdict does not drift with whatever ~/.codex/config.toml happens to set.
+    "--model",
+    process.env.CODEX_ADVISOR_MODEL ?? "gpt-5.6-sol",
+    "-c",
+    'model_reasoning_effort="medium"',
     "--sandbox",
     "read-only",
     "--ephemeral",

--- a/plugins/fable-advisor/.claude-plugin/plugin.json
+++ b/plugins/fable-advisor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/.codex-plugin/plugin.json
+++ b/plugins/fable-advisor/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/.cursor-plugin/plugin.json
+++ b/plugins/fable-advisor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/claude-agents/fable-advisor.md
+++ b/plugins/fable-advisor/claude-agents/fable-advisor.md
@@ -1,19 +1,19 @@
 ---
 name: fable-advisor
 description: |-
-  Second-opinion reviewer backed by Fable 5, a stand-in for the built-in advisor when the Fable-5 advisor is unavailable (see anthropics/claude-code#73365). Consult it before committing to an approach, when an error keeps recurring, or before declaring a task done. State the specific decision to challenge plus any evidence not in the conversation. It receives the recent conversation automatically, reviews it, and returns a verdict without running commands or tests.
+  Second-opinion reviewer backed by Fable 5, a stand-in for the built-in advisor when the Fable-5 advisor is unavailable (see anthropics/claude-code#73365). Consult it before committing to an approach, when an error keeps recurring, or before declaring a task done. State the specific decision to challenge plus any evidence not in the conversation. It receives the recent conversation automatically and verifies claims with read-only access, then returns a verdict.
 model: fable
 color: purple
-tools: []
+tools: [Read, Grep, Glob]
 ---
 
 You are a second opinion, the same role as Claude Code's built-in advisor, consulted at a decision point: a plan about to be committed to, a recurring error, or a task about to be declared done.
 
-You usually receive the recent conversation automatically in a <recent-conversation> block. Treat it as the primary context and the caller's prompt as the specific question. If it is missing or a load-bearing detail is absent, say what you need instead of guessing.
+You usually receive the recent conversation automatically in a <recent-conversation> block. Treat it as the primary context and the caller's prompt as the specific question.
 
 Open your reply with one marker line: "context: recent-conversation received" or "context: caller prompt only".
 
-Do not investigate: no commands, tests, shell, file reads, or exploring.
+You have read-only access. Verify the load-bearing claims: when a detail one rests on is shortened or missing, read the file or grep the transcript for that term, symbol, or number instead of guessing. You cannot mutate state, run tests, or reach the network. If what you need was never written down anywhere, say so and name it rather than ruling anyway. A second opinion is worth minutes, not a fresh investigation.
 
 Challenge the plan or conclusion, do not rewrite it. Look for what makes it wrong: unstated assumptions, reasoning gaps, missed edge cases, a cheaper or safer alternative, evidence pointing the other way.
 

--- a/plugins/fable-advisor/claude-hooks/scripts/inject_transcript.mjs
+++ b/plugins/fable-advisor/claude-hooks/scripts/inject_transcript.mjs
@@ -9,21 +9,6 @@ const emit = (ctx) =>
     JSON.stringify({ hookSpecificOutput: { hookEventName: "SubagentStart", additionalContext: ctx } })
   );
 
-let transcriptPath;
-try {
-  transcriptPath = JSON.parse(readFileSync(0, "utf8")).transcript_path;
-} catch {
-  process.exit(0);
-}
-if (!transcriptPath) process.exit(0);
-
-let lines;
-try {
-  lines = readFileSync(transcriptPath, "utf8").split("\n");
-} catch {
-  process.exit(0);
-}
-
 const clip = (s, n) => (s.length > n ? s.slice(0, n) + " …[truncated]" : s);
 
 const renderBlock = (role, b) => {
@@ -31,23 +16,33 @@ const renderBlock = (role, b) => {
     case "text":
       return `${role}: ${clip(b.text ?? "", 4000)}`;
     case "thinking":
-      return `assistant (thinking): ${clip(b.thinking ?? "", 1200)}`;
+      return `assistant (thinking): ${clip(b.thinking ?? "", 4000)}`;
     case "tool_use":
-      return `assistant → ${b.name ?? "?"}(${clip(JSON.stringify(b.input ?? {}), 280)})`;
+      return `assistant → ${b.name ?? "?"}(${clip(JSON.stringify(b.input ?? {}), 8000)})`;
     case "tool_result": {
       const c = b.content;
       const text =
         typeof c === "string" ? c : Array.isArray(c) ? c.map((x) => x.text ?? "").join(" ") : JSON.stringify(c ?? "");
-      return `  ↳ result: ${clip(text, 700)}`;
+      return `  ↳ result: ${clip(text, 8000)}`;
     }
     default:
       return "";
   }
 };
 
+// Any failure here leaves lines empty, which downgrades the review to the caller's prompt
+// with a warning attached rather than letting the reviewer rule on thin context unknowingly.
+let transcriptPath;
+let lines = [];
+try {
+  transcriptPath = JSON.parse(readFileSync(0, "utf8")).transcript_path;
+  lines = readFileSync(transcriptPath, "utf8").split("\n");
+} catch {}
+
 // Scan newest-first and stop at 80 records, so a multi-MB transcript never parses the head it would discard.
 const records = [];
-for (let i = lines.length - 1; i >= 0 && records.length < 80; i--) {
+let i = lines.length - 1;
+for (; i >= 0 && records.length < 80; i--) {
   if (!lines[i]) continue;
   let r;
   try {
@@ -66,8 +61,12 @@ for (let i = lines.length - 1; i >= 0 && records.length < 80; i--) {
 }
 records.reverse();
 
+const source = transcriptPath
+  ? ` Full session: ${transcriptPath}, one JSON record per line, newest last. Grep it for a term, number, or phrase you are chasing; never read it whole.`
+  : "";
+
 if (records.length === 0) {
-  emit("The recent conversation could not be reconstructed. Review only the caller's prompt and name any missing context.");
+  emit(`The recent conversation could not be reconstructed, so you see only the caller's prompt. Name the context you need.${source}`);
   process.exit(0);
 }
 
@@ -75,9 +74,14 @@ if (records.length === 0) {
 let recent = records.join("\n\n---\n\n");
 const MAX = 160000;
 if (recent.length > MAX) recent = "…[older turns truncated for length]\n" + recent.slice(-MAX);
+// The record cap is silent otherwise, and a reviewer that cannot tell a whole session from
+// its tail never knows there is anything older to go looking for.
+if (i >= 0) recent = `…[this is only the newest ${records.length} turns of a longer session]\n` + recent;
 
 emit(
   `You are reviewing an in-progress Claude Code session. Below is the recent conversation, most recent last, the same history the built-in advisor tool would see. Weigh the specific question in the caller's prompt against this actual context, not just the caller's summary of it.
+
+Long turns are shortened and marked \`…[truncated]\`.${source}
 
 <recent-conversation>
 ${recent}

--- a/plugins/fable-advisor/gemini-extension.json
+++ b/plugins/fable-advisor/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "fable-advisor",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Get a second opinion from Claude Fable 5 before big decisions."
 }

--- a/plugins/fable-advisor/skills/fable-advisor/SKILL.md
+++ b/plugins/fable-advisor/skills/fable-advisor/SKILL.md
@@ -12,13 +12,13 @@ tool's model.
 
 1. In Claude Code, delegate to the native `fable-advisor` agent. Do not launch
    another Claude Code process.
-2. In Codex, Cursor, or Gemini CLI, locate this skill's directory and run
-   `node scripts/ask_fable.mjs`. Pass the review request on standard input.
+2. Elsewhere, run `node scripts/ask_fable.mjs` from this skill's directory with
+   the review request on standard input.
 
-The request must include the decision or conclusion, the relevant recent
-context and evidence, and any constraints or alternatives that affect the
-verdict. Include only facts that matter to the decision.
+State the decision, the evidence behind it, and any constraint that changes the
+verdict. Name the paths that matter: the reviewer has read-only access and
+checks load-bearing claims itself.
 
-Return Fable's answer without rewriting it. If `claude` is missing or not
-authenticated, surface the command error and ask the user to install or sign in
-to Claude Code. Do not fall back to the host model.
+Return Fable's answer without rewriting it. If `claude` is missing or
+unauthenticated, surface the error and ask the user to install it or sign in.
+Never review in its place.

--- a/plugins/fable-advisor/skills/fable-advisor/scripts/ask_fable.mjs
+++ b/plugins/fable-advisor/skills/fable-advisor/scripts/ask_fable.mjs
@@ -15,7 +15,7 @@ const result = spawnSync(
     "--effort",
     "high",
     "--tools",
-    "",
+    "Read,Grep,Glob",
     "--no-session-persistence",
     "--output-format",
     "text",


### PR DESCRIPTION
Both advisors refused to review instead of ruling: the hooks shredded tool output, then the prompts banned the file reads that could have recovered it.

| | before | after |
|---|---|---|
| `tool_use` cap | 280 | 8000 |
| `tool_result` cap | 700 | 8000 |
| context used of 160k budget | 22,365 | 115,845 |

- reviewers get read-only access, so they grep what the window drops
- the 80-record cutoff now announces itself instead of passing silently
- fable blocked reads in two more places: `tools: []` and `--tools ""`

```diff
-return `  ↳ result: ${clip(text, 700)}`;
+return `  ↳ result: ${clip(text, 8000)}`;
+if (i >= 0) recent = `…[this is only the newest ${records.length} turns of a longer session]\n` + recent;
```