### PR TITLE
[codex] Allow a one-time simplify bypass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/test_simplify_guard.py
+++ b/.github/scripts/test_simplify_guard.py
@@ -13,6 +13,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 GUARD = REPO_ROOT / "plugins" / "simplify" / "hooks" / "scripts" / "guard.py"
 COMPLETION_SIGNAL = "echo simplify-guard:complete"
+BYPASS_SIGNAL = "echo simplify-guard:bypass"
 
 
 class SimplifyGuardTest(unittest.TestCase):
@@ -98,6 +99,21 @@ class SimplifyGuardTest(unittest.TestCase):
         self.assertFalse(self.marker.exists())
         self.assert_denied(self.run_guard("PreToolUse", "git commit -m again", codex=True))
 
+    def test_explicit_user_bypass_allows_exactly_one_commit_attempt(self) -> None:
+        for runtime in ("codex", "claude"):
+            with self.subTest(runtime=runtime):
+                self.assertIsNone(
+                    self.run_guard("PreToolUse", BYPASS_SIGNAL, **{runtime: True})
+                )
+                self.assertTrue(self.marker.exists())
+                self.assertIsNone(
+                    self.run_guard("PreToolUse", "git commit -m test", **{runtime: True})
+                )
+                self.assertFalse(self.marker.exists())
+                self.assert_denied(
+                    self.run_guard("PreToolUse", "git commit -m again", **{runtime: True})
+                )
+
     def test_claude_skill_event_still_allows_one_commit_attempt(self) -> None:
         self.assertIsNone(self.run_guard("PostToolUse", skill="simplify", claude=True))
         self.assertTrue(self.marker.exists())
@@ -109,9 +125,15 @@ class SimplifyGuardTest(unittest.TestCase):
             {"event": "PostToolUse", "skill": "simplify", "codex": True},
             {"event": "PreToolUse", "command": COMPLETION_SIGNAL, "claude": True},
             {"event": "PreToolUse", "command": COMPLETION_SIGNAL},
+            {"event": "PreToolUse", "command": BYPASS_SIGNAL},
             {
                 "event": "PreToolUse",
                 "command": "echo simplify-guard:complete-later",
+                "codex": True,
+            },
+            {
+                "event": "PreToolUse",
+                "command": "echo simplify-guard:bypass-later",
                 "codex": True,
             },
         ]

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 
 **Hooks:**
 
-- [`guard.py`](./plugins/simplify/hooks/scripts/guard.py) - Require a completed /simplify run before each Claude Code or Codex commit
+- [`guard.py`](./plugins/simplify/hooks/scripts/guard.py) - Require a completed /simplify run before each Claude Code or Codex commit. When a user explicitly asks to skip simplify, the agent can bypass it for one commit without skipping normal Git hooks
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 
 **Hooks:**
 
-- [`guard.py`](./plugins/simplify/hooks/scripts/guard.py) - Require a completed /simplify run before each Claude Code or Codex commit. When a user explicitly asks to skip simplify, the agent can bypass it for one commit without skipping normal Git hooks
+- [`guard.py`](./plugins/simplify/hooks/scripts/guard.py) - Require a completed /simplify run before each Claude Code or Codex commit, unless you explicitly ask to skip it for one commit
 
 </details>
 

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "simplify",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes."
 }

