### PR TITLE
Answer stuck mAP with the cheap knob, not more data

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -376,15 +376,15 @@
     {
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
-      "description": "Auto-format hooks for Python, JavaScript, Markdown, and Bash, plus a push guard.",
-      "version": "2.2.6",
+      "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
+      "version": "2.3.0",
       "author": {
         "name": "Fatih C. Akyon"
       },
       "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
       "repository": "https://github.com/fcakyon/claude-codex-settings",
       "license": "Apache-2.0",
-      "keywords": ["ultralytics", "formatting", "hooks", "python", "code-quality", "docstrings"],
+      "keywords": ["ultralytics", "yolo", "platform", "training", "computer-vision", "formatting", "hooks"],
       "category": "developer-tools",
       "tags": ["formatting", "development"]
     },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -173,8 +173,8 @@
     {
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
-      "description": "Auto-format hooks for Python, JavaScript, Markdown, and Bash, plus a push guard.",
-      "version": "2.2.6",
+      "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
+      "version": "2.3.0",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -48,7 +48,7 @@ done
 
 # Local skill-only plugins have no vendor sync script, so zip their skills here for download assets
 source "$SCRIPTS_DIR/_helpers.sh"
-for skill_dir in plugins/{python-skills,adhd-output-style}/skills/*/; do
+for skill_dir in plugins/{python-skills,adhd-output-style,ultralytics-dev}/skills/*/; do
   create_zip "$skill_dir"
 done
 

--- a/README.md
+++ b/README.md
@@ -735,13 +735,20 @@ Git and GitHub automation. Run the `setup` skill after install.
 </details>
 
 <details>
-<summary><strong>ultralytics-dev</strong> - Auto-formatting hooks + force-push guard</summary>
+<summary><strong>ultralytics-dev</strong> - Ultralytics Platform + YOLO26 training skills, auto-formatting hooks</summary>
 
 | Claude Code                                             | Codex CLI                                          | Gemini CLI                                                   |
 | ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
 | `claude plugin install ultralytics-dev@claude-settings` | `codex plugin add ultralytics-dev@claude-settings` | `gemini extensions install --path ./plugins/ultralytics-dev` |
 
-Auto-formatting hooks for Python, JavaScript, Markdown, and Bash, plus a guard that blocks force-push and rebase.
+Ultralytics Platform API flows and YOLO26 training know-how, plus auto-formatting hooks for Python, JavaScript, Markdown, and Bash and a guard that blocks force-push and rebase.
+
+**Skills** (ZIP for claude.ai, Claude Code, Cursor, Codex, VS Code):
+
+| Skill                                                                                    | Description                                                  | ZIP                                                                                                                                                                          |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`ultralytics-platform`](./plugins/ultralytics-dev/skills/ultralytics-platform/SKILL.md) | Platform API: model upload, datasets, search, cloud training | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/ultralytics-platform.zip) |
+| [`yolo-training`](./plugins/ultralytics-dev/skills/yolo-training/SKILL.md) | YOLO26 training diagnosis: read the curves, pick the knob    | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/yolo-training.zip) |
 
 **Hooks:**
 

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.6",
-  "description": "Auto-format hooks for Python, JavaScript, Markdown, and Bash, plus a push guard.",
+  "version": "2.3.0",
+  "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
   "author": {
     "name": "Fatih C. Akyon"
   },

--- a/plugins/ultralytics-dev/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.6",
-  "description": "Auto-format hooks for Python, JavaScript, Markdown, and Bash, plus a push guard.",
+  "version": "2.3.0",
+  "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
   "author": {
     "name": "Fatih C. Akyon"
   },

--- a/plugins/ultralytics-dev/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.6",
-  "description": "Auto-format hooks for Python, JavaScript, Markdown, and Bash, plus a push guard.",
+  "version": "2.3.0",
+  "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
   "author": {
     "name": "Fatih C. Akyon"
   },

--- a/plugins/ultralytics-dev/gemini-extension.json
+++ b/plugins/ultralytics-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.2.6",
-  "description": "Auto-format hooks for Python, JavaScript, Markdown, and Bash, plus a push guard."
+  "version": "2.3.0",
+  "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard."
 }

--- a/plugins/ultralytics-dev/skills/ultralytics-platform/SKILL.md
+++ b/plugins/ultralytics-dev/skills/ultralytics-platform/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ultralytics-platform
+description: This skill should be used when user asks to "upload my model to Ultralytics Platform", "push this run to the platform", "upload a dataset to platform", "download a dataset from platform", "search platform datasets", "start cloud training", "train on platform GPUs", "export a model on platform", "deploy a model endpoint", "why is my run not showing on platform", or mentions platform.ultralytics.com, ul:// URIs, or ULTRALYTICS_API_KEY.
+---
+
+# Ultralytics Platform
+
+REST API at `https://platform.ultralytics.com`, auth `Authorization: Bearer ul_...`.
+Interactive spec: `GET /openapi.json` (needs the bearer header).
+
+The auth shape and the four gotchas below were run against the live API on
+2026-08-04. Endpoint shapes not covered by those runs come from `/openapi.json` and are marked
+unverified in `references/`.
+
+## Get the key first
+
+```bash
+export ULTRALYTICS_API_KEY=ul_... # Settings > API Keys on platform.ultralytics.com
+```
+
+The `ultralytics` package reads `ULTRALYTICS_API_KEY` env first, then `api_key` in
+`settings.json` (`yolo settings api_key=ul_...`). Check both before assuming the key is missing.
+
+## Pick the path before writing any code
+
+| Goal                                                          | Path                      |
+| ------------------------------------------------------------- | ------------------------- |
+| Track a run that has **not started yet**                      | Package callback, no REST |
+| Push a run that **already finished**                          | REST retro upload         |
+| Read a platform dataset or model in training code             | `ul://` URI               |
+| Upload/download datasets, search, cloud train, export, deploy | REST                      |
+
+### Package callback (live runs)
+
+Set the key and pass `project=`, then train normally. `ultralytics/utils/callbacks/platform.py`
+streams per-epoch metrics, system metrics, console output, PR/F1/confusion-matrix plots, and
+uploads `best.pt` at the end.
+
+```python
+model.train(data="coco8.yaml", epochs=100, project="my-project", name="run1")
+```
+
+**`project=` is mandatory.** The callback returns early without it, so no key and no `project=`
+both produce the same silent nothing. That is the #1 cause of "I trained but the platform is
+empty". See `references/recipes.md` for the full enablement gate and the other failure modes.
+
+### `ul://` URIs
+
+Resolve to signed URLs inside `data=` and `model=`, no manual download:
+
+```python
+YOLO("ul://username/my-project/my-model").train(data="ul://username/datasets/my-dataset", epochs=100)
+```
+
+## REST flows
+
+Read `references/recipes.md` before writing a request. It carries working code for retro upload
+of a finished run, dataset upload and download, search, cloud training, export, deployment, and
+cleanup. Each section states whether it was run live or derived from the spec.
+
+`references/api-reference.md` is the endpoint table plus the request shapes.
+
+## Four things that break first-time requests
+
+1. **`POST /api/models` and `GET /api/models` need the 24-char project ID, not the slug.** Every
+   other endpoint accepts a slug in the path. These two return `400 Invalid project ID` for a slug
+   even though the parameter is documented as "name or ID". Create the project first and keep the
+   returned `projectId`.
+2. **Top-level `metrics` is a closed key set**, listed in `references/api-reference.md`. Posting
+   a raw `results.csv` key like `metrics/mAP50-95(B)` returns `400 Unrecognized key`.
+   `trainResults[].metrics` is free-form, so csv rows go in there as is.
+3. **Uploads are three calls, not one.** `POST /api/upload/signed-url` to get the URL, plain
+   `PUT` of the bytes to that URL with no auth header, then `POST /api/upload/complete`. Skipping
+   the third call leaves the file unattached.
+4. **Deletes are soft.** `DELETE /api/projects/{id}` moves to trash and cascades to its models.
+   `DELETE /api/trash/empty` makes it permanent.
+
+## Cost and destructive actions
+
+`POST /api/training/start`, `POST /api/exports`, and `POST /api/deployments` spend credits.
+The cost comes back in the create response, not from a lookup beforehand, so report
+`billing.estimatedCostDisplay` from the `POST` result before letting the job run.
+Confirm with the user before any create-with-cost or any delete.

