### PR TITLE
Stop fable's context from being spilled to a preview

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,7 +42,7 @@
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "Get a second opinion from Claude Fable 5 before big decisions.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "fable-advisor",
       "source": "./plugins/fable-advisor",
       "description": "Get a second opinion from Claude Fable 5 before big decisions.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/fable-advisor/.claude-plugin/plugin.json
+++ b/plugins/fable-advisor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/.codex-plugin/plugin.json
+++ b/plugins/fable-advisor/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/.cursor-plugin/plugin.json
+++ b/plugins/fable-advisor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-advisor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Get a second opinion from Claude Fable 5 before big decisions.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/fable-advisor/claude-agents/fable-advisor.md
+++ b/plugins/fable-advisor/claude-agents/fable-advisor.md
@@ -9,9 +9,9 @@ tools: [Read, Grep, Glob]
 
 You are a second opinion, the same role as Claude Code's built-in advisor, consulted at a decision point: a plan about to be committed to, a recurring error, or a task about to be declared done.
 
-You usually receive the recent conversation automatically in a <recent-conversation> block. Treat it as the primary context and the caller's prompt as the specific question.
+You are usually handed a path to the recent conversation. Read that file before anything else, treat its <recent-conversation> block as the primary context, and treat the caller's prompt as the specific question it answers.
 
-Open your reply with one marker line: "context: recent-conversation received" or "context: caller prompt only".
+Open your reply with one marker line: "context: recent-conversation received" once you have read that file, or "context: caller prompt only" when you were given no path.
 
 You have read-only access. Verify the load-bearing claims: when a detail one rests on is shortened or missing, read the file or grep the transcript for that term, symbol, or number instead of guessing. You cannot mutate state, run tests, or reach the network. If what you need was never written down anywhere, say so and name it rather than ruling anyway. A second opinion is worth minutes, not a fresh investigation.
 

--- a/plugins/fable-advisor/claude-hooks/scripts/inject_transcript.mjs
+++ b/plugins/fable-advisor/claude-hooks/scripts/inject_transcript.mjs
@@ -2,7 +2,9 @@
 // SubagentStart hook: feeds the fable-advisor subagent the recent conversation
 // (it otherwise sees only the caller's prompt). Node-only, cross-platform, exits 0 on any failure.
 
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const emit = (ctx) =>
   process.stdout.write(
@@ -65,11 +67,6 @@ const source = transcriptPath
   ? ` Full session: ${transcriptPath}, one JSON record per line, newest last. Grep it for a term, number, or phrase you are chasing; never read it whole.`
   : "";
 
-if (records.length === 0) {
-  emit(`The recent conversation could not be reconstructed, so you see only the caller's prompt. Name the context you need.${source}`);
-  process.exit(0);
-}
-
 // Keep the newest characters so a very chatty session cannot flood the reviewer.
 let recent = records.join("\n\n---\n\n");
 const MAX = 160000;
@@ -78,12 +75,28 @@ if (recent.length > MAX) recent = "…[older turns truncated for length]\n" + re
 // its tail never knows there is anything older to go looking for.
 if (i >= 0) recent = `…[this is only the newest ${records.length} turns of a longer session]\n` + recent;
 
-emit(
-  `You are reviewing an in-progress Claude Code session. Below is the recent conversation, most recent last, the same history the built-in advisor tool would see. Weigh the specific question in the caller's prompt against this actual context, not just the caller's summary of it.
+// Staged to a file rather than inlined, because the harness spills a large additionalContext
+// to disk and previews it: the reviewer then sees less than a pointer would have given it.
+let contextFile;
+try {
+  if (records.length) {
+    const staged = join(mkdtempSync(join(tmpdir(), "fable-advisor-")), "conversation.md");
+    writeFileSync(
+      staged,
+      `You are reviewing an in-progress Claude Code session. Below is the recent conversation, most recent last, the same history the built-in advisor tool would see. Weigh the specific question in the caller's prompt against this actual context, not just the caller's summary of it.
 
 Long turns are shortened and marked \`…[truncated]\`.${source}
 
 <recent-conversation>
 ${recent}
 </recent-conversation>`
+    );
+    contextFile = staged; // only after the write returned, so the path always resolves
+  }
+} catch {}
+
+emit(
+  contextFile
+    ? `Read ${contextFile} before answering. It holds the recent conversation your question is about, and the caller's prompt is only a summary of it.`
+    : `The recent conversation could not be reconstructed, so you see only the caller's prompt. Name the context you need.${source}`
 );

--- a/plugins/fable-advisor/gemini-extension.json
+++ b/plugins/fable-advisor/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "fable-advisor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Get a second opinion from Claude Fable 5 before big decisions."
 }


### PR DESCRIPTION
#262 raised the truncation caps, which pushed fable's injected context from 22KB to 65KB. Past ~64KB the harness spills `additionalContext` to disk and hands the subagent a ~2KB preview, so the reviewer ended up with less than before. Codex never hit this because it already stages to a file.

| | before | after |
|---|---|---|
| emitted payload | 67,302 B | 293 B |
| reviewer sees | 2KB preview | whole conversation |

- the agent is told to read a path now, so its marker line stays truthful
- one terminal `emit`, so a throw can no longer write two JSON objects
- `contextFile` is set after the write returns, so the path always resolves

```diff
-emit(`You are reviewing an in-progress Claude Code session. ...${recent}...`)
+writeFileSync(staged, `You are reviewing an in-progress Claude Code session. ...${recent}...`)
+emit(`Read ${staged} before answering. ...`)
```

Verified across 8 hook inputs (missing file, malformed stdin, null path, empty file, junk lines, directory as path): all exit 0, all emit exactly one object, none above 341 B.