--- a/plugins/simplify/hooks/hooks.json
+++ b/plugins/simplify/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "simplify-guard: require /simplify before each git commit attempt in a worktree",
+  "description": "simplify-guard: require /simplify or an explicit one-time user bypass before each git commit attempt in a worktree",
   "hooks": {
     "PostToolUse": [
       {

--- a/plugins/simplify/hooks/scripts/guard.py
+++ b/plugins/simplify/hooks/scripts/guard.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Block `git commit` until /simplify runs. Each commit attempt spends one /simplify.
+"""Block `git commit` until /simplify runs or the user requests a one-time bypass.
 
 The marker lives in the per-worktree Git directory because /simplify reviews
 the worktree's index. Claude Code mints it through the Skill event; Codex mints
-it through the explicit completion signal at the end of the skill. Other
-runtimes remain unblocked because they have no supported completion path.
+it through the explicit completion signal at the end of the skill. An agent can
+mint the same one-use permission when the user explicitly asks to skip
+/simplify. Other runtimes remain unblocked because they have no supported path.
 """
 
 import json
@@ -19,6 +20,7 @@ event = data.get("hook_event_name", "")
 tool_input = data.get("tool_input") or {}
 
 COMPLETION_SIGNAL = "echo simplify-guard:complete"
+BYPASS_SIGNAL = "echo simplify-guard:bypass"
 SHELL_OPERATORS = {";", "&&", "||", "|", "(", ")"}
 GIT_OPTIONS_WITH_VALUES = {"-C", "-c", "--config-env", "--git-dir", "--namespace", "--work-tree"}
 GIT_OPTIONS_WITHOUT_SUBCOMMAND = {
@@ -76,7 +78,8 @@ def main():
         return
 
     command = tool_input.get("command", "")
-    if is_codex and command.strip() == COMPLETION_SIGNAL:
+    signal = command.strip()
+    if signal == BYPASS_SIGNAL or (is_codex and signal == COMPLETION_SIGNAL):
         if m := marker():
             m.touch()
         return
@@ -94,7 +97,7 @@ def main():
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
-                    "permissionDecisionReason": "simplify-guard: run /simplify on the staged diff first, then retry the commit.",
+                    "permissionDecisionReason": "simplify-guard: run /simplify on the staged diff first. If the user explicitly asked to skip it, run echo simplify-guard:bypass before retrying.",
                 }
             }
         )

--- a/plugins/simplify/hooks/scripts/guard.py
+++ b/plugins/simplify/hooks/scripts/guard.py
@@ -97,7 +97,7 @@ def main():
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
-                    "permissionDecisionReason": "simplify-guard: run /simplify on the staged diff first. If the user explicitly asked to skip it, run echo simplify-guard:bypass before retrying.",
+                    "permissionDecisionReason": "simplify-guard: run /simplify on the staged diff first, then retry the commit.",
                 }
             }
         )

--- a/plugins/simplify/skills/simplify/SKILL.md
+++ b/plugins/simplify/skills/simplify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simplify
-description: This skill should be used when the user asks to "simplify", "clean up the diff", "run simplify", "simplify the changes", "review changed code for cleanup", or explicitly invokes "/simplify". Reviews the changed code across reuse, simplification, efficiency, and altitude with parallel agents, then applies the fixes. Not for correctness bugs.
+description: This skill should be used when the user asks to "simplify", "clean up the diff", "run simplify", "simplify the changes", "review changed code for cleanup", explicitly invokes "/simplify", or asks to "commit without simplify", "skip simplify for this commit", or "commit this but skip simplify". Reviews changed code across reuse, simplification, efficiency, and altitude, or grants an explicit one-commit bypass. Not for correctness bugs.
 ---
 
 # Simplify
@@ -8,6 +8,21 @@ description: This skill should be used when the user asks to "simplify", "clean 
 `/simplify → 4 cleanup agents in parallel → apply the fixes`
 
 You are improving the quality of the changed code, not hunting for bugs. Review it for reuse, simplification, efficiency, and altitude issues, then fix what you find. Do not look for correctness bugs, that is what `/code-review` is for.
+
+## Explicit commit bypass
+
+If the user explicitly asks to commit while skipping simplify, skip the review phases below:
+
+1. State that simplify will be skipped for one commit and normal Git hooks will still run.
+2. Run this exact command from the worktree:
+
+```bash
+echo simplify-guard:bypass
+```
+
+3. Commit normally without `--no-verify`.
+
+Never infer permission to bypass from the size, urgency, or type of change. The user must explicitly name simplify when asking to skip it.
 
 ## Phase 0 — Gather the diff
 


### PR DESCRIPTION
## Why

The simplify review is valuable, but it can be unnecessary for a small or obvious change. A user should be able to tell an agent, “commit this but skip simplify,” while keeping the repository's normal Git hooks.

## How it works

- Normal commits still require a completed simplify review.
- When the user explicitly asks to skip simplify, the agent says that the bypass applies to one commit and that Git hooks will still run.
- The agent records a one-use bypass, then commits normally.
- The next commit attempt consumes the bypass.
- Agents cannot infer permission from the size, urgency, or type of change. The user must name simplify when asking to skip it.

The user only needs to say something like “commit without simplify.” The internal bypass command is an implementation detail.

## What changed

- Add natural-language triggers for an explicit one-commit bypass.
- Reuse the guard's existing worktree-scoped, one-use permission.
- Explain the option in the denial message and plugin documentation.
- Bump the simplify plugin to 1.1.8.
