### PR TITLE
Correct six wrong facts in the YOLO and platform skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -377,7 +377,7 @@
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -174,7 +174,7 @@
       "name": "ultralytics-dev",
       "source": "./plugins/ultralytics-dev",
       "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "Apache-2.0"
     },
     {

--- a/plugins/ultralytics-dev/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/ultralytics-dev/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/ultralytics-dev/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/ultralytics-dev/gemini-extension.json
+++ b/plugins/ultralytics-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "ultralytics-dev",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Ultralytics Platform API and YOLO26 training skills, format hooks, push guard."
 }

--- a/plugins/ultralytics-dev/skills/ultralytics-platform/SKILL.md
+++ b/plugins/ultralytics-dev/skills/ultralytics-platform/SKILL.md
@@ -52,7 +52,7 @@ Resolve to signed URLs inside `data=` and `model=`, no manual download:
 YOLO("ul://username/my-project/my-model").train(data="ul://username/datasets/my-dataset", epochs=100)
 ```
 
-## REST flows
+## REST
 
 Read `references/recipes.md` before writing a request. It carries working code for retro upload
 of a finished run, dataset upload and download, search, cloud training, export, deployment, and

--- a/plugins/ultralytics-dev/skills/ultralytics-platform/references/recipes.md
+++ b/plugins/ultralytics-dev/skills/ultralytics-platform/references/recipes.md
@@ -2,9 +2,9 @@
 
 Working code for each flow. All snippets assume `ULTRALYTICS_API_KEY` is exported.
 
-Recipes 1, 5, and 8 were run end to end against the live API on 2026-08-04. The rest are
-derived from `/openapi.json` and have not been executed, since recipes 3, 6, and 7 create
-billable resources. Treat their request shapes as correct and their responses as unconfirmed.
+Recipes 1, 5, and 8 were run end to end against the live API on 2026-08-04. The rest come from
+`/openapi.json` and were not executed, since 3, 6, and 7 create billable resources. Their
+request shapes are correct, their responses unconfirmed.
 
 ## Shared client
 
@@ -142,11 +142,15 @@ yolo train model=yolo26n.pt data=my-data.yaml epochs=100 project=my-project name
 It prints `Platform: Streaming training metrics to Platform` at startup and a model URL at the
 end. Enablement gate, all must hold:
 
-1. Not running under pytest.
-2. `SETTINGS["platform"] is True` or `ULTRALYTICS_API_KEY` set or `SETTINGS["api_key"]` set.
-3. A resolved API key.
-4. `trainer.args.project` is truthy, checked separately in every callback.
-5. `RANK` in `{-1, 0}`, so under DDP only rank 0 reports.
+1. `RANK` in `{-1, 0}` and not the DDP launcher process, so under DDP only rank 0 reports.
+2. Not running under pytest.
+3. `trainer.args.project` is truthy, checked again in every callback.
+4. A key from `ULTRALYTICS_API_KEY` or `settings.json`. There is no separate on/off setting, the
+   key and `project=` are the whole switch.
+
+All traffic goes to one endpoint, `POST /api/webhooks/training/metrics`. A `401` from it clears
+the cached key and silently disables tracking for the rest of the process, while `403` and `404`
+only warn, so a mid-run stop with no error usually means the key was rejected once.
 
 Diagnosing silence:
 
@@ -216,9 +220,9 @@ Fastest path, let the package do it:
 YOLO("yolo26n.pt").train(data="ul://username/datasets/my-dataset", epochs=100)
 ```
 
-`resolve_platform_uri` in `ultralytics/utils/callbacks/platform.py` turns the URI into a signed
-URL, `check_file` in `ultralytics/utils/checks.py` downloads it, and
-`convert_ndjson_to_yolo_if_needed` in `ultralytics/data/utils.py` converts the NDJSON on the fly.
+`resolve_platform_uri` and `check_file`, both in `ultralytics/utils/checks.py`, turn the URI into
+a signed URL and download it, then `convert_ndjson_to_yolo_if_needed` in
+`ultralytics/data/utils.py` converts the NDJSON on the fly.
 
 To materialize it on disk:
 

