### PR TITLE
Show monthly clone and view counts as README badges

### DIFF
--- a/.github/scripts/traffic.py
+++ b/.github/scripts/traffic.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Accumulate GitHub traffic counts into rolling 30-day shields.io badge payloads."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+WINDOW_DAYS = 30
+
+
+def fetch(metric: str) -> dict[str, int]:
+    """Return {date: count} for the 14 days of traffic the API still holds."""
+    payload = subprocess.run(
+        ["gh", "api", f"repos/{{owner}}/{{repo}}/traffic/{metric}"], capture_output=True, text=True, check=True
+    ).stdout
+    return {day["timestamp"][:10]: day["count"] for day in json.loads(payload)[metric]}
+
+
+def badge(label: str, total: int, collected: int) -> str:
+    """Render a shields.io endpoint payload, naming the real window until a month has accrued."""
+    count = f"{total / 1000:.1f}k" if total >= 1000 else str(total)
+    period = "month" if collected >= WINDOW_DAYS else f"{collected}d"
+    payload = {
+        "schemaVersion": 1,
+        "label": label.capitalize(),
+        "message": f"{count}/{period}",
+        "color": "blue",
+        "cacheSeconds": 86400,
+    }
+    return json.dumps(payload) + "\n"
+
+
+data_dir = Path(sys.argv[1])
+history_path = data_dir / "history.json"
+history = json.loads(history_path.read_text()) if history_path.exists() else {}
+cutoff = str(date.today() - timedelta(days=WINDOW_DAYS))
+
+# `uniques` is deduplicated per day and cannot be summed, so only `count` is carried.
+# History is append-only because the API drops everything past 14 days, which makes this
+# file the only lasting record, so the 30-day window is applied at render time.
+for metric in ("clones", "views"):
+    history[metric] = history.get(metric, {}) | fetch(metric)
+    total = sum(count for day, count in history[metric].items() if day > cutoff)
+    collected = (date.today() - date.fromisoformat(min(history[metric]))).days
+    payload = badge(metric, total, collected)
+    (data_dir / f"{metric}.json").write_text(payload)
+    print(payload.strip())
+
+history_path.write_text(json.dumps(history, indent=2, sort_keys=True) + "\n")

--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -1,0 +1,38 @@
+name: Traffic counts
+
+# GitHub's traffic API only keeps 14 days, so a "this month" number has to be collected
+# daily before it ages out. Counts land on the orphan `traffic-data` branch, which
+# shields.io reads as a badge endpoint. The API needs Administration:read, which the
+# default GITHUB_TOKEN cannot hold, hence the TRAFFIC_TOKEN secret.
+
+on:
+  schedule:
+    - cron: "41 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  collect:
+    name: Collect and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check out the data branch
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git fetch origin traffic-data:traffic-data && git worktree add data traffic-data \
+            || git worktree add --orphan -b traffic-data data
+      - name: Collect counts
+        env:
+          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+        run: python3 .github/scripts/traffic.py data
+      - name: Publish counts
+        working-directory: data
+        run: |
+          git add -A
+          git diff --cached --quiet && exit 0
+          git commit -m "Traffic counts for $(date -u +%F)"
+          git push origin traffic-data

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![Cursor](https://img.shields.io/badge/Cursor-Plugin-purple)](#installation)
 [![Context7 MCP](https://img.shields.io/badge/Context7%20MCP-Indexed-blue)](https://context7.com/fcakyon/claude-codex-settings)
 [![llms.txt](https://img.shields.io/badge/llms.txt-✓-brightgreen)](https://context7.com/fcakyon/claude-codex-settings/llms.txt)
+[![Clones](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffcakyon%2Fclaude-codex-settings%2Ftraffic-data%2Fclones.json)](https://github.com/fcakyon/claude-codex-settings/blob/traffic-data/history.json)
+[![Views](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffcakyon%2Fclaude-codex-settings%2Ftraffic-data%2Fviews.json)](https://github.com/fcakyon/claude-codex-settings/blob/traffic-data/history.json)
 
 Battle-tested [Claude Code](https://github.com/anthropics/claude-code), [Claude Desktop](https://claude.ai/download), [OpenAI Codex](https://developers.openai.com/codex), and [Cursor](https://cursor.com) setup with skills, commands, hooks, subagents, and MCP servers, plus Kimi, MiniMax, and GLM API support.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Mentioned in Awesome Claude Code](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/hesreallyhim/awesome-claude-code)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-Plugin-blue)](#installation)
 [![Codex CLI](https://img.shields.io/badge/Codex_CLI-Plugin-green)](#installation)
-[![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-Extension-orange)](#installation)
 [![Cursor](https://img.shields.io/badge/Cursor-Plugin-purple)](#installation)
 [![Context7 MCP](https://img.shields.io/badge/Context7%20MCP-Indexed-blue)](https://context7.com/fcakyon/claude-codex-settings)
 [![llms.txt](https://img.shields.io/badge/llms.txt-✓-brightgreen)](https://context7.com/fcakyon/claude-codex-settings/llms.txt)


### PR DESCRIPTION
GitHub keeps only 14 days of traffic data and the API needs a token with `Administration: read`, so no badge service can render it directly. A daily job accumulates the counts instead.

- 5,347 clones and 2,920 views in the last 14 days were invisible in the README until now
- counts land on an orphan `traffic-data` branch, read by two shields.io endpoint badges
- `uniques` is deduplicated per day by GitHub, so only `count` is summed and a monthly unique-visitor number is not derivable
- history is append-only, so the badge window can widen later without losing data
- badge reads `5.3k/14d` today and flips to `/month` once 30 days accrue

```json
{"schemaVersion": 1, "label": "Clones", "message": "5.3k/14d", "color": "blue", "cacheSeconds": 86400}
```

Needs a `TRAFFIC_TOKEN` secret (fine-grained PAT, `Administration: read`, this repo only) before the first run. Triggers are `schedule` and `workflow_dispatch` only, so no fork PR can reach the secret, and the token is read-only on one repo.

Also drops the Gemini CLI badge to keep the header row from wrapping.