--- a/plugins/ultralytics-dev/skills/ultralytics-platform/references/api-reference.md
+++ b/plugins/ultralytics-dev/skills/ultralytics-platform/references/api-reference.md
@@ -1,0 +1,144 @@
+# Platform API reference
+
+Base `https://platform.ultralytics.com`, header `Authorization: Bearer ul_...`.
+Full spec: `curl -H "Authorization: Bearer $ULTRALYTICS_API_KEY" https://platform.ultralytics.com/openapi.json`.
+
+Path parameters accept a URL slug (`my-dataset`) or a 24-char ID. The two exceptions are
+`POST /api/models` (body `projectId`) and `GET /api/models` (query `projectId`), which require the ID.
+
+## Datasets
+
+| Method | Path                                      | Notes                                                               |
+| ------ | ----------------------------------------- | ------------------------------------------------------------------- |
+| GET    | `/api/datasets`                           | `limit` (max 1000), `username`, `owner`, `region`, `includeSamples` |
+| POST   | `/api/datasets`                           | requires `slug`, `name`, `task`, `imageCount`, `format`             |
+| GET    | `/api/datasets/{id}`                      | detail                                                              |
+| PATCH  | `/api/datasets/{id}`                      | rename, visibility, tags, license                                   |
+| DELETE | `/api/datasets/{id}`                      | soft delete to trash                                                |
+| POST   | `/api/datasets/ingest`                    | `datasetId` plus exactly one of `sessionId` or `sourceUrl`          |
+| GET    | `/api/datasets/{id}/export`               | signed NDJSON download URL, `?v=N` for a saved version              |
+| POST   | `/api/datasets/{id}/export`               | freeze an immutable numbered version                                |
+| GET    | `/api/datasets/{id}/class-stats`          | per-class instance counts                                           |
+| GET    | `/api/datasets/{id}/images`               | list, paginated                                                     |
+| PATCH  | `/api/datasets/{id}/images/bulk`          | move images between splits                                          |
+| POST   | `/api/datasets/{id}/splits/redistribute`  | re-split train/val/test                                             |
+| POST   | `/api/datasets/{id}/classes/merge`        | merge class names                                                   |
+| POST   | `/api/datasets/{id}/predict`              | auto-annotate with a model                                          |
+| PUT    | `/api/datasets/{id}/images/{hash}/labels` | edit one image's labels                                             |
+| POST   | `/api/datasets/{id}/embeddings`           | run similarity analysis                                             |
+| GET    | `/api/datasets/{id}/images/clustering`    | 2D embedding layout                                                 |
+| POST   | `/api/datasets/{id}/clone`                | copy an accessible dataset                                          |
+
+`task`: detect, segment, semantic, classify, pose, obb.
+`format`: yolo, coco, voc, raw, ndjson.
+Ingest `conflictPolicy`: skip, keep_both, replace. `targetSplit` overrides the archive's own layout.
+
+## Projects and models
+
+| Method               | Path                        | Notes                                                     |
+| -------------------- | --------------------------- | --------------------------------------------------------- |
+| GET / POST           | `/api/projects`             | create needs `slug` + `name`                              |
+| GET / PATCH / DELETE | `/api/projects/{id}`        | delete cascades to models                                 |
+| GET                  | `/api/models`               | `projectId` required, `fields=summary` or `fields=charts` |
+| POST                 | `/api/models`               | create a model record, body `projectId`                   |
+| GET                  | `/api/models/completed`     | usable models across all projects                         |
+| GET / PATCH / DELETE | `/api/models/{id}`          | `?project=my-project` disambiguates a slug                |
+| GET                  | `/api/models/{id}/files`    | signed download URLs, valid 1 hour                        |
+| POST                 | `/api/models/{id}/predict`  | inference on stored weights                               |
+| GET                  | `/api/models/{id}/training` | live status, epoch, timing, metrics                       |
+| DELETE               | `/api/models/{id}/training` | cancel a running job                                      |
+
+### POST /api/models body
+
+| Field                                    | Type             | Notes                                                                              |
+| ---------------------------------------- | ---------------- | ---------------------------------------------------------------------------------- |
+| `projectId`                              | string           | required                                                                           |
+| `slug`                                   | string           | `^[a-z0-9-]+$`                                                                     |
+| `name`, `description`, `version`, `docs` | string           |                                                                                    |
+| `task`                                   | enum             | detect, segment, semantic, depth, classify, pose, obb                              |
+| `trainArgs`                              | object           | free-form, mirror `args.yaml`                                                      |
+| `trainResults`                           | array, max 10000 | `{epoch, metrics{str: number}, system, fitness, timestamp}`, free-form metric keys |
+| `metrics`                                | object           | closed key set, see below                                                          |
+| `epochs`                                 | number           |                                                                                    |
+| `environment`                            | object           | free-form host/git/gpu info                                                        |
+| `completedAt`                            | ISO 8601         | must end in `Z`                                                                    |
+
+Allowed `metrics` keys, everything else returns `400 Unrecognized key`:
+`mAP50`, `mAP50-95`, `precision`, `recall`, `accuracy_top1`, `accuracy_top5`, `miou`,
+`pixel_acc`, `delta1`, `abs_rel`, `rmse`, `silog`.
+
+No `plots` field exists. PR curves, F1 curves, and confusion matrices reach the platform only
+through the training callback.
+
+## Uploads
+
+| Method | Path                     | Notes                                                                                              |
+| ------ | ------------------------ | -------------------------------------------------------------------------------------------------- |
+| POST   | `/api/upload/signed-url` | `assetType` (models, datasets, images, videos), `assetId`, `filename`, `contentType`, `totalBytes` |
+| POST   | `/api/upload/complete`   | `sessionId`, optional `checksum`                                                                   |
+
+`assetId` is validated against a real record, a bad one returns `404 Model not found`.
+The `PUT` to `uploadUrl` carries no `Authorization` header, the signature is in the URL.
+`uploadUrl` expires, `expiresAt` is in the signed-url response.
+
+## Cloud training
+
+| Method | Path                             | Notes                                          |
+| ------ | -------------------------------- | ---------------------------------------------- |
+| POST   | `/api/training/start`            | `modelId`, `projectId`, `trainArgs`, `gpuType` |
+| GET    | `/api/training/gpu-availability` | stock status per GPU id                        |
+
+`gpuType`: `rtx-4090` (default), `a100`, `h100`.
+`trainArgs` requires `model`, `data`, `epochs` and accepts any other `default.yaml` key.
+`model` and `data` accept `ul://` URIs or shipped names (`yolo26n.pt`, `coco8.yaml`).
+The response returns `estimatedCost.pricePerHour`, `billing.estimatedCostCents`, and a
+preformatted `billing.estimatedCostDisplay`. Show these
+to the user before starting.
+
+## Exports and deployments
+
+| Method       | Path                            | Notes                                                |
+| ------------ | ------------------------------- | ---------------------------------------------------- |
+| GET / POST   | `/api/exports`                  | `modelId`, `format`, `gpuType` (engine only), `args` |
+| GET / DELETE | `/api/exports/{id}`             | status, cancel                                       |
+| GET / POST   | `/api/deployments`              | `modelId`, `name`, `region`, `resources`             |
+| GET / DELETE | `/api/deployments/{id}`         | detail, delete                                       |
+| POST         | `/api/deployments/{id}/predict` | inference on the endpoint                            |
+| GET          | `/api/deployments/{id}/health`  | readiness, also `/metrics` and `/logs`               |
+| POST         | `/api/deployments/{id}/start`   | also `/stop`                                         |
+
+Export `args`: `imgsz`, `quantize` (8/16/32 or int8/fp16/fp32 or w8a8/w16a16/w8a16/w8a32),
+`dynamic`, `simplify`, `opset` (9-23), `batch`, `nms`, `end2end`, `workspace`, `conf`, `iou`,
+plus a `name` target for RKNN, QNN, Hailo, and Ascend.
+Deployment `resources`: `cpu` 1-8, `memoryGi` 1-32, `minInstances` 0-10 (0 scales to zero),
+`maxInstances` 1-100.
+
+## Discovery and account
+
+| Method              | Path                                 | Notes                                                                              |
+| ------------------- | ------------------------------------ | ---------------------------------------------------------------------------------- |
+| GET                 | `/api/explore/search`                | `q`, `type` (all/projects/datasets), `sort`, `task`, `author`, `starred`, `offset` |
+| GET                 | `/api/explore/sidebar`               | curated public resources                                                           |
+| GET                 | `/api/account/summary`               | username, plan, credits, resource counts                                           |
+| GET                 | `/api/billing/balance`               | credit balance                                                                     |
+| GET                 | `/api/billing/usage-summary`         | plan and usage                                                                     |
+| GET                 | `/api/storage`                       | storage usage                                                                      |
+| GET                 | `/api/activity`                      | recent events                                                                      |
+| GET / POST / DELETE | `/api/api-keys`                      | manage keys                                                                        |
+| GET / POST          | `/api/teams`, `/api/members`         | team management                                                                    |
+| GET / POST          | `/api/integrations/buckets`          | S3, GCS, Azure connections                                                         |
+| POST                | `/api/integrations/roboflow/preview` | also `/import`                                                                     |
+| GET / POST / DELETE | `/api/trash`                         | plus `DELETE /api/trash/empty` to purge                                            |
+
+`sort` values: stars, newest, oldest, name-asc, name-desc, count-desc, count-asc.
+`/api/explore/search` works unauthenticated except for `starred`.
+
+## Error codes seen in practice
+
+| Code                          | Meaning                                        |
+| ----------------------------- | ---------------------------------------------- |
+| 400 `Invalid project ID`      | slug passed where the ID is required           |
+| 400 `Unrecognized key: "..."` | key outside a closed schema, usually `metrics` |
+| 401 `Unauthorized`            | missing or wrong bearer token                  |
+| 404 `Model not found`         | bad `assetId` or `modelId`                     |
+| 409                           | resource still processing, retry later         |