--- a/plugins/ultralytics-dev/skills/ultralytics-platform/references/recipes.md
+++ b/plugins/ultralytics-dev/skills/ultralytics-platform/references/recipes.md
@@ -148,9 +148,9 @@ end. Enablement gate, all must hold:
 4. A key from `ULTRALYTICS_API_KEY` or `settings.json`. There is no separate on/off setting, the
    key and `project=` are the whole switch.
 
-All traffic goes to one endpoint, `POST /api/webhooks/training/metrics`. A `401` from it clears
-the cached key and silently disables tracking for the rest of the process, while `403` and `404`
-only warn, so a mid-run stop with no error usually means the key was rejected once.
+All traffic goes to one endpoint, `POST /api/webhooks/training/metrics`. A `401` clears the
+cached key and stops tracking for the rest of the process, while `403` and `404` fail only the
+one request. Every one of them logs a warning.
 
 Diagnosing silence:
 
@@ -160,6 +160,7 @@ Diagnosing silence:
 | `Training will not be tracked on Platform` | key present, server rejected `training_started`            |
 | Run appears, no weights                    | `best.pt` upload failed, warning is in the console log     |
 | Name is `train-2` not `train`              | server auto-incremented a taken slug, it logs the real one |
+| Streams for a while, then stops            | a `401` cleared the key, the warning is in the console log |
 
 Checkpoints upload at most every 15 minutes mid-run, then `best.pt` uploads blocking at the end.
 Project and name are slugified, so `My Run 1` becomes `my-run-1`.

--- a/plugins/ultralytics-dev/skills/yolo-training/SKILL.md
+++ b/plugins/ultralytics-dev/skills/yolo-training/SKILL.md
@@ -5,29 +5,26 @@ description: This skill should be used when user asks to "improve my mAP", "why 
 
 # YOLO26 training
 
-Read the run before changing anything. Most requests for "better accuracy" arrive with a
-`results.csv` and confusion matrix that already name the problem.
+Read the run before changing anything. The `results.csv` and confusion matrix usually name the
+problem already.
 
 ## Order of operations
 
-Ordered by cost to try, cheapest first, not by size of the potential win. The last two are the
-ones people reach for first and they are the two that spend real budget.
+Ordered by cost to try, cheapest first, not by size of the potential win.
 
 1. **Epochs and schedule.** Undertrained looks like every other problem, and it costs nothing
    but time to rule out.
-2. **Augmentation.** The lever for the generalization gap, at no extra compute per epoch.
+2. **Augmentation.** The knob for the generalization gap, at no extra compute per epoch.
 3. **Loss weights and LR.** Cheap, and the curves usually say which one is wrong.
 4. **Model size.** Scale up when train loss is still falling at the end of the schedule and the
-   train and val curves sit close together. That is the signature of underfitting, and the only
-   one a bigger model reliably fixes.
+   train and val curves sit close together. That is underfitting, and it is the only case a
+   bigger model reliably fixes.
 5. **Resolution.** Compute scales with the square of `imgsz`, so 640 to 1280 is roughly 4x the
-   training budget. Pretrained weights also transfer worse the further you move from the size
-   they were trained at, so a large jump is a new training budget, not a free knob. Justify it
-   with the object sizes in your data, not as a default first move.
-6. **Data**, label quality and class balance. The highest ceiling and the slowest to move, and
-   the package ships no dataset-analysis tooling, so any audit here is your own script plus
-   looking at images. Worth it once the cheap knobs are spent and the curves say the model is
-   not the limit.
+   training budget, and pretrained weights transfer worse the further you move from the size
+   they were fit at. Justify it with the object sizes in your data, not as a default first move.
+6. **Data**, label quality and class balance. The highest ceiling and the slowest to move. The
+   package ships no dataset-analysis tooling, so any audit here is your own script plus looking
+   at images. Worth it once the cheap knobs are spent.
 
 ## Diagnostic loop
 
