### PR TITLE
Stop release.sh from rewriting the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -24,15 +24,18 @@ fi
 
 cd "$REPO_ROOT"
 
-# Update marketplace top-level version
+# Check the marketplace version. gh release create tags the pushed branch, so a local
+# edit here would never reach the release. The bump belongs in the commit that precedes it.
 python3 -c "
 import json
 from pathlib import Path
-p = Path('.claude-plugin/marketplace.json')
-d = json.loads(p.read_text())
-d['metadata']['version'] = '$VERSION'
-p.write_text(json.dumps(d, indent=2) + '\n')
-print('Updated marketplace metadata.version to $VERSION')
+current = json.loads(Path('.claude-plugin/marketplace.json').read_text())['metadata']['version']
+if current != '$VERSION':
+    raise SystemExit(
+        'ERROR: marketplace metadata.version is ' + current + ', expected $VERSION. '
+        'Bump it, run sync-versions.sh, then commit and merge before releasing.'
+    )
+print('Marketplace metadata.version is $VERSION')
 "
 
 # Sync all plugin versions across platforms

--- a/.github/scripts/validate_plugins.py
+++ b/.github/scripts/validate_plugins.py
@@ -462,6 +462,28 @@ def validate_marketplace_alignment() -> list[str]:
     return errors
 
 
+MAX_PLUGIN_SUMMARY_CHARS = 100
+
+
+def validate_plugin_summary_length() -> list[str]:
+    """Fail when a Claude marketplace entry makes an over-long README row.
+
+    update-readme.md writes each row as `<summary><strong>{name}</strong> - {description}</summary>`, so the
+    row is the name plus a 3-char separator plus the description. This is an editorial limit that keeps rows
+    short enough to read as one line, not a rendering guarantee.
+    """
+    errors = []
+    data = load_json(CLAUDE_MARKETPLACE)
+    for entry in (data or {}).get("plugins", []):
+        length = len(entry.get("name", "")) + 3 + len(entry.get("description", ""))
+        if length > MAX_PLUGIN_SUMMARY_CHARS:
+            errors.append(
+                f"claude marketplace/{entry.get('name')}: README row exceeds {MAX_PLUGIN_SUMMARY_CHARS} "
+                f"chars ({length}). Shorten the description by {length - MAX_PLUGIN_SUMMARY_CHARS}"
+            )
+    return errors
+
+
 def _git(*args: str) -> subprocess.CompletedProcess:
     """Run a git command in the repo root and capture its output."""
     return subprocess.run(["git", *args], capture_output=True, text=True, cwd=REPO_ROOT)
@@ -610,6 +632,7 @@ def main():
 
     all_errors.extend(validate_symlinks())
     all_errors.extend(validate_marketplace_alignment())
+    all_errors.extend(validate_plugin_summary_length())
     all_errors.extend(validate_advisor_context_handoff())
     all_errors.extend(validate_version_bumps())
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,7 +439,7 @@ Updates marketplace version, regenerates all skill zips, uploads them as release
 
 **Pre-flight**: run `bash .github/scripts/sync-versions.sh` and every `sync-*-skills.sh` manually first. `release.sh` re-runs them, but if any has broken on an upstream restructure the release will ship a stale or empty plugin. Surface those breakages BEFORE tagging.
 
-**Versioning**: pass the new semver to `release.sh <version>`. The script bumps `metadata.version` in `.claude-plugin/marketplace.json` and propagates everywhere via `sync-versions.sh`. Bump minor for new plugins or skill-set additions, patch for sync refreshes, bug fixes, or copy edits.
+**Versioning**: bump `metadata.version` in `.claude-plugin/marketplace.json` yourself, run `sync-versions.sh` to propagate it, and commit that before releasing. `release.sh <version>` only checks the committed value matches and stops if it does not, because `gh release create` tags the pushed branch and never sees a local edit. Bump minor for new plugins or skill-set additions, patch for sync refreshes, bug fixes, or copy edits.
 
 **README zip URLs**: existing zip badges use `releases/latest/download/<skill>.zip` and auto-resolve to the new tag. Do NOT manually bump these URLs after release. New skills introduced in the release need new badge rows added via `/claude-tools:update-readme`.
 

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/gemini-extension.json
+++ b/plugins/humanize/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "humanize",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Block a curated list of AI buzzwords on every write with a hook."
 }

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -203,7 +203,7 @@ text = extract(data.get("tool_name", ""), data.get("tool_input") or {})
 
 notes = [f"remove {label}" for ch, label in MARKS.items() if ch in text]
 notes += [f"'{w}' -> {SWAP[w]}" for w in dict.fromkeys(m.group(1).lower() for m in SWAP_RE.finditer(text))]
-notes += [note for pat, note in PHRASES if re.search(pat, text, re.IGNORECASE)]
+notes += [note for pat, note in PHRASES if re.search(rf"\b(?:{pat})\b", text, re.IGNORECASE)]
 counts = Counter(m.group(1).lower() for m in OFTEN_RE.finditer(text))
 notes += [f"'{w}' used {n} times, vary it" for w, n in counts.items() if n >= LIMIT]
 


### PR DESCRIPTION
The v2.5.0 release left ~350 lines of churn in the working tree. `release.sh` rewrote `.claude-plugin/marketplace.json` with `json.dumps(indent=2)`, expanding every hand-tuned compact array. The write was pointless either way, since `gh release create` tags the pushed branch and never sees a local edit.

- `release.sh` now checks the committed `metadata.version` matches the release argument and stops if it does not, replacing the write
- new CI check fails a PR when `name + " - " + description` exceeds 100 chars, the width that wraps a plugin row onto a second line
- `humanize.py` matched buzzword phrases without word boundaries, so `in summary` fired inside `plugin summary` and blocked a valid docstring

```
-notes += [note for pat, note in PHRASES if re.search(pat, text, re.IGNORECASE)]
+notes += [note for pat, note in PHRASES if re.search(rf"\b(?:{pat})\b", text, re.IGNORECASE)]
```