--- a/plugins/ultralytics-dev/skills/ultralytics-platform/references/recipes.md
+++ b/plugins/ultralytics-dev/skills/ultralytics-platform/references/recipes.md
@@ -1,0 +1,322 @@
+# Platform recipes
+
+Working code for each flow. All snippets assume `ULTRALYTICS_API_KEY` is exported.
+
+Recipes 1, 5, and 8 were run end to end against the live API on 2026-08-04. The rest are
+derived from `/openapi.json` and have not been executed, since recipes 3, 6, and 7 create
+billable resources. Treat their request shapes as correct and their responses as unconfirmed.
+
+## Shared client
+
+```python
+import json
+import os
+import urllib.request
+
+KEY, BASE = os.environ["ULTRALYTICS_API_KEY"], "https://platform.ultralytics.com"
+
+
+def api(method, path, body=None):
+    """Call the platform API and return the parsed JSON response."""
+    req = urllib.request.Request(
+        BASE + path,
+        data=json.dumps(body).encode() if body is not None else None,
+        method=method,
+        headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req) as r:
+        return json.loads(r.read().decode())
+```
+
+`requests` works the same way and is already an ultralytics dependency.
+
+## 1. Upload a finished local run
+
+Turns `runs/detect/train/` into a platform model with training curves, final metrics,
+resolved args, and downloadable weights.
+
+```python
+import csv
+import pathlib
+import urllib.request
+
+import yaml
+
+run = pathlib.Path("runs/detect/train")
+
+# results.csv column -> the closed metrics key set
+FINAL = {
+    "metrics/mAP50(B)": "mAP50",
+    "metrics/mAP50-95(B)": "mAP50-95",
+    "metrics/precision(B)": "precision",
+    "metrics/recall(B)": "recall",
+    "metrics/accuracy_top1": "accuracy_top1",
+    "metrics/accuracy_top5": "accuracy_top5",
+    "metrics/mIoU": "miou",
+    "metrics/pixel_acc": "pixel_acc",
+    "metrics/delta1": "delta1",
+    "metrics/abs_rel": "abs_rel",
+    "metrics/rmse": "rmse",
+    "metrics/silog": "silog",
+}
+
+rows = [{k.strip(): v for k, v in r.items()} for r in csv.DictReader((run / "results.csv").open())]
+train_args = yaml.safe_load((run / "args.yaml").read_text())
+
+# Per-epoch curves. Keys here are free-form, so raw csv names go straight in.
+# Drop `time`, it is wall-clock seconds and would ship as a chart series.
+train_results = [
+    {
+        "epoch": int(float(r["epoch"])),
+        "metrics": {k: float(v) for k, v in r.items() if k not in {"epoch", "time"} and v not in ("", None)},
+    }
+    for r in rows
+]
+
+# Final metrics, taken from the best epoch. Keys must be renamed or the request 400s.
+best = max(train_results, key=lambda r: r["metrics"].get("metrics/mAP50-95(B)", 0.0))["metrics"]
+metrics = {v: best[k] for k, v in FINAL.items() if k in best}
+
+# The project must exist first, and POST /api/models needs its ID, not its slug.
+project_id = api("POST", "/api/projects", {"slug": "my-project", "name": "My Project"})["projectId"]
+
+model_id = api(
+    "POST",
+    "/api/models",
+    {
+        "projectId": project_id,
+        "slug": "yolo26n-run1",
+        "name": "yolo26n run1",
+        "task": train_args.get("task", "detect"),
+        "epochs": len(rows),
+        "trainArgs": {k: str(v) for k, v in train_args.items()},
+        "trainResults": train_results,
+        "metrics": metrics,
+    },
+)["modelId"]
+
+# Weights: signed URL, bare PUT, then complete. All three calls are required.
+weights = run / "weights" / "best.pt"
+signed = api(
+    "POST",
+    "/api/upload/signed-url",
+    {
+        "assetType": "models",
+        "assetId": model_id,
+        "filename": "best.pt",
+        "contentType": "application/octet-stream",
+        "totalBytes": weights.stat().st_size,
+    },
+)
+urllib.request.urlopen(
+    urllib.request.Request(
+        signed["uploadUrl"],
+        data=weights.read_bytes(),
+        method="PUT",
+        headers={"Content-Type": "application/octet-stream"},  # no Authorization here
+    )
+)
+api("POST", "/api/upload/complete", {"sessionId": signed["sessionId"]})
+```
+
+Verify with `GET /api/models/{model_id}/files`. The file is served under the model slug
+(`yolo26n-run1.pt`) regardless of the `filename` you uploaded.
+
+`results.csv` numbers epochs from 1, the callback in recipe 2 sends `trainer.epoch` from 0.
+Charts from a retro upload and a streamed run are offset by one against each other.
+
+For a large `best.pt`, stream the PUT instead of `read_bytes()`, or reuse
+`ultralytics.utils.uploads.safe_upload(file=..., url=..., retry=3, progress=True)`,
+which adds retries and a progress bar.
+
+The plot PNGs do not transfer, only the per-epoch curves in `trainResults`. Use recipe 2 instead
+if the charts matter.
+
+## 2. Track a run that has not started
+
+```bash
+export ULTRALYTICS_API_KEY=ul_...
+yolo train model=yolo26n.pt data=my-data.yaml epochs=100 project=my-project name=run1
+```
+
+It prints `Platform: Streaming training metrics to Platform` at startup and a model URL at the
+end. Enablement gate, all must hold:
+
+1. Not running under pytest.
+2. `SETTINGS["platform"] is True` or `ULTRALYTICS_API_KEY` set or `SETTINGS["api_key"]` set.
+3. A resolved API key.
+4. `trainer.args.project` is truthy, checked separately in every callback.
+5. `RANK` in `{-1, 0}`, so under DDP only rank 0 reports.
+
+Diagnosing silence:
+
+| Symptom                                    | Cause                                                      |
+| ------------------------------------------ | ---------------------------------------------------------- |
+| No `Platform:` line at all                 | no key, or `project=` unset                                |
+| `Training will not be tracked on Platform` | key present, server rejected `training_started`            |
+| Run appears, no weights                    | `best.pt` upload failed, warning is in the console log     |
+| Name is `train-2` not `train`              | server auto-incremented a taken slug, it logs the real one |
+
+Checkpoints upload at most every 15 minutes mid-run, then `best.pt` uploads blocking at the end.
+Project and name are slugified, so `My Run 1` becomes `my-run-1`.
+
+## 3. Upload a dataset
+
+Local archive, four calls:
+
+```python
+ds = api(
+    "POST",
+    "/api/datasets",
+    {
+        "slug": "my-dataset",
+        "name": "My Dataset",
+        "task": "detect",
+        "format": "yolo",
+        "imageCount": 1200,
+        "visibility": "private",
+    },
+)["datasetId"]
+
+archive = pathlib.Path("my-dataset.zip")
+signed = api(
+    "POST",
+    "/api/upload/signed-url",
+    {
+        "assetType": "datasets",
+        "assetId": ds,
+        "filename": archive.name,
+        "contentType": "application/zip",
+        "totalBytes": archive.stat().st_size,
+    },
+)
+# PUT the bytes then POST /api/upload/complete as in recipe 1, streaming rather than
+# read_bytes() since dataset archives are large.
+job = api("POST", "/api/datasets/ingest", {"datasetId": ds, "sessionId": signed["sessionId"]})
+```
+
+Remote archive, no upload at all:
+
+```python
+api("POST", "/api/datasets/ingest", {"datasetId": ds, "sourceUrl": "https://example.com/data.zip"})
+```
+
+Accepted archives: ZIP, TAR, TAR.GZ, TGZ, NDJSON. The archive should carry the standard
+`images/{split}` + `labels/{split}` layout, or pass `targetSplit` to force every incoming image
+into one split. Ingest is async, poll `GET /api/datasets/{id}` until `status` leaves `processing`.
+
+Adding to an existing dataset uses the same calls with `conflictPolicy` set to
+`skip`, `keep_both`, or `replace`.
+
+## 4. Download a dataset
+
+Fastest path, let the package do it:
+
+```python
+YOLO("yolo26n.pt").train(data="ul://username/datasets/my-dataset", epochs=100)
+```
+
+`resolve_platform_uri` in `ultralytics/utils/callbacks/platform.py` turns the URI into a signed
+URL, `check_file` in `ultralytics/utils/checks.py` downloads it, and
+`convert_ndjson_to_yolo_if_needed` in `ultralytics/data/utils.py` converts the NDJSON on the fly.
+
+To materialize it on disk:
+
+```python
+import asyncio
+
+from ultralytics.data.converter import convert_ndjson_to_yolo
+
+url = api("GET", "/api/datasets/my-dataset/export")["downloadUrl"]
+urllib.request.urlretrieve(url, "my-dataset.ndjson")
+data_yaml = asyncio.run(convert_ndjson_to_yolo("my-dataset.ndjson", output_path="datasets/"))
+```
+
+`convert_ndjson_to_yolo` is async and downloads images concurrently. It returns the `data.yaml`
+path for detect, segment, pose, and obb, and the dataset directory for classify.
+
+Pin a snapshot before a training campaign so the dataset cannot shift underneath the runs:
+
+```python
+v = api("POST", "/api/datasets/my-dataset/export", {"description": "v1 baseline"})
+# later: api("GET", f"/api/datasets/my-dataset/export?v={v['version']}")
+```
+
+## 5. Search datasets
+
+```python
+r = api("GET", "/api/explore/search?q=weld+defect&type=datasets&task=detect&sort=stars")
+for d in r["datasets"]:
+    print(f"ul://{d['username']}/datasets/{d['slug']}  {d['imageCount']} imgs  {d['classCount']} cls")
+```
+
+Returned `slug` plus `username` compose the `ul://` URI directly, so a search result is
+immediately trainable. `hasMore` drives pagination through `offset`.
+`GET /api/datasets?username=someone` lists one user's public datasets instead.
+
+## 6. Start cloud training
+
+```python
+print(api("GET", "/api/training/gpu-availability"))  # what is free right now
+
+model_id = api(
+    "POST", "/api/models", {"projectId": project_id, "slug": "cloud-run1", "name": "cloud run1", "task": "detect"}
+)["modelId"]
+
+job = api(
+    "POST",
+    "/api/training/start",
+    {
+        "modelId": model_id,
+        "projectId": project_id,
+        "gpuType": "rtx-4090",
+        "trainArgs": {
+            "model": "yolo26n.pt",
+            "data": "ul://username/datasets/my-dataset",
+            "epochs": 100,
+            "imgsz": 640,
+            "batch": 16,
+        },
+    },
+)
+print(job["billing"]["estimatedCostDisplay"])
+```
+
+Poll with
+`GET /api/models/{modelId}/training`, cancel with `DELETE /api/models/{modelId}/training`.
+
+## 7. Export and deploy
+
+```python
+exp = api(
+    "POST",
+    "/api/exports",
+    {"modelId": model_id, "format": "engine", "gpuType": "rtx-4090", "args": {"imgsz": 640, "quantize": 16}},
+)
+# poll api("GET", f"/api/exports/{exp['exportId']}") until it reports complete
+
+dep = api(
+    "POST",
+    "/api/deployments",
+    {
+        "modelId": model_id,
+        "name": "prod-endpoint",
+        "region": "europe-west1",
+        "resources": {"cpu": 2, "memoryGi": 4, "minInstances": 0, "maxInstances": 3},
+    },
+)
+```
+
+TensorRT (`engine`) exports require `gpuType` because the plan is GPU-specific.
+`minInstances: 0` scales to zero and trades cold-start latency for cost.
+Both endpoints spend credits, confirm with the user first.
+
+## 8. Cleanup
+
+```python
+api("DELETE", f"/api/projects/{project_id}")  # soft, cascades to the project's models
+api("DELETE", "/api/trash/empty")  # permanent
+```
+
+`DELETE /api/projects/{id}` returns `cascadedModels`. `DELETE /api/trash/empty` returns a
+per-type deleted count. Ask the user before running either.