@@ -56,13 +53,14 @@ out before turning that knob. Read it before recommending a change.
 `references/task-notes.md` covers detect, segment, semantic, pose, obb, classify, and depth
 specifics.
 
-## Things that silently override your settings
+## Defaults that will surprise you
 
-These produce "I changed X and nothing happened", and each one is real in current defaults.
+These produce "I changed X and nothing happened". All six are current defaults.
 
-1. **`optimizer=auto` ignores `lr0` and `momentum`.** It is the default. It picks
-   `MuSGD` at lr 0.01 when total iterations exceed 10000, otherwise `AdamW` at
-   `0.002 * 5 / (4 + nc)`, and forces `warmup_bias_lr=0`. Setting `lr0` while leaving
+1. **`optimizer=auto` ignores `lr0` and `momentum`.** It is the default. It picks `MuSGD` at
+   lr 0.01 when `ceil(len(dataset) / max(batch, nbs)) * epochs` exceeds 10000, otherwise `AdamW`
+   at `0.002 * 5 / (4 + nc)`, and forces `warmup_bias_lr=0`. Crossing that iteration count
+   silently changes optimizer between two runs you meant to compare. Setting `lr0` while leaving
    `optimizer=auto` does nothing. Set `optimizer=AdamW` or `optimizer=SGD` explicitly first.
 2. **`nbs=64` normalizes the loss, so batch does not scale LR the way you assume.** Below 64 the
    trainer accumulates gradients to an effective 64. Dropping batch 64 to 16 changes almost
@@ -76,8 +74,8 @@ These produce "I changed X and nothing happened", and each one is real in curren
    mAP50-95 is flat will still early-stop.
 5. **`max_det=300`** truncates validation on dense scenes. Above roughly 300 objects per image
    your recall ceiling is an artifact.
-6. **YOLO26 `end2end` models do their own NMS-free decoding**, so `iou` and `agnostic_nms`
-   have no effect on them.
+6. **YOLO26 `end2end` models decode without NMS**, so `iou` does nothing on them. `agnostic_nms`
+   still applies, the predictor passes it into the head, so only the IoU threshold is dead.
 
 ## Starting recipe
 
