### PR TITLE
Move traffic badges to their own row in logo orange

### DIFF
--- a/.github/scripts/traffic.py
+++ b/.github/scripts/traffic.py
@@ -28,7 +28,7 @@ def badge(label: str, total: int, collected: int) -> str:
         "schemaVersion": 1,
         "label": label.capitalize(),
         "message": f"{count}/{period}",
-        "color": "blue",
+        "color": "e2603a",
         "cacheSeconds": 86400,
     }
     return json.dumps(payload) + "\n"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Cursor](https://img.shields.io/badge/Cursor-Plugin-purple)](#installation)
 [![Context7 MCP](https://img.shields.io/badge/Context7%20MCP-Indexed-blue)](https://context7.com/fcakyon/claude-codex-settings)
 [![llms.txt](https://img.shields.io/badge/llms.txt-✓-brightgreen)](https://context7.com/fcakyon/claude-codex-settings/llms.txt)
+
 [![Clones](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffcakyon%2Fclaude-codex-settings%2Ftraffic-data%2Fclones.json)](https://github.com/fcakyon/claude-codex-settings/blob/traffic-data/history.json)
 [![Views](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffcakyon%2Fclaude-codex-settings%2Ftraffic-data%2Fviews.json)](https://github.com/fcakyon/claude-codex-settings/blob/traffic-data/history.json)
 


### PR DESCRIPTION
The two count badges wrapped awkwardly, leaving one orphan on a second line, and their blue duplicated Claude Code and Context7.

- blank line splits the header into 6 install badges and 2 stat badges, so nothing wraps mid-group
- `e2603a` matches the banner brick color and is the only orange in the row now
- stats read as a distinct group instead of a fourth blue

```diff
-        "color": "blue",
+        "color": "e2603a",
```

The published badge JSON only changes when the workflow runs, so this needs one manual dispatch after merge.