--- a/plugins/ultralytics-dev/skills/yolo-training/SKILL.md
+++ b/plugins/ultralytics-dev/skills/yolo-training/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: yolo-training
+description: This skill should be used when user asks to "improve my mAP", "why is my model overfitting", "my training is diverging", "read my results.csv", "interpret my training curves", "my AP50 is good but AP50-95 is bad", "my recall is low", "how do I pick learning rate", "which augmentations should I use", "should I use a bigger model", "tune hyperparameters", or asks how to train YOLO26 for detection, instance or semantic segmentation, pose, OBB, classification, or depth.
+---
+
+# YOLO26 training
+
+Read the run before changing anything. Most requests for "better accuracy" arrive with a
+`results.csv` and confusion matrix that already name the problem.
+
+## Order of operations
+
+Ordered by cost to try, cheapest first, not by size of the potential win. The last two are the
+ones people reach for first and they are the two that spend real budget.
+
+1. **Epochs and schedule.** Undertrained looks like every other problem, and it costs nothing
+   but time to rule out.
+2. **Augmentation.** The lever for the generalization gap, at no extra compute per epoch.
+3. **Loss weights and LR.** Cheap, and the curves usually say which one is wrong.
+4. **Model size.** Scale up when train loss is still falling at the end of the schedule and the
+   train and val curves sit close together. That is the signature of underfitting, and the only
+   one a bigger model reliably fixes.
+5. **Resolution.** Compute scales with the square of `imgsz`, so 640 to 1280 is roughly 4x the
+   training budget. Pretrained weights also transfer worse the further you move from the size
+   they were trained at, so a large jump is a new training budget, not a free knob. Justify it
+   with the object sizes in your data, not as a default first move.
+6. **Data**, label quality and class balance. The highest ceiling and the slowest to move, and
+   the package ships no dataset-analysis tooling, so any audit here is your own script plus
+   looking at images. Worth it once the cheap knobs are spent and the curves say the model is
+   not the limit.
+
+## Diagnostic loop
+
+```python
+import pandas as pd
+
+df = pd.read_csv("runs/detect/train/results.csv")
+df.columns = df.columns.str.strip()
+print(df.tail(10)[["epoch", "train/box_loss", "val/box_loss", "metrics/mAP50(B)", "metrics/mAP50-95(B)"]])
+print("best epoch:", df["metrics/mAP50-95(B)"].idxmax(), "of", len(df))
+```
+
+Then read, in this order:
+
+| Read                                       | Question it answers                       |
+| ------------------------------------------ | ----------------------------------------- |
+| best epoch vs total epochs                 | undertrained, overtrained, or right       |
+| train loss vs val loss trend               | which side of the generalization gap      |
+| mAP50 vs mAP50-95                          | classification and recall vs localization |
+| P vs R at the operating point              | over-suppression vs over-firing           |
+| per-class AP spread                        | one broken class or a general weakness    |
+| confusion matrix background row and column | false positives vs missed detections      |
+
+`references/diagnostics.md` maps each pattern to a cause and a knob, and lists what to rule
+out before turning that knob. Read it before recommending a change.
+`references/task-notes.md` covers detect, segment, semantic, pose, obb, classify, and depth
+specifics.
+
+## Things that silently override your settings
+
+These produce "I changed X and nothing happened", and each one is real in current defaults.
+
+1. **`optimizer=auto` ignores `lr0` and `momentum`.** It is the default. It picks
+   `MuSGD` at lr 0.01 when total iterations exceed 10000, otherwise `AdamW` at
+   `0.002 * 5 / (4 + nc)`, and forces `warmup_bias_lr=0`. Setting `lr0` while leaving
+   `optimizer=auto` does nothing. Set `optimizer=AdamW` or `optimizer=SGD` explicitly first.
+2. **`nbs=64` normalizes the loss, so batch does not scale LR the way you assume.** Below 64 the
+   trainer accumulates gradients to an effective 64. Dropping batch 64 to 16 changes almost
+   nothing about the effective step.
+3. **`close_mosaic=10` turns off mosaic for the last 10 epochs.** The late jump in mAP is that
+   switch, not convergence. On a 20-epoch run it is half the schedule, and on a 10-epoch run
+   mosaic never runs at all.
+4. **Fitness for detect is mAP50-95 alone**, weights `[0, 0, 0, 1]`. `best.pt` and `patience`
+   ignore precision, recall, and mAP50 completely. Segment and pose sum both heads, classify
+   uses `(top1 + top5) / 2`, semantic uses mIoU. A run whose precision is climbing while
+   mAP50-95 is flat will still early-stop.
+5. **`max_det=300`** truncates validation on dense scenes. Above roughly 300 objects per image
+   your recall ceiling is an artifact.
+6. **YOLO26 `end2end` models do their own NMS-free decoding**, so `iou` and `agnostic_nms`
+   have no effect on them.
+
+## Starting recipe
+
+Fine-tuning a pretrained checkpoint on a normal custom dataset:
+
+```bash
+yolo train model=yolo26s.pt data=my-data.yaml epochs=200 imgsz=640 batch=16 \
+  optimizer=AdamW lr0=0.001 lrf=0.01 cos_lr=True warmup_epochs=3 \
+  patience=50 close_mosaic=20
+```
+
+Deviate on evidence from the charts, one axis at a time. Reasons this differs from the shipped
+defaults: `epochs=100` is short for a small dataset, `patience=100` never fires inside 100
+epochs so it is not real early stopping, and `close_mosaic=10` is too short a clean tail once
+epochs rise.
+
+Change one thing per run and keep `seed` fixed. Run-to-run noise on a small dataset is often
+0.5 to 1.0 mAP, so a 0.3 mAP "improvement" from a single run is not a result. Confirm anything
+smaller than about 1 point across two or three seeds before believing it.