@@ -89,11 +87,10 @@ yolo train model=yolo26s.pt data=my-data.yaml epochs=200 imgsz=640 batch=16 \
   patience=50 close_mosaic=20
 ```
 
-Deviate on evidence from the charts, one axis at a time. Reasons this differs from the shipped
-defaults: `epochs=100` is short for a small dataset, `patience=100` never fires inside 100
-epochs so it is not real early stopping, and `close_mosaic=10` is too short a clean tail once
-epochs rise.
+Deviate on evidence from the charts, one axis at a time. It differs from the shipped defaults
+because `epochs=100` is short for a small dataset, `patience=100` never fires inside 100 epochs,
+and `close_mosaic=10` is too short a clean tail once epochs rise.
 
 Change one thing per run and keep `seed` fixed. Run-to-run noise on a small dataset is often
 0.5 to 1.0 mAP, so a 0.3 mAP "improvement" from a single run is not a result. Confirm anything
-smaller than about 1 point across two or three seeds before believing it.
+under about 1 point across three seeds.

--- a/plugins/ultralytics-dev/skills/yolo-training/references/diagnostics.md
+++ b/plugins/ultralytics-dev/skills/yolo-training/references/diagnostics.md
@@ -1,8 +1,19 @@
 # Reading a run
 
-Symptom, the cheap knob, and what to check when the knob does not move it. Reach for the free
-changes first and treat anything that costs compute or relabeling as the answer you fall back
-to, not the one you open with.
+Symptom, the cheap knob, and what to check when the knob does not move it. Compute and
+relabeling are the fallback, not the opener.
+
+## Schedule patterns
+
+| Best epoch lands at          | Meaning                          | Action                             |
+| ---------------------------- | -------------------------------- | ---------------------------------- |
+| final epoch                  | undertrained                     | more epochs, 1.5x to 2x            |
+| 80 to 95 percent through     | about right                      | leave it                           |
+| 40 to 60 percent, then decay | overtrained                      | more augmentation, or stop earlier |
+| under 25 percent             | LR too high, or the data is tiny | lower `lr0`, add regularization    |
+
+`patience=100` against `epochs=100` means early stopping never fires. Set `patience` to roughly
+a quarter of `epochs` when you want it to be real.
 
 ## Metric-shape patterns
 
@@ -10,16 +21,17 @@ to, not the one you open with.
 
 Classification and coarse localization work. Tight localization does not.
 
-Start with the loss weights. This is the cheap test and it is the one targeted at the symptom:
+Start with the loss weights. Cheap, and aimed at the symptom:
 
 ```bash
 box=10.0 dfl=2.0 # from 7.5 / 1.5
 ```
 
-Raise `box` and `dfl` together, roughly 1.3x to 2x. `dfl` governs the distribution focal loss
-that produces sub-pixel box edges, so it is the more targeted of the two for this symptom.
-Watch that `cls` does not get crowded out, a collapsing `metrics/precision(B)` means you went
-too far.
+Raise `box` and `dfl` together, roughly 1.3x to 2x. YOLO26 sets `reg_max: 1`, which switches the
+distribution focal loss off, so `dfl` weights a plain L1 term on the box edges and the
+results.csv column is `train/l1_loss`, not `train/dfl_loss`. The knob still works, and it is
+still the more targeted of the two. Watch that `cls` does not get crowded out, a collapsing
+`metrics/precision(B)` means you went too far.
 
 If that moves nothing, the ceiling is probably not the loss:
 
@@ -31,11 +43,6 @@ If that moves nothing, the ceiling is probably not the loss:
 3. **Objects too small for the resolution.** An object spanning 12 pixels cannot be localized
    to mAP50-95 precision at any loss weight. Read the Small objects section for what raising
    `imgsz` costs before reaching for it.
-
-### mAP50-95 close to mAP50
-
-Unusual, and normally means objects are large and easy. Little headroom on localization.
-Look at recall and per-class AP instead.
 
 ### Precision high, recall low
 
@@ -94,6 +101,11 @@ then look at 20 of its images. A class with 40 instances against classes with 40
 underperform regardless of the recipe. Options, in order: collect more, merge it into a
 neighbor class, or apply `cls_pw`.
 
+### mAP50-95 close to mAP50
+
+Unusual, and normally means objects are large and easy. Little headroom on localization.
+Look at recall and per-class AP instead.
+
 ## Loss-curve patterns
 
 ### Train loss falls, val loss rises
@@ -108,8 +120,9 @@ mixup=0.15 copy_paste=0.3 scale=0.9 degrees=10 mosaic=1.0 close_mosaic=20
 
 - `mixup` blends two images and their labels. The general-purpose regularizer, and the first
   thing to reach for. `0.1` to `0.2` on small datasets.
-- `copy_paste` pastes instances between images. Needs segmentation masks to work well, and it
-  is the strongest single lever for rare-class recall when they exist.
+- `copy_paste` pastes instances between images. It returns the labels untouched when they carry
+  no segments, so on a box-only detect dataset it is a silent no-op, not a weak effect. Where
+  masks exist it is the strongest single knob for rare-class recall.
 - `scale` is the most underrated. `0.5` means 0.5x to 1.5x. Raising to `0.9` widens the
   scale range the model must handle, and it costs nothing at inference.
 - `erasing` (classify) and `cutmix` are alternatives when mixup is already maxed.
@@ -155,18 +168,6 @@ Small val split, or LR too high late in the schedule. Set `cos_lr=True` and `lrf
 LR actually decays to near zero, and check the val split has at least a few hundred instances
 per class. Below that, epoch-to-epoch swings are sampling noise and reading them is a mistake.
 
