### PR TITLE
Ship the Ultralytics brand guide as a plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -305,6 +305,18 @@
       "category": "developer-tools"
     },
     {
+      "name": "ultralytics-branding",
+      "source": {
+        "source": "local",
+        "path": "./plugins/ultralytics-branding"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "design"
+    },
+    {
       "name": "azure-tools",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Claude Code plugins featuring skills, slash commands, autonomous subagents, hooks, and MCP server integrations for Git workflow, code review, and plugin development.",
-    "version": "2.5.0"
+    "version": "2.6.0"
   },
   "plugins": [
     {
@@ -387,6 +387,21 @@
       "keywords": ["ultralytics", "yolo", "platform", "training", "computer-vision", "formatting", "hooks"],
       "category": "developer-tools",
       "tags": ["formatting", "development"]
+    },
+    {
+      "name": "ultralytics-branding",
+      "source": "./plugins/ultralytics-branding",
+      "description": "Ultralytics brand colors, fonts, logo, naming, and tone for branded content.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fatih C. Akyon"
+      },
+      "homepage": "https://github.com/fcakyon/claude-codex-settings#plugins",
+      "repository": "https://github.com/fcakyon/claude-codex-settings",
+      "license": "Apache-2.0",
+      "keywords": ["ultralytics", "branding", "design", "presentation", "marketing", "social-media"],
+      "category": "design",
+      "tags": ["branding", "design", "marketing"]
     },
     {
       "name": "azure-tools",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -178,6 +178,13 @@
       "license": "Apache-2.0"
     },
     {
+      "name": "ultralytics-branding",
+      "source": "./plugins/ultralytics-branding",
+      "description": "Ultralytics brand colors, fonts, logo, naming, and tone for branded content.",
+      "version": "1.0.0",
+      "license": "Apache-2.0"
+    },
+    {
       "name": "azure-tools",
       "source": "./plugins/azure-tools",
       "description": "Azure MCP Server integration for 40+ Azure services with Azure CLI authentication.",

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -48,7 +48,7 @@ done
 
 # Local skill-only plugins have no vendor sync script, so zip their skills here for download assets
 source "$SCRIPTS_DIR/_helpers.sh"
-for skill_dir in plugins/{python-skills,adhd-output-style,ultralytics-dev}/skills/*/; do
+for skill_dir in plugins/{python-skills,adhd-output-style,ultralytics-dev,ultralytics-branding}/skills/*/; do
   create_zip "$skill_dir"
 done
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ cursor plugin install simplify@claude-settings
 Want the shared agent guidance too? [`.claude/CLAUDE.md`](https://github.com/fcakyon/claude-codex-settings/blob/main/.claude/CLAUDE.md) is the file written for your projects. Run `/claude-tools:sync-claude-md` to pull it into `~/.claude/CLAUDE.md`, or paste it into a project as `CLAUDE.md`, then point the other tools at the same file:
 
 ```bash
-ln -sfn CLAUDE.md AGENTS.md   # Codex CLI, Cursor, Copilot
-ln -sfn CLAUDE.md GEMINI.md   # Gemini CLI
+ln -sfn CLAUDE.md AGENTS.md # Codex CLI, Cursor, Copilot
+ln -sfn CLAUDE.md GEMINI.md # Gemini CLI
 ```
 
 ## Plugins
@@ -748,7 +748,7 @@ Ultralytics Platform API flows and YOLO26 training know-how, plus auto-formattin
 | Skill                                                                                    | Description                                                  | ZIP                                                                                                                                                                          |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`ultralytics-platform`](./plugins/ultralytics-dev/skills/ultralytics-platform/SKILL.md) | Platform API: model upload, datasets, search, cloud training | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/ultralytics-platform.zip) |
-| [`yolo-training`](./plugins/ultralytics-dev/skills/yolo-training/SKILL.md) | YOLO26 training diagnosis: read the curves, pick the knob    | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/yolo-training.zip) |
+| [`yolo-training`](./plugins/ultralytics-dev/skills/yolo-training/SKILL.md)               | YOLO26 training diagnosis: read the curves, pick the knob    | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/yolo-training.zip)        |
 
 **Hooks:**
 