--- a/plugins/ultralytics-dev/skills/yolo-training/references/diagnostics.md
+++ b/plugins/ultralytics-dev/skills/yolo-training/references/diagnostics.md
@@ -1,0 +1,260 @@
+# Reading a run
+
+Symptom, the cheap knob, and what to check when the knob does not move it. Reach for the free
+changes first and treat anything that costs compute or relabeling as the answer you fall back
+to, not the one you open with.
+
+## Metric-shape patterns
+
+### mAP50 high, mAP50-95 low
+
+Classification and coarse localization work. Tight localization does not.
+
+Start with the loss weights. This is the cheap test and it is the one targeted at the symptom:
+
+```bash
+box=10.0 dfl=2.0 # from 7.5 / 1.5
+```
+
+Raise `box` and `dfl` together, roughly 1.3x to 2x. `dfl` governs the distribution focal loss
+that produces sub-pixel box edges, so it is the more targeted of the two for this symptom.
+Watch that `cls` does not get crowded out, a collapsing `metrics/precision(B)` means you went
+too far.
+
+If that moves nothing, the ceiling is probably not the loss:
+
+1. **Loose ground truth.** Sloppy boxes cap mAP50-95 permanently and no loss weight recovers
+   it. Overlay 30 to 50 GT boxes on their images and look. If human boxes sit 5 to 10 pixels
+   outside the object, the ceiling is the labels and the only fix is relabeling.
+2. **Ambiguous class boundaries.** "Where does the scratch end" has no tight answer, and
+   annotators disagree with each other. Check inter-annotator spread before blaming the model.
+3. **Objects too small for the resolution.** An object spanning 12 pixels cannot be localized
+   to mAP50-95 precision at any loss weight. Read the Small objects section for what raising
+   `imgsz` costs before reaching for it.
+
+### mAP50-95 close to mAP50
+
+Unusual, and normally means objects are large and easy. Little headroom on localization.
+Look at recall and per-class AP instead.
+
+### Precision high, recall low
+
+The model fires rarely and is right when it does. It is missing objects.
+
+Rule out first:
+
+1. **Missing annotations.** Unlabeled true objects train the model to suppress them, and then
+   penalize it again at validation. Look at the highest-confidence false positives. If they are
+   correct detections of unlabeled objects, the dataset is the bug.
+2. **`conf` at inference.** Validation uses `conf=0.001`, prediction defaults to `0.25`. A
+   recall complaint from `predict` output and one from `val` metrics are different problems.
+3. **`max_det=300`** on dense scenes.
+4. **Small objects** below the P3 stride, see the small-object section.
+
+Then:
+
+```bash
+cls=1.0    # from 0.5, push classification confidence up
+cls_pw=0.5 # inverse-frequency class weighting if rare classes carry the loss
+```
+
+`cls_pw` is the underused one. `0.0` disables it, `1.0` is full inverse frequency, and values
+between dampen it. On a dataset with a 50:1 class ratio, `0.3` to `0.5` often moves rare-class
+recall several points where nothing else does. The trainer asserts `0 <= cls_pw <= 1`, so
+values above 1 raise rather than weight harder.
+
+### Precision low, recall high
+
+The model fires often, including on nothing.
+
+Rule out first:
+
+1. **Duplicate boxes.** Look at raw predictions. Many overlapping boxes on one object means
+   NMS, not the model. Lower `iou` from `0.7` toward `0.5`. On YOLO26 `end2end` this knob does
+   nothing, the model decodes without NMS.
+2. **Background false positives.** Read the confusion matrix background column. If one class
+   dominates it, that class needs hard negatives.
+3. **Class confusion.** Off-diagonal mass between two classes means the taxonomy is the
+   problem, not the threshold. Merging two classes that annotators cannot separate reliably
+   often beats any amount of tuning.
+
+Then add background-only images (5 to 10 percent of the train set, no label file), and raise
+inference `conf`.
+
+### Both precision and recall low across every class
+
+Undertrained, wrong LR, or broken data loading. Check that training loss is still falling. If
+the first-epoch mAP is near zero and stays there, verify the label format and `nc` before
+touching hyperparameters.
+
+### One class far below the others
+
+Per-class AP spread is data, not hyperparameters, nine times out of ten. Check instance count,
+then look at 20 of its images. A class with 40 instances against classes with 4000 will
+underperform regardless of the recipe. Options, in order: collect more, merge it into a
+neighbor class, or apply `cls_pw`.
+
+## Loss-curve patterns
+
+### Train loss falls, val loss rises
+
+Overfitting. The gap opens, and mAP50-95 peaks then decays.
+
+Augmentation, strongest first:
+
+```bash
+mixup=0.15 copy_paste=0.3 scale=0.9 degrees=10 mosaic=1.0 close_mosaic=20
+```
+
+- `mixup` blends two images and their labels. The general-purpose regularizer, and the first
+  thing to reach for. `0.1` to `0.2` on small datasets.
+- `copy_paste` pastes instances between images. Needs segmentation masks to work well, and it
+  is the strongest single lever for rare-class recall when they exist.
+- `scale` is the most underrated. `0.5` means 0.5x to 1.5x. Raising to `0.9` widens the
+  scale range the model must handle, and it costs nothing at inference.
+- `erasing` (classify) and `cutmix` are alternatives when mixup is already maxed.
+
+Then regularization: `weight_decay=0.001` from `0.0005`, and `dropout` for classify only.
+
+Then, if it persists: fewer epochs, a smaller model, more data.
+
+Do not raise `degrees`, `flipud`, or `perspective` without checking that the transform is
+valid for your domain. Rotating an X-ray 15 degrees is fine. Rotating a document or a road
+scene is not, and it costs accuracy.
+
+### Train and val loss both plateau early, mAP flat
+
+Underfitting or the LR is too low. Confirm the LR actually applied (`optimizer=auto` overrides
+it), then raise `lr0` roughly 3x, extend epochs, or reduce augmentation. Heavy `mixup` plus
+heavy `mosaic` on a small model genuinely prevents convergence.
+
+### Loss spikes to NaN or explodes
+
+Diverging.
+
+1. Check AMP first. `amp=False` isolates fp16 overflow, which is the usual cause on custom
+   architectures and unusual input statistics.
+2. Then LR: drop `lr0` 10x.
+3. Then warmup: raise `warmup_epochs` to 5, and confirm `warmup_bias_lr` is not the source.
+   `optimizer=auto` sets it to 0, an explicit optimizer leaves it at `0.1`.
+4. Check labels for out-of-range coordinates. Normalized values above 1.0 produce inf loss.
+
+Gradient clipping is not a knob. `trainer.py` calls `clip_grad_norm_` with a hardcoded
+`max_norm=10.0` and exposes no argument, so a run that still explodes needs the LR or the data
+fixed, not a tighter clip.
+
+### mAP jumps sharply in the last N epochs
+
+That is `close_mosaic` disabling mosaic, not convergence. Expected. If the jump is large, the
+model was fighting mosaic the whole run, and a longer clean tail (`close_mosaic=20` or `30`)
+or `mosaic=0.5` will do better.
+
+### Val metrics oscillate hard between epochs
+
+Small val split, or LR too high late in the schedule. Set `cos_lr=True` and `lrf=0.01` so the
+LR actually decays to near zero, and check the val split has at least a few hundred instances
+per class. Below that, epoch-to-epoch swings are sampling noise and reading them is a mistake.
+
+## Schedule patterns
+
+| Best epoch lands at          | Meaning                          | Action                             |
+| ---------------------------- | -------------------------------- | ---------------------------------- |
+| final epoch                  | undertrained                     | more epochs, 1.5x to 2x            |
+| 80 to 95 percent through     | about right                      | leave it                           |
+| 40 to 60 percent, then decay | overtrained                      | more augmentation, or stop earlier |
+| under 25 percent             | LR too high, or the data is tiny | lower `lr0`, add regularization    |
+
+`patience=100` against `epochs=100` means early stopping never fires. Set `patience` to roughly
+a quarter of `epochs` when you want it to be real.
+
+## Learning rate
+
+`lr0` is the initial LR, `lrf` is a fraction, so the final LR is `lr0 * lrf`. Default `lrf=0.01`
+decays to 1 percent.
+
+| Situation                                    | lr0          |
+| -------------------------------------------- | ------------ |
+| AdamW fine-tune from a pretrained checkpoint | 0.001        |
+| AdamW, small dataset under about 1000 images | 0.0005       |
+| SGD from scratch                             | 0.01         |
+| Diverging                                    | current / 10 |
+| Flat loss, confirmed the value applied       | current \* 3 |
+
+`cos_lr=True` beats the linear default on most fine-tunes. `warmup_epochs=3` is right for
+most runs, raise to 5 for large batches or an unstable start, and drop toward 1 on runs under
+30 epochs where 3 epochs of warmup is 10 percent of the budget.
+
+There is no per-group LR argument. To protect a pretrained backbone from a randomly initialized
+head, `freeze` it for the first run, or lower `lr0` for the whole model. A discriminative LR
+needs a callback that rewrites `optimizer.param_groups`.
+
+## Batch size
+
+Set it to fill the GPU, not to tune accuracy. `nbs=64` normalization means small batches get
+gradient accumulation, so batch mostly buys throughput.
+
+- `batch=-1` or a float like `batch=0.8` uses AutoBatch to fill a memory fraction.
+- Above 64, the effective LR does rise, so scale `lr0` roughly linearly.
+- Very small batches (under 8) make BatchNorm statistics noisy, which is a real accuracy cost
+  and the one case where batch size is not just a throughput decision.
+
+## Small objects
+
+Confirm the problem is real before spending anything on it. Nothing in the package reports box
+sizes, so measure them yourself: read the label files, multiply the normalized width and height
+by your training `imgsz`, and look at the distribution. Under roughly 32 pixels is the small
+regime, under 16 is the hard regime. If most boxes are above that, the ceiling is elsewhere.
+
+Free first:
+
+1. `multi_scale=0.5` trains across a scale range and helps generalization across sizes.
+2. `scale=0.9` widens the augmentation scale range.
+3. A P2 head variant if objects sit below the P3 stride of 8 pixels.
+
+Then the expensive ones:
+
+4. Tile large images into overlapping crops for training and inference. More images per epoch,
+   but each stays at the resolution the pretrained weights expect, which is usually the better
+   trade for 4K imagery with 20-pixel objects.
+5. Raise `imgsz`. It works, and it is last because the cost is quadratic: 640 to 1280 is about
+   4x the compute and memory per epoch, and it moves the model away from the input size its
+   pretrained weights were fit at. Budget for a longer schedule rather than swapping `imgsz`
+   into an otherwise unchanged recipe.
+
+## Class imbalance
+
+1. `cls_pw` in `0.3` to `0.5`, see Precision high, recall low for what the power does.
+2. `copy_paste` to synthesize rare-class instances, needs masks.
+3. Oversample rare-class images by duplicating their paths in the train list. Crude, effective.
+4. Merge classes that annotators confuse anyway.
+
+Report per-class AP, never only the macro mAP. A macro number hides a class at 0.05.
+
+## Transfer learning
+
+- `pretrained=True` uses the shipped COCO weights. Always start there, from-scratch training on
+  a custom dataset is almost never right.
+- `cls_remap=True` (default) matches pretrained classification-head rows by class name, so
+  shared names like `person` keep their learned weights across datasets.
+- `freeze=10` freezes the backbone. Useful for a tiny dataset (under about 500 images) or a
+  first sanity run. Unfreeze for the real run, a frozen backbone gives up several points once
+  the dataset is large enough to move it.
+- Domain distance decides how much you fine-tune. Medical, thermal, and satellite imagery share
+  little with COCO, so they need more epochs and a higher `lr0` than a natural-image dataset.
+
+## Automated tuning
+
+```python
+model.tune(data="my-data.yaml", epochs=30, iterations=300, optimizer="AdamW", plots=False, save=False)
+```
+
+Worth running only after the manual passes above are exhausted, and only on a dataset large
+enough that a 0.5 mAP difference is signal. It costs `iterations` full trainings. Use a reduced
+`epochs` per iteration, then retrain the winner at full length.
+
+## Reporting a change honestly
+
+- State the delta and the baseline: "mAP50-95 0.412 to 0.437, +2.5 points, one seed".
+- Name what else changed. A recipe with three simultaneous edits attributes nothing.
+- Compare at the same epoch count and the same `imgsz`. Different budgets are different
+  experiments.