-## Schedule patterns
-
-| Best epoch lands at          | Meaning                          | Action                             |
-| ---------------------------- | -------------------------------- | ---------------------------------- |
-| final epoch                  | undertrained                     | more epochs, 1.5x to 2x            |
-| 80 to 95 percent through     | about right                      | leave it                           |
-| 40 to 60 percent, then decay | overtrained                      | more augmentation, or stop earlier |
-| under 25 percent             | LR too high, or the data is tiny | lower `lr0`, add regularization    |
-
-`patience=100` against `epochs=100` means early stopping never fires. Set `patience` to roughly
-a quarter of `epochs` when you want it to be real.
-
 ## Learning rate
 
 `lr0` is the initial LR, `lrf` is a fraction, so the final LR is `lr0 * lrf`. Default `lrf=0.01`
@@ -180,9 +181,11 @@ decays to 1 percent.
 | Diverging                                    | current / 10 |
 | Flat loss, confirmed the value applied       | current \* 3 |
 
-`cos_lr=True` beats the linear default on most fine-tunes. `warmup_epochs=3` is right for
-most runs, raise to 5 for large batches or an unstable start, and drop toward 1 on runs under
-30 epochs where 3 epochs of warmup is 10 percent of the budget.
+The default schedule is linear, `(1 - x/epochs) * (1 - lrf) + lrf`. `cos_lr=True` swaps in a
+one-cycle cosine and beats it on most fine-tunes. `warmup_epochs=3` is right for most runs,
+raise to 5 for large batches or an unstable start, and drop toward 1 on runs under 30 epochs
+where 3 epochs of warmup is 10 percent of the budget. It is clamped to `epochs - 1`, so a
+10-epoch smoke test with the default spends 3 of its 10 epochs warming up.
 
 There is no per-group LR argument. To protect a pretrained backbone from a randomly initialized
 head, `freeze` it for the first run, or lower `lr0` for the whole model. A discriminative LR
@@ -193,10 +196,13 @@ needs a callback that rewrites `optimizer.param_groups`.
 Set it to fill the GPU, not to tune accuracy. `nbs=64` normalization means small batches get
 gradient accumulation, so batch mostly buys throughput.
 
-- `batch=-1` or a float like `batch=0.8` uses AutoBatch to fill a memory fraction.
+- `batch=-1` or a float like `batch=0.8` uses AutoBatch to fill a memory fraction, `-1` targeting
+  60 percent.
 - Above 64, the effective LR does rise, so scale `lr0` roughly linearly.
-- Very small batches (under 8) make BatchNorm statistics noisy, which is a real accuracy cost
-  and the one case where batch size is not just a throughput decision.
+- Weight decay is rescaled the same way, `weight_decay * batch * accumulate / nbs`. At
+  `batch=128` your `0.0005` is really `0.001`, which is a common unexplained regularization
+  change when someone moves a recipe to a bigger GPU.
+- Very small batches (under 8) make BatchNorm statistics noisy, a real accuracy cost.
 
 ## Small objects
 
@@ -216,15 +222,13 @@ Then the expensive ones:
 4. Tile large images into overlapping crops for training and inference. More images per epoch,
    but each stays at the resolution the pretrained weights expect, which is usually the better
    trade for 4K imagery with 20-pixel objects.