@@ -760,6 +760,23 @@ Ultralytics Platform API flows and YOLO26 training know-how, plus auto-formattin
 - [`block_force_push.py`](./plugins/ultralytics-dev/hooks/scripts/block_force_push.py) - Block force-push and rebase
 
 Install `ruff` and `prettier` first ([setup](INSTALL.md#code-quality-tools)).
+
+</details>
+
+<details>
+<summary><strong>ultralytics-branding</strong> - Ultralytics brand colors, fonts, logo, naming, and tone for branded content.</summary>
+
+| Claude Code                                                  | Codex CLI                                               | Gemini CLI                                                        |
+| ------------------------------------------------------------ | ------------------------------------------------------- | ----------------------------------------------------------------- |
+| `claude plugin install ultralytics-branding@claude-settings` | `codex plugin add ultralytics-branding@claude-settings` | `gemini extensions install --path ./plugins/ultralytics-branding` |
+
+Official colors, Archivo typography, logo and naming rules, tone of voice, and per-format defaults from [ultralytics.com/brand](https://www.ultralytics.com/brand) for PDF/PPTX/Canva decks, DOCX documents, marketing email HTML, social posts, and web designs.
+
+**Skills** (ZIP for claude.ai, Claude Code, Cursor, Codex, VS Code):
+
+| Skill                                                                                         | Description                                              | ZIP                                                                                                                                                                          |
+| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`ultralytics-branding`](./plugins/ultralytics-branding/skills/ultralytics-branding/SKILL.md) | Brand colors, fonts, logo, naming, tone, format defaults | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/ultralytics-branding.zip) |
 
 </details>
 

--- a/plugins/ultralytics-branding/.claude-plugin/plugin.json
+++ b/plugins/ultralytics-branding/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "ultralytics-branding",
+  "version": "1.0.0",
+  "description": "Ultralytics brand guidelines (colors, Archivo font, naming, tone) for presentations, documents, marketing emails, social posts, and web designs.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/ultralytics-branding/.codex-plugin/plugin.json
+++ b/plugins/ultralytics-branding/.codex-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "ultralytics-branding",
+  "version": "1.0.0",
+  "description": "Ultralytics brand guidelines (colors, Archivo font, naming, tone) for presentations, documents, marketing emails, social posts, and web designs.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/ultralytics-branding/.cursor-plugin/plugin.json
+++ b/plugins/ultralytics-branding/.cursor-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "ultralytics-branding",
+  "version": "1.0.0",
+  "description": "Ultralytics brand guidelines (colors, Archivo font, naming, tone) for presentations, documents, marketing emails, social posts, and web designs.",
+  "author": {
+    "name": "Fatih C. Akyon"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/ultralytics-branding/gemini-extension.json
+++ b/plugins/ultralytics-branding/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "ultralytics-branding",
+  "version": "1.0.0",
+  "description": "Ultralytics brand guidelines (colors, Archivo font, naming, tone) for presentations, documents, marketing emails, social posts, and web designs."
+}

--- a/plugins/ultralytics-branding/skills/ultralytics-branding/SKILL.md
+++ b/plugins/ultralytics-branding/skills/ultralytics-branding/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: ultralytics-branding
+description: This skill should be used when creating Ultralytics-branded content of any kind, including PDF, PPTX, Canva, or Google Slides presentations, DOCX documents, marketing or newsletter HTML emails, social media post copy or visuals, website or landing page designs, and dataset or model result visuals. Provides official colors, typography, logo rules, naming rules, and tone of voice from ultralytics.com/brand.
+---
+
+# Ultralytics Branding
+
+Apply these rules to every Ultralytics-branded deliverable. Source of truth: https://www.ultralytics.com/brand
+
+## Colors
+
+Primary palette:
+
+| Name        | Hex       | Use                                                        |
+| ----------- | --------- | ---------------------------------------------------------- |
+| Dark Blue   | `#111F68` | Primary brand color, headings, dark logo, dark backgrounds |
+| Bright Blue | `#042AFF` | Accents, links, CTAs, highlights                           |
+| Neon Yellow | `#E1FF25` | High-energy accent, callouts on dark                       |
+| Neon Pink   | `#FF64DA` | Secondary accent, sparingly                                |
+| Light Grey  | `#F3F3F3` | Light backgrounds, cards                                   |
+| White       | `#FFFFFF` | Backgrounds, text on dark                                  |
+
+Secondary palette (supporting accents only, never dominant): Aqua Blue `#00FFFF`, Light Blue `#ACF9FF`, Neon Green `#76FFD6`, Grey `#CCCCCC`, Dark Grey `#9E9E9E`.
+
+Rules:
+
+- Default scheme: white or Light Grey background, Dark Blue text, Bright Blue accents. Dark scheme: Dark Blue background, white text, Neon Yellow or Aqua accents.
+- Neon colors are accents, not fills for large areas or body text.
+- Keep text and logos at a 3.5:1 contrast ratio minimum against their background.
+
+Bounding box palette (detection or annotation visuals, one color per class, labels in Arial): Bright Blue `#042AFF`, Vivid Sky Blue `#0BDBEB`, Bleached Silk `#F3F3F3`, Robin Egg Blue `#00DFB7`, Pure Midnight `#111F68`, Candy Pink `#FF6FDD`, Sunburnt Cyclops `#FF444F`, Electric Lime `#CCED00`, Malachite `#00F344`, Electric Purple `#BD00FF`, Blue Bolt `#00B4FF`, Deep Magenta `#DD00BA`, Aqua `#00FFFF`, Yellow-Green `#26C000`, Medium Spring Green `#01FFB3`, Blue-Violet `#7D24FF`, Philippine Violet `#7B0068`, Electric Pink `#FF1B6C`, Smashed Pumpkin `#FC6D2F`, Spring Bud `#A2FF0B`.
+
+## Typography
+
+- Official typeface: **Archivo** (Google Fonts, free). Fallback stack: `Archivo, Helvetica, Arial, sans-serif`. In PPTX/DOCX where Archivo is unavailable, use Arial.
+- Headings: Archivo Bold, tight scale from 72px hero down, 116% line-height.
+- Body: Archivo Regular at 24px (large), 18px (medium), 16px (regular), 14px (small).
+- Never use serif or decorative fonts. Bounding box labels use Arial.
+
+## Logo
+
+- Assets: logo pack at https://cdn.ul.run/f/4bf3c9729ff9eb1affc29e2dcab72bfc.zip, more on the brand page (Ultralytics, YOLO, YOLOv5, YOLOv8, YOLO11, YOLO26, YOLO Vision, Platform logotypes and logomarks).
+- Dark Blue logo on light backgrounds, white logo on dark backgrounds.
+- Keep clear space around the logo, never stretch, recolor, rotate, add effects, or redraw it.
+- Co-branding: Ultralytics logo first and largest, separate partner logos with a simple dividing line, official assets only.
+
+## Naming
+
+- First mention: "Ultralytics YOLO26", after that "YOLO26".
+- YOLO is always all caps, no space before the version: YOLO26, never YOLO 26 or Yolo26.
+- Lowercase "v" only in YOLOv5 and YOLOv8. Newer models drop the "v": YOLO11, YOLO26, never YOLOv26.
+- Never shorten, restyle, or alter product names.
+- Non-partners describe usage as "leveraged Ultralytics solutions", never "partnered with" or "collaborated with" without an actual agreement.
+
+## Tone of Voice
+
+Knowledgeable, approachable, confident, energetic. Brand claim: "Simpler. Smarter. Further."
+
+- Positive and straightforward, conversational except in technical content.
+- Lighthearted with personality, grounded, never boastful.
+- American English, inclusive language, no all caps, no excessive punctuation.
+
+## Social Media
+
+Post structure: intro sentence ending with one emoji, then body details, then CTA with a ➡️ arrow and shortened link.
+
+- One emoji after the intro sentence only, never mid-sentence or replacing words.
+- Concise copy, clear CTA, branded hashtags: #Ultralytics, #YOLO11, #YOLO26, #VisionAI.
+- No off-topic memes, no posting during breaking news.
+
+## Per-Format Defaults
+
+- **Slides (PPTX, Canva, PDF)**: title slides Dark Blue background with white Archivo Bold and a neon accent, content slides white with Dark Blue headings, Bright Blue for links and highlights, generous whitespace, logo small in a corner.
+- **Documents (DOCX, PDF)**: white background, Dark Blue headings, black or Dark Blue body, Bright Blue links, Archivo or Arial.
+- **Marketing email HTML**: table-based layout, web-safe fallback stack, Dark Blue header band with white logo, Bright Blue CTA button with white text, Light Grey section dividers, 600px max width.
+- **Web and social visuals**: pick one scheme (light or dark) per asset, one neon accent max, banner sizes 1920x960 for platform headers.


### PR DESCRIPTION
Every branded deck, doc, email, or post meant re-fetching ultralytics.com/brand and hoping the hexes came back right, so this bakes the guide into an `ultralytics-branding` skill.

`claude plugin install ultralytics-branding@claude-settings`

- full palette (6 primary + 5 secondary + 20 bounding-box colors), Archivo type scale, logo and contrast rules
- YOLO naming (YOLO26 never YOLOv26), tone of voice, social post structure, per-format defaults for slides/docs/email/web
- wired like humanize/python-skills: 4 tool manifests, 3 marketplaces (metadata 2.5.0 -> 2.6.0), release.sh zip list, README section

The README ZIP badge 404s until the next release is cut, since releases/latest still points at the pre-2.6.0 tag.