--- a/plugins/ultralytics-dev/skills/yolo-training/references/task-notes.md
+++ b/plugins/ultralytics-dev/skills/yolo-training/references/task-notes.md
@@ -1,0 +1,98 @@
+# Per-task notes
+
+What differs by task. Everything in `diagnostics.md` still applies on top of this.
+
+## Detection
+
+Loss gains: `box=7.5`, `cls=0.5`, `dfl=1.5`. Fitness is mAP50-95 alone.
+
+- YOLO26 ships `end2end` NMS-free heads. `iou` and `agnostic_nms` do nothing on those models,
+  and duplicate-box complaints need a different explanation.
+- `single_cls=True` collapses every class into one. The fastest way to answer "is this a
+  localization problem or a classification problem", run it and compare mAP50-95. A large jump
+  means the boxes were never the issue.
+- `rect=True` batches by aspect ratio instead of padding to square. Faster and slightly better
+  on consistently non-square imagery, incompatible with shuffling so it interacts with mosaic.
+
+## Instance segmentation
+
+Adds `overlap_mask=True` and `mask_ratio=4`. Fitness sums the mask and box components, so both
+heads gate early stopping.
+
+- `mask_ratio=4` downsamples masks 4x during training. Drop to `1` or `2` when objects are thin
+  or small, since a 20-pixel object becomes 5 pixels of mask at the default and loses its shape.
+  It costs memory.
+- `overlap_mask=True` merges instances into one mask per image. Set `False` when instances
+  overlap heavily and you need them separated during training.
+- `copy_paste` is far more effective here than in detection because real masks make the pasted
+  instances look right. `copy_paste=0.3` with `copy_paste_mode=flip` is a reasonable start.
+- Mask AP trailing box AP by a lot means polygon quality. Coarse polygons (4 to 6 points around
+  a curved object) cap mask AP no matter what you train.
+- `retina_masks=True` at inference only, higher-resolution masks at some cost.
+
+## Semantic segmentation
+
+Fitness is mIoU. Loss is cross-entropy with `ignore_index=255`, so 255 is the void label.
+
+- `cls_pw` applies ENet inverse-log weighting, `(1 / ln(1.02 + p)) ** cls_pw`, not the
+  inverse-frequency form detection uses. It is the main lever for classes that occupy few
+  pixels, which in semantic segmentation is most of the interesting ones.
+- mIoU is a mean over classes, so one collapsed class costs a full share regardless of its
+  pixel count. Always print per-class IoU.
+- Binary (`nc=1`) uses BCE and ignores class weighting by design.
+- Resolution binds harder than in detection, since thin structures below a few pixels wide
+  cannot survive the encoder stride. Same quadratic cost as everywhere else, so confirm the
+  structures are actually that thin before paying it.
+
+## Pose
+
+Loss gains: `pose=12.0`, `kobj=1.0`, `rle=1.0`. Fitness sums pose and box.
+
+- **`flip_idx` in `data.yaml` is required for any flip augmentation.** Without it the trainer
+  sets both `fliplr` and `flipud` to 0 and logs a warning, so pose runs quietly lose their
+  cheapest augmentation. `flip_idx` is the permutation that swaps left and right keypoints, and
+  a wrong one is worse than none because it trains mirrored labels.
+- `kpt_shape: [N, 3]` means x, y, visibility. `[N, 2]` means no visibility flag, and then
+  occluded keypoints cannot be marked, which distorts the loss.
+- Keypoint accuracy far behind box accuracy often means resolution, since keypoints need more
+  pixels on target than boxes do. Try `scale` and a longer schedule first, raising `imgsz` is
+  the expensive answer.
+- Raise `pose` above 12.0 only after confirming boxes are already good, the two compete.
+
+## Oriented bounding boxes
+
+Adds `angle=1.0`.
+
+- `degrees` is the augmentation that matters, and unlike axis-aligned detection it is safe.
+  Aerial and document imagery have no canonical up, so `degrees=180` is reasonable.
+- `flipud=0.5` is equally valid for aerial imagery and off by default.
+- Angle-periodicity errors show as a class of predictions rotated 90 or 180 degrees from the
+  target. Check the label convention before raising `angle`, a systematic offset is a data bug.
+- Objects with near-square aspect ratio have poorly defined angles and will always score worse.
+  Exclude them from the analysis rather than tuning against them.
+
+## Classification
+
+Fitness is `(top1 + top5) / 2`. Different augmentation set from the detection tasks.
+
+- `auto_augment` accepts `randaugment` (default), `autoaugment`, `augmix`. `randaugment` is the
+  right default. Set it empty for small fine-grained datasets where the transforms destroy the
+  distinguishing detail.
+- `erasing=0.4` is random erasing, the classification analogue of cutout, and it is the main
+  overfitting lever alongside `mixup` and `cutmix`.
+- `dropout` applies to the classification head only, and is 0 by default. `0.1` to `0.2` for a
+  small dataset.
+- Mosaic, mixup ratios, and the box augmentations do not apply.
+- Top-1 far below top-5 means confusable classes, not general weakness. Read the confusion
+  matrix and consider merging.
+- Class imbalance shows in top-1 immediately. Balance the sampler or the dataset, `cls_pw` is
+  not wired into the classification loss.
+
+## Depth
+
+Loss gains: `dlog=1.0` (SILog), `dgrad=0.5` (gradient), `dlam=1.0`. Fitness is `delta1`.
+
+- `dlam=1.0` is fully scale-invariant, `0.0` is plain log-RMSE. Lower it when absolute depth
+  matters rather than relative structure.
+- `dgrad` sharpens depth discontinuities at object boundaries. Raise it when edges look smeared.
+- Reported metrics are `delta1`, `abs_rel`, `rmse`, `silog`. Only `delta1` is higher-is-better.


### PR DESCRIPTION
`ultralytics-dev` shipped formatting hooks and nothing else. Two skills give it what the docs do not, how to read a training run and how to talk to Platform.

`yolo-training` maps a symptom to the knob, ordered by what a run costs:

```
1. Epochs and schedule      4. Model size
2. Augmentation             5. Resolution    4x the budget at 1280
3. Loss weights and LR      6. Data          no analysis tooling ships
```

| | |
| --- | --- |
| Args, defaults, and metric keys verified on `origin/main` | 48 |
| Fork-only args caught and cut | 2 |
| Silent overrides documented | 6 |

- mAP50 high and mAP50-95 low, raise `box` and `dfl` before blaming labels
- `optimizer=auto` ignores `lr0`, so setting it changes nothing
- `ultralytics-platform` covers retro-upload, datasets, search, cloud training