-5. Raise `imgsz`. It works, and it is last because the cost is quadratic: 640 to 1280 is about
-   4x the compute and memory per epoch, and it moves the model away from the input size its
-   pretrained weights were fit at. Budget for a longer schedule rather than swapping `imgsz`
-   into an otherwise unchanged recipe.
+5. Raise `imgsz`. It works, and it is last because of the quadratic cost. Budget for a longer
+   schedule rather than swapping `imgsz` into an otherwise unchanged recipe.
 
 ## Class imbalance
 
 1. `cls_pw` in `0.3` to `0.5`, see Precision high, recall low for what the power does.
-2. `copy_paste` to synthesize rare-class instances, needs masks.
+2. `copy_paste` to synthesize rare-class instances, and only if the labels carry segments.
 3. Oversample rare-class images by duplicating their paths in the train list. Crude, effective.
 4. Merge classes that annotators confuse anyway.
 
@@ -236,7 +240,9 @@ Report per-class AP, never only the macro mAP. A macro number hides a class at 0
   a custom dataset is almost never right.
 - `cls_remap=True` (default) matches pretrained classification-head rows by class name, so
   shared names like `person` keep their learned weights across datasets.
-- `freeze=10` freezes the backbone. Useful for a tiny dataset (under about 500 images) or a
+- `freeze=N` freezes model indices `0` to `N-1`. On YOLO26 the backbone ends at C2PSA, index 10,
+  and the head starts at 11, so `freeze=11` is the whole backbone and the widely copied
+  `freeze=10` leaves C2PSA trainable. Useful for a tiny dataset (under about 500 images) or a
   first sanity run. Unfreeze for the real run, a frozen backbone gives up several points once
   the dataset is large enough to move it.
 - Domain distance decides how much you fine-tune. Medical, thermal, and satellite imagery share
@@ -252,9 +258,8 @@ Worth running only after the manual passes above are exhausted, and only on a da
 enough that a 0.5 mAP difference is signal. It costs `iterations` full trainings. Use a reduced
 `epochs` per iteration, then retrain the winner at full length.
 
-## Reporting a change honestly
+## Reporting a change
 
 - State the delta and the baseline: "mAP50-95 0.412 to 0.437, +2.5 points, one seed".
 - Name what else changed. A recipe with three simultaneous edits attributes nothing.
-- Compare at the same epoch count and the same `imgsz`. Different budgets are different
-  experiments.
+- Compare at the same epoch count and the same `imgsz`. Different budgets are not comparable.

--- a/plugins/ultralytics-dev/skills/yolo-training/references/task-notes.md
+++ b/plugins/ultralytics-dev/skills/yolo-training/references/task-notes.md
@@ -6,8 +6,10 @@ What differs by task. Everything in `diagnostics.md` still applies on top of thi
 
 Loss gains: `box=7.5`, `cls=0.5`, `dfl=1.5`. Fitness is mAP50-95 alone.
 
-- YOLO26 ships `end2end` NMS-free heads. `iou` and `agnostic_nms` do nothing on those models,
-  and duplicate-box complaints need a different explanation.
+- YOLO26 `end2end` heads train two branches at once, `0.8 * one2many + 0.2 * one2one`, and decay
+  the one2many weight to `0.1` across the schedule. Only the one2one losses reach `results.csv`,
+  so the logged box loss is not the whole objective and comparing it against a non-end2end run
+  compares different quantities.
 - `single_cls=True` collapses every class into one. The fastest way to answer "is this a
   localization problem or a classification problem", run it and compare mAP50-95. A large jump
   means the boxes were never the issue.
@@ -24,8 +26,9 @@ heads gate early stopping.
   It costs memory.
 - `overlap_mask=True` merges instances into one mask per image. Set `False` when instances
   overlap heavily and you need them separated during training.
