### PR TITLE
Move badge cache control to the URL so restyles take effect

### DIFF
--- a/.github/scripts/traffic.py
+++ b/.github/scripts/traffic.py
@@ -29,7 +29,6 @@ def badge(label: str, total: int, collected: int) -> str:
         "label": label.capitalize(),
         "message": f"{count}/{period}",
         "color": "e2603a",
-        "cacheSeconds": 86400,
     }
     return json.dumps(payload) + "\n"
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![Context7 MCP](https://img.shields.io/badge/Context7%20MCP-Indexed-blue)](https://context7.com/fcakyon/claude-codex-settings)
 [![llms.txt](https://img.shields.io/badge/llms.txt-✓-brightgreen)](https://context7.com/fcakyon/claude-codex-settings/llms.txt)
 
-[![Clones](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffcakyon%2Fclaude-codex-settings%2Ftraffic-data%2Fclones.json)](https://github.com/fcakyon/claude-codex-settings/blob/traffic-data/history.json)
-[![Views](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffcakyon%2Fclaude-codex-settings%2Ftraffic-data%2Fviews.json)](https://github.com/fcakyon/claude-codex-settings/blob/traffic-data/history.json)
+[![Clones](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffcakyon%2Fclaude-codex-settings%2Ftraffic-data%2Fclones.json&cacheSeconds=3600)](https://github.com/fcakyon/claude-codex-settings/blob/traffic-data/history.json)
+[![Views](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Ffcakyon%2Fclaude-codex-settings%2Ftraffic-data%2Fviews.json&cacheSeconds=3600)](https://github.com/fcakyon/claude-codex-settings/blob/traffic-data/history.json)
 
 Battle-tested [Claude Code](https://github.com/anthropics/claude-code), [Claude Desktop](https://claude.ai/download), [OpenAI Codex](https://developers.openai.com/codex), and [Cursor](https://cursor.com) setup with skills, commands, hooks, subagents, and MCP servers, plus Kimi, MiniMax, and GLM API support.
 


### PR DESCRIPTION
The orange restyle merged but the badges stayed blue. Shields had cached the old badge for a full day, because the payload asked it to.

- `cacheSeconds` moved from the JSON payload into the badge URL, so the setting lives in one place and a URL change busts the cache immediately
- lowered 86400 to 3600, so counts and restyles land within an hour instead of a day
- verified the new URL renders `#e2603a` right now, while the old one still serves blue

```diff
-        "color": "e2603a",
-        "cacheSeconds": 86400,
+        "color": "e2603a",
```

No workflow dispatch needed this time. The URL changed, so shields fetches fresh on merge.