-- `copy_paste` is far more effective here than in detection because real masks make the pasted
-  instances look right. `copy_paste=0.3` with `copy_paste_mode=flip` is a reasonable start.
+- `copy_paste` only does anything here. The augmentation returns early when the labels carry no
+  segments, so it is live on segment datasets and a no-op on box-only detect ones.
+  `copy_paste=0.3` with `copy_paste_mode=flip` is a reasonable start.
 - Mask AP trailing box AP by a lot means polygon quality. Coarse polygons (4 to 6 points around
   a curved object) cap mask AP no matter what you train.
 - `retina_masks=True` at inference only, higher-resolution masks at some cost.
@@ -35,14 +38,13 @@ heads gate early stopping.
 Fitness is mIoU. Loss is cross-entropy with `ignore_index=255`, so 255 is the void label.
 
 - `cls_pw` applies ENet inverse-log weighting, `(1 / ln(1.02 + p)) ** cls_pw`, not the
-  inverse-frequency form detection uses. It is the main lever for classes that occupy few
+  inverse-frequency form detection uses. It is the main knob for classes that occupy few
   pixels, which in semantic segmentation is most of the interesting ones.
 - mIoU is a mean over classes, so one collapsed class costs a full share regardless of its
   pixel count. Always print per-class IoU.
 - Binary (`nc=1`) uses BCE and ignores class weighting by design.
 - Resolution binds harder than in detection, since thin structures below a few pixels wide
-  cannot survive the encoder stride. Same quadratic cost as everywhere else, so confirm the
-  structures are actually that thin before paying it.
+  cannot survive the encoder stride. Measure their width before paying the quadratic cost.
 
 ## Pose
 
@@ -70,6 +72,8 @@ Adds `angle=1.0`.
   target. Check the label convention before raising `angle`, a systematic offset is a data bug.
 - Objects with near-square aspect ratio have poorly defined angles and will always score worse.
   Exclude them from the analysis rather than tuning against them.
+- OBB validation runs at `conf=0.01`, the other tasks at `0.001`. OBB mAP is measured on a
+  smaller candidate pool, so it is not directly comparable to an axis-aligned number.
 
 ## Classification
 
@@ -78,8 +82,8 @@ Fitness is `(top1 + top5) / 2`. Different augmentation set from the detection ta
 - `auto_augment` accepts `randaugment` (default), `autoaugment`, `augmix`. `randaugment` is the
   right default. Set it empty for small fine-grained datasets where the transforms destroy the
   distinguishing detail.
-- `erasing=0.4` is random erasing, the classification analogue of cutout, and it is the main
-  overfitting lever alongside `mixup` and `cutmix`.
+- `erasing=0.4` is random erasing, the classification analogue of cutout, and the main
+  overfitting knob alongside `mixup` and `cutmix`.
 - `dropout` applies to the classification head only, and is 0 by default. `0.1` to `0.2` for a
   small dataset.
 - Mosaic, mixup ratios, and the box augmentations do not apply.


### PR DESCRIPTION
The skills shipped with six claims that a check against ultralytics main showed are wrong, so the advice they drive is wrong too.

- `reg_max: 1` turns DFL off, the csv column is `train/l1_loss`
- `agnostic_nms` works on end2end, only `iou` is dead
- `freeze=10` leaves C2PSA trainable, `freeze=11` is the backbone

| Claim                         | Was                     | Is                             |
| ----------------------------- | ----------------------- | ------------------------------ |
| `dfl` on YOLO26               | distribution focal      | L1, `reg_max: 1`               |
| `agnostic_nms` on end2end     | no effect               | applies                        |
| backbone freeze               | `freeze=10`             | `freeze=11`                    |
| `copy_paste` without segments | less effective          | silent no-op                   |
| platform enablement           | `SETTINGS["platform"]`  | key plus `project=`, no toggle |
| `resolve_platform_uri`        | `callbacks/platform.py` | `utils/checks.py`              |

Also traded about 150 words of filler for the optimizer-selection formula, the `weight_decay * batch * accumulate / nbs` rescale, the `warmup_epochs` clamp, and the end2end two-branch loss. Every added fact was read back out of `origin/main` rather than recalled.