### PR TITLE
Make humanize findings accurate and actionable

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/test_humanize.py
+++ b/.github/scripts/test_humanize.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Test humanize extraction and source locations."""
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+HOOK = Path(__file__).parents[2] / "plugins/humanize/hooks/scripts/humanize.py"
+SEMICOLON = chr(59)
+
+
+def run_hook(tool, tool_input):
+    """Run humanize with one tool payload."""
+    return subprocess.run(
+        ["python3", HOOK],
+        input=json.dumps({"tool_name": tool, "tool_input": tool_input}),
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+
+
+class HumanizeTest(unittest.TestCase):
+    """Test that humanize checks writing without mistaking code for it."""
+
+    def test_masks_markdown_code(self):
+        """Mask closed, incomplete, and multi-backtick Markdown code."""
+        fence = "`" * 3
+        for content in (
+            f"Intro.\n{fence}js\nconst a = 1{SEMICOLON}\n{fence}\n",
+            f"Intro.\n{fence}js\nconst a = 1{SEMICOLON}\n",
+            f"Use ``leverage`this{SEMICOLON}`` in a sentence.\n",
+        ):
+            self.assertEqual(run_hook("Write", {"file_path": "README.md", "content": content}), "")
+
+    def test_ignores_ambiguous_text_files(self):
+        """Ignore generic text files that may contain logs or fixtures."""
+        self.assertEqual(
+            run_hook("Write", {"file_path": "fixture.txt", "content": f"GET /a 200{SEMICOLON} GET /b 404{SEMICOLON}"}),
+            "",
+        )
+
+    def test_comments_are_quote_aware(self):
+        """Ignore comment markers inside quoted values and strings."""
+        cases = (
+            ("config.yml", f'motd: "welcome # to prod{SEMICOLON} be careful"\n'),
+            ("app.ts", f'const note = "see {"/" * 2} ref{SEMICOLON} here"{SEMICOLON}\n'),
+        )
+        for path, content in cases:
+            self.assertEqual(run_hook("Write", {"file_path": path, "content": content}), "")
+
+    def test_checks_real_writing(self):
+        """Keep blocking marks in Markdown and code comments."""
+        cases = (
+            ("README.md", f"This sentence has a semicolon{SEMICOLON} replace it."),
+            ("config.yml", f"# This comment has a semicolon{SEMICOLON} replace it."),
+            ("app.ts", f"{'/' * 2} This comment has a semicolon{SEMICOLON} replace it."),
+        )
+        for path, content in cases:
+            self.assertTrue(run_hook("Write", {"file_path": path, "content": content}))
+
+    def test_applies_markdown_edits_with_file_context(self):
+        """Use the full Markdown file to classify edited text."""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "README.md"
+            path.write_text(f"Intro.\n```js\nconst value = 1{SEMICOLON}\n```\nOld sentence.\n")
+            code_edit = {
+                "file_path": str(path),
+                "old_string": f"const value = 1{SEMICOLON}",
+                "new_string": f"const value = 2{SEMICOLON}",
+            }
+            prose_edit = {
+                "file_path": str(path),
+                "old_string": "Old sentence.",
+                "new_string": f"New{SEMICOLON} sentence.",
+            }
+            self.assertEqual(run_hook("Edit", code_edit), "")
+            self.assertTrue(run_hook("Edit", prose_edit))
+
+    def test_applies_markdown_patches_with_file_context(self):
+        """Use the full Markdown file to classify patched text."""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "README.md"
+            path.write_text(f"Intro.\n```js\nconst value = 1{SEMICOLON}\n```\n")
+            patch = (
+                f"*** Begin Patch\n*** Update File: {path}\n@@\n ```js\n"
+                f"-const value = 1{SEMICOLON}\n+const value = 2{SEMICOLON}\n ```\n*** End Patch"
+            )
+            self.assertEqual(run_hook("apply_patch", {"command": patch}), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_humanize.py
+++ b/.github/scripts/test_humanize.py
@@ -100,13 +100,18 @@ class HumanizeTest(unittest.TestCase):
         """Report every file finding with line, column, fix, and context."""
         reason = run_hook(
             "Write",
-            {"file_path": "README.md", "content": f"First line.\nAI sections{SEMICOLON} it does not{SEMICOLON}\n"},
+            {
+                "file_path": "README.md",
+                "content": f"First line.\nAI sections{SEMICOLON} it does not{SEMICOLON}\nWe leverage tools.\nIn conclusion, done.\n",
+            },
         )
         self.assertIn(
             f'- semicolon at README.md:2:12, use a period or comma: "AI sections{SEMICOLON} it does not{SEMICOLON}"',
             reason,
         )
         self.assertEqual(reason.count("- semicolon at"), 2)
+        self.assertIn('"leverage" at README.md:3:4, use "use"', reason)
+        self.assertIn('"In conclusion" at README.md:4:1, drop it', reason)
 
     def test_caps_pileup_locations(self):
         """Report five pile-up locations and count the remainder."""

--- a/.github/scripts/test_humanize.py
+++ b/.github/scripts/test_humanize.py
@@ -13,13 +13,14 @@ SEMICOLON = chr(59)
 
 def run_hook(tool, tool_input):
     """Run humanize with one tool payload."""
-    return subprocess.run(
+    output = subprocess.run(
         ["python3", HOOK],
         input=json.dumps({"tool_name": tool, "tool_input": tool_input}),
         capture_output=True,
         check=True,
         text=True,
     ).stdout
+    return json.loads(output)["hookSpecificOutput"]["permissionDecisionReason"] if output else ""
 
 
 class HumanizeTest(unittest.TestCase):
@@ -77,18 +78,66 @@ class HumanizeTest(unittest.TestCase):
                 "new_string": f"New{SEMICOLON} sentence.",
             }
             self.assertEqual(run_hook("Edit", code_edit), "")
-            self.assertTrue(run_hook("Edit", prose_edit))
+            self.assertIn(f"{path}:5:4", run_hook("Edit", prose_edit))
 
     def test_applies_markdown_patches_with_file_context(self):
         """Use the full Markdown file to classify patched text."""
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "README.md"
-            path.write_text(f"Intro.\n```js\nconst value = 1{SEMICOLON}\n```\n")
-            patch = (
+            path.write_text(f"Intro.\n```js\nconst value = 1{SEMICOLON}\n```\nOld sentence.\n")
+            code_patch = (
                 f"*** Begin Patch\n*** Update File: {path}\n@@\n ```js\n"
                 f"-const value = 1{SEMICOLON}\n+const value = 2{SEMICOLON}\n ```\n*** End Patch"
             )
-            self.assertEqual(run_hook("apply_patch", {"command": patch}), "")
+            prose_patch = (
+                f"*** Begin Patch\n*** Update File: {path}\n@@\n ```\n"
+                f"-Old sentence.\n+New{SEMICOLON} sentence.\n*** End Patch"
+            )
+            self.assertEqual(run_hook("apply_patch", {"command": code_patch}), "")
+            self.assertIn(f"{path}:5:4", run_hook("apply_patch", {"command": prose_patch}))
+
+    def test_reports_each_file_location_with_context(self):
+        """Report every file finding with line, column, fix, and context."""
+        reason = run_hook(
+            "Write",
+            {"file_path": "README.md", "content": f"First line.\nAI sections{SEMICOLON} it does not{SEMICOLON}\n"},
+        )
+        self.assertIn(
+            f'- semicolon at README.md:2:12, use a period or comma: "AI sections{SEMICOLON} it does not{SEMICOLON}"',
+            reason,
+        )
+        self.assertEqual(reason.count("- semicolon at"), 2)
+
+    def test_caps_pileup_locations(self):
+        """Report five pile-up locations and count the remainder."""
+        content = "\n".join(f"crucial item {i}" for i in range(7))
+        reason = run_hook("Write", {"file_path": "README.md", "content": content})
+        self.assertIn('"crucial" used 7 times', reason)
+        self.assertIn("README.md:5:1, +2 more", reason)
+        self.assertNotIn("README.md:6:1", reason)
+
+    def test_labels_non_file_sources(self):
+        """Label PR, Slack, and heredoc findings by their real source."""
+        cases = (
+            ("Bash", {"command": f'gh pr create -b "One{SEMICOLON} two"'}, "PR body:1:4"),
+            (
+                "mcp__claude_ai_Slack__slack_send_message",
+                {"message": f"One{SEMICOLON} two"},
+                "Slack message:1:4",
+            ),
+            (
+                "mcp__codex_apps__slack_slack_send_message",
+                {"message": {"markdown_text": f"One{SEMICOLON} two"}},
+                "Slack message:1:4",
+            ),
+            (
+                "Bash",
+                {"command": f"cat > notes.md <<'EOF'\nOne{SEMICOLON} two\nEOF"},
+                "notes.md:1:4",
+            ),
+        )
+        for tool, tool_input, source in cases:
+            self.assertIn(source, run_hook(tool, tool_input))
 
 
 if __name__ == "__main__":

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/gemini-extension.json
+++ b/plugins/humanize/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "humanize",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Block a curated list of AI buzzwords on every write with a hook."
 }

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -8,15 +8,18 @@ common words only when they pile up. En-dash is allowed.
 
 Words draw on Wikipedia "Signs of AI writing": https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
 """
+
 import json
 import re
 import shlex
 import sys
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
 
 # TODO: build a companion guidance skill from that page's pitfalls, not only its word list
 
+# fmt: off
 # always blocked on any hit, each mapped to a plain swap or a short "drop it" note
 SWAP = {
     "leverage": "use", "utilize": "use", "plethora": "many", "myriad": "many",
@@ -77,42 +80,141 @@ REDIRECT = re.compile(r"(?<![0-9&])>>?[ \t]*(\"[^\"]*\"|'[^']*'|[^\s'\"|&;<>]+)"
 TEXT_KEYS = {"body", "text", "markdown_text", "content", "description", "title",
              "comment", "message", "subject", "note", "summary", "richtext", "rich_text"}
 
-MD_EXT = {".md", ".markdown", ".mdx", ".txt"}
+MD_EXT = {".md", ".markdown", ".mdx"}
 HASH_EXT = {".py", ".sh", ".bash", ".zsh", ".rb", ".yaml", ".yml", ".toml"}
 C_EXT = {".js", ".ts", ".jsx", ".tsx", ".c", ".cc", ".cpp", ".h", ".hpp", ".java", ".go", ".rs", ".css", ".scss", ".swift", ".kt", ".php"}
+# fmt: on
+
+
+@dataclass(frozen=True)
+class Region:
+    """Store checkable text without losing its source coordinates.
+
+    Attributes:
+        source (str): File path or non-file source label.
+        text (str): Source-length text with excluded content masked.
+    """
+
+    source: str
+    text: str
+
+
+def masked(text, keep):
+    """Mask excluded characters with spaces while preserving newlines."""
+    return "".join(char if char in "\r\n" or keep[i] else " " for i, char in enumerate(text))
 
 
 def md_text(text):
-    """Return markdown with fenced and inline code removed."""
-    text = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
-    return re.sub(r"`[^`]*`", "", text)
+    """Mask fenced and inline Markdown code without changing source offsets."""
+    keep = [True] * len(text)
+    lines = text.splitlines(keepends=True)
+    offset = 0
+    fence = None
+    for line in lines:
+        match = re.match(r" {0,3}(`{3,}|~{3,})(.*)$", line.rstrip("\r\n"))
+        if fence:
+            keep[offset : offset + len(line)] = [False] * len(line)
+            if (
+                match
+                and match.group(1)[0] == fence[0]
+                and len(match.group(1)) >= len(fence)
+                and not match.group(2).strip()
+            ):
+                fence = None
+        elif match:
+            fence = match.group(1)
+            keep[offset : offset + len(line)] = [False] * len(line)
+        offset += len(line)
+
+    i = 0
+    while i < len(text):
+        if text[i] != "`" or not keep[i]:
+            i += 1
+            continue
+        end = i
+        while end < len(text) and text[end] == "`":
+            end += 1
+        delimiter = text[i:end]
+        close = text.find(delimiter, end)
+        if close < 0:
+            i = end
+            continue
+        keep[i : close + len(delimiter)] = [False] * (close + len(delimiter) - i)
+        i = close + len(delimiter)
+    return masked(text, keep)
 
 
 def hash_comments(text):
-    """Return line-start docstrings and hash comment tails from a hash-comment language."""
-    out = re.findall(r'^[ \t]*[rbuRBU]*"""(.*?)"""', text, flags=re.DOTALL | re.MULTILINE)
-    out += re.findall(r"^[ \t]*[rbuRBU]*'''(.*?)'''", text, flags=re.DOTALL | re.MULTILINE)
-    out += [m.group(1) for line in text.splitlines() if (m := re.search(r"(?:^|\s)#(.*)", line))]
-    return "\n".join(out)
+    """Mask everything except docstrings and quote-aware hash comments."""
+    keep = [False] * len(text)
+    for pattern in (r'^[ \t]*[rbuRBU]*""".*?"""', r"^[ \t]*[rbuRBU]*'''.*?'''"):
+        for match in re.finditer(pattern, text, flags=re.DOTALL | re.MULTILINE):
+            keep[match.start() : match.end()] = [True] * (match.end() - match.start())
+    offset = 0
+    for line in text.splitlines(keepends=True):
+        quote = None
+        escaped = False
+        for i, char in enumerate(line):
+            if escaped:
+                escaped = False
+            elif char == "\\" and quote:
+                escaped = True
+            elif quote:
+                if char == quote:
+                    quote = None
+            elif char in "\"'":
+                quote = char
+            elif char == "#":
+                keep[offset + i : offset + len(line)] = [True] * (len(line) - i)
+                break
+        offset += len(line)
+    return masked(text, keep)
 
 
 def c_comments(text):
-    """Return block comments and double-slash comment tails from a C-style language."""
-    out = re.findall(r"/\*(.*?)\*/", text, flags=re.DOTALL)
-    out += [m.group(1) for line in text.splitlines() if (m := re.search(r"(?:^|\s)//(.*)", line))]
-    return "\n".join(out)
+    """Mask everything except quote-aware C-style comments."""
+    keep = [False] * len(text)
+    i = 0
+    quote = None
+    while i < len(text):
+        if quote:
+            if text[i] == "\\":
+                i += 2
+            else:
+                quote = None if text[i] == quote else quote
+                i += 1
+        elif text[i] in "\"'`":
+            quote = text[i]
+            i += 1
+        elif text.startswith("//", i):
+            end = text.find("\n", i)
+            end = len(text) if end < 0 else end
+            keep[i:end] = [True] * (end - i)
+            i = end
+        elif text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            end = len(text) if end < 0 else end + 2
+            keep[i:end] = [True] * (end - i)
+            i = end
+        else:
+            i += 1
+    return masked(text, keep)
 
 
-def checked(path, text):
-    """Return the text regions to check for the file type, empty for unknown types."""
+def checked(path, text, selected=None):
+    """Return one source-preserving region for a known file type."""
     ext = Path(path).suffix.lower()
     if ext in MD_EXT:
-        return md_text(text)
-    if ext in HASH_EXT:
-        return hash_comments(text)
-    if ext in C_EXT:
-        return c_comments(text)
-    return ""
+        text = md_text(text)
+    elif ext in HASH_EXT:
+        text = hash_comments(text)
+    elif ext in C_EXT:
+        text = c_comments(text)
+    else:
+        return []
+    if selected is not None:
+        text = masked(text, selected)
+    return [Region(path, text)] if text.strip() else []
 
 
 def heredocs(command):
@@ -122,7 +224,7 @@ def heredocs(command):
 
 
 def heredoc_writes(command):
-    """Return checkable text from heredoc bodies that cat or tee writes to a file, routed per target."""
+    """Return regions from heredoc bodies that cat or tee writes unchanged."""
     out = []
     for head, body in heredocs(command):
         if not (writer := CAT_TEE.match(head)):
@@ -130,16 +232,17 @@ def heredoc_writes(command):
         targets = REDIRECT.findall(head)
         if writer.group(1) == "tee":
             targets += [a for a in REDIRECT.sub(" ", writer.group(2)).split() if not a.startswith("-")]
-        out += [checked(t.strip("\"'"), body) for t in targets]
-    return "\n".join(p for p in out if p)
+        for target in targets:
+            out += checked(target.strip("\"'"), body)
+    return out
 
 
 def bash_text(command):
-    """Return commit, PR, and comment message text from a git-commit or gh command, else empty."""
+    """Return commit, PR, and comment message strings from a shell command."""
     git_commit = re.search(r"\bgit\b[^|&]*\bcommit\b", command)
     gh = re.search(r"\bgh\b", command)
     if not (git_commit or gh):
-        return ""
+        return []
     parts = [body for head, body in heredocs(command) if re.search(r"\b(?:git|gh)\b", head)]
     stripped = HEREDOC.sub(" ", command)
     flags = {"-m", "--message"} if git_commit else set()
@@ -159,47 +262,98 @@ def bash_text(command):
             field, _, value = tokens[i + 1].partition("=")
             if field in {"body", "title"} and not value.startswith("@"):
                 parts.append(value)
-    return "\n".join(parts)
+    return parts
 
 
-def patch_text(patch):
-    """Return checkable text from a Codex apply_patch envelope, split by file type."""
+def apply_edits(path, edits):
+    """Apply editor replacements and select only their new text."""
+    text = Path(path).read_text()
+    selected = [False] * len(text)
+    for edit in edits:
+        old, new = edit["old_string"], edit["new_string"]
+        parts, keep, cursor = [], [], 0
+        while (start := text.find(old, cursor)) >= 0:
+            parts += [text[cursor:start], new]
+            keep += selected[cursor:start] + [True] * len(new)
+            cursor = start + len(old)
+            if not edit.get("replace_all"):
+                break
+        parts.append(text[cursor:])
+        keep += selected[cursor:]
+        text, selected = "".join(parts), keep
+    return checked(path, text, selected)
+
+
+def apply_patch_file(path, action, block):
+    """Apply one patch block in memory and select only added text."""
+    if action == "Add":
+        text = "\n".join(line[1:] for line in block.splitlines() if line.startswith("+"))
+        return checked(path, text + ("\n" if block.endswith("\n") else ""))
+
+    original = Path(path).read_text()
+    parts, selected = [], []
+    cursor = 0
+    for hunk in re.split(r"^@@.*$", block, flags=re.MULTILINE)[1:]:
+        lines = [line for line in hunk.strip("\n").splitlines() if not line.startswith("\\ No newline")]
+        old_lines = [line[1:] if line.startswith(("-", " ")) else line for line in lines if not line.startswith("+")]
+        new_lines = [line[1:] if line.startswith(("+", " ")) else line for line in lines if not line.startswith("-")]
+        old, new = "\n".join(old_lines), "\n".join(new_lines)
+        start = original.index(old, cursor)
+        parts += [original[cursor:start], new]
+        selected += [False] * (start - cursor)
+        keep = []
+        for i, line in enumerate(line for line in lines if not line.startswith("-")):
+            if i:
+                keep.append(False)
+            keep += [line.startswith("+")] * len(line[1:] if line.startswith(("+", " ")) else line)
+        selected += keep
+        cursor = start + len(old)
+    parts.append(original[cursor:])
+    selected += [False] * (len(original) - cursor)
+    return checked(path, "".join(parts), selected)
+
+
+def patch_regions(patch):
+    """Return source-preserving regions from a Codex patch envelope."""
     out = []
-    for path, block in re.findall(r"^\*\*\* (?:Add|Update) File: (.+?)\s*$(.*?)(?=^\*\*\* |\Z)", patch, re.DOTALL | re.MULTILINE):
-        added = "\n".join(ln[1:] for ln in block.splitlines() if ln.startswith("+") and not ln.startswith("+++"))
-        out.append(checked(path, added))
-    return "\n".join(p for p in out if p)
+    pattern = r"^\*\*\* (Add|Update) File: (.+?)\s*$(.*?)(?=^\*\*\* |\Z)"
+    for action, path, block in re.findall(pattern, patch, re.DOTALL | re.MULTILINE):
+        out += apply_patch_file(path, action, block)
+    return out
 
 
 def mcp_text(obj):
-    """Return human-facing field values pulled from an MCP tool input, walked in full."""
+    """Return human-facing field values pulled from an MCP tool input."""
     if isinstance(obj, dict):
-        items = [v if k.lower() in TEXT_KEYS and isinstance(v, str) else mcp_text(v) for k, v in obj.items()]
+        items = [[v] if k.lower() in TEXT_KEYS and isinstance(v, str) else mcp_text(v) for k, v in obj.items()]
     elif isinstance(obj, list):
         items = [mcp_text(v) for v in obj]
     else:
-        return ""
-    return "\n".join(p for p in items if p)
+        return []
+    return [text for group in items for text in group]
 
 
 def extract(tool, tool_input):
-    """Return the checkable text for a tool call, routed by tool type."""
+    """Return source-preserving regions for a tool call."""
     command = tool_input.get("command", "")
     if isinstance(command, list):  # Codex sends the shell tool an argv array, Claude Code a string
         command = " ".join(str(c) for c in command)
     if tool.startswith("mcp__"):
-        return md_text(mcp_text(tool_input))
+        return [Region("tool input", md_text(text)) for text in mcp_text(tool_input)]
     if tool == "Bash":
-        return "\n".join(p for p in (md_text(bash_text(command)), heredoc_writes(command)) if p)
+        return [Region("shell message", md_text(text)) for text in bash_text(command)] + heredoc_writes(command)
     if tool == "apply_patch":
-        return patch_text(command)
-    chunks = [tool_input.get("content", ""), tool_input.get("new_string", "")]
-    chunks += [e.get("new_string", "") for e in tool_input.get("edits", []) if isinstance(e, dict)]
-    return checked(tool_input.get("file_path", ""), "\n".join(c for c in chunks if c))
+        return patch_regions(command)
+    path = tool_input.get("file_path", "")
+    if "content" in tool_input:
+        return checked(path, tool_input["content"])
+    edits = tool_input.get("edits") or [tool_input]
+    return apply_edits(path, [edit for edit in edits if isinstance(edit, dict) and "old_string" in edit])
 
 
 data = json.load(sys.stdin)
-text = extract(data.get("tool_name", ""), data.get("tool_input") or {})
+regions = extract(data.get("tool_name", ""), data.get("tool_input") or {})
+text = "\n".join(region.text for region in regions)
 
 notes = [f"remove {label}" for ch, label in MARKS.items() if ch in text]
 notes += [f"'{w}' -> {SWAP[w]}" for w in dict.fromkeys(m.group(1).lower() for m in SWAP_RE.finditer(text))]
@@ -209,4 +363,14 @@ notes += [f"'{w}' used {n} times, vary it" for w, n in counts.items() if n >= LI
 
 if notes:
     reason = "humanize: " + ", ".join(notes) + ". Applies to markdown, code comments, and message text."
-    print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}))
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -63,7 +63,8 @@ PHRASES = [
 LIMIT = 3
 OFTEN = ["crucial", "essential", "vital", "significant", "moreover", "furthermore", "additionally", "aligns", "explore", "prompted"]
 
-MARKS = {"—": "em-dash, use commas or periods", "§": "section sign", ";": "semicolon, use a period or comma"}
+MARKS = {"—": ("em-dash", "use commas or periods"), "§": ("section sign", "remove it"), ";": ("semicolon", "use a period or comma")}
+MARK_RE = re.compile("|".join(map(re.escape, MARKS)))
 SWAP_RE = re.compile(r"\b(" + "|".join(SWAP) + r")\b", re.IGNORECASE)
 OFTEN_RE = re.compile(r"\b(" + "|".join(OFTEN) + r")\b", re.IGNORECASE)
 
@@ -97,6 +98,27 @@ class Region:
 
     source: str
     text: str
+
+
+@dataclass(frozen=True)
+class Finding:
+    """Store one detector match and its source span.
+
+    Attributes:
+        region (Region): Source region containing the match.
+        start (int): Match start offset in the region.
+        end (int): Match end offset in the region.
+        rule (str): Human-readable rule name.
+        replacement (str): Suggested correction.
+        pileup (bool): Whether the rule depends on repeated use.
+    """
+
+    region: Region
+    start: int
+    end: int
+    rule: str
+    replacement: str
+    pileup: bool = False
 
 
 def masked(text, keep):
@@ -238,16 +260,22 @@ def heredoc_writes(command):
 
 
 def bash_text(command):
-    """Return commit, PR, and comment message strings from a shell command."""
+    """Return labeled commit, PR, and comment messages from a shell command."""
     git_commit = re.search(r"\bgit\b[^|&]*\bcommit\b", command)
     gh = re.search(r"\bgh\b", command)
     if not (git_commit or gh):
         return []
-    parts = [body for head, body in heredocs(command) if re.search(r"\b(?:git|gh)\b", head)]
+    is_pr = re.search(r"\bgh\s+pr\b", command)
+    body_source = "PR body" if is_pr else "GitHub body"
+    parts = [
+        ("commit message" if re.search(r"\bgit\b", head) else body_source, body)
+        for head, body in heredocs(command)
+        if re.search(r"\b(?:git|gh)\b", head)
+    ]
     stripped = HEREDOC.sub(" ", command)
-    flags = {"-m", "--message"} if git_commit else set()
+    flags = {"-m": "commit message", "--message": "commit message"} if git_commit else {}
     if gh:
-        flags |= {"-b", "--body", "-t", "--title"}
+        flags |= {"-b": body_source, "--body": body_source, "-t": "PR title", "--title": "PR title"}
     try:
         tokens = shlex.split(stripped, comments=False)
     except ValueError:
@@ -255,13 +283,13 @@ def bash_text(command):
     for i, tok in enumerate(tokens):
         key, sep, val = tok.partition("=")
         if tok in flags and i + 1 < len(tokens):
-            parts.append(tokens[i + 1])
+            parts.append((flags[tok], tokens[i + 1]))
         elif sep and key in flags:
-            parts.append(val)
+            parts.append((flags[key], val))
         elif gh and tok in FIELD_FLAGS and i + 1 < len(tokens):
             field, _, value = tokens[i + 1].partition("=")
             if field in {"body", "title"} and not value.startswith("@"):
-                parts.append(value)
+                parts.append((body_source if field == "body" else "PR title", value))
     return parts
 
 
@@ -323,9 +351,11 @@ def patch_regions(patch):
 
 
 def mcp_text(obj):
-    """Return human-facing field values pulled from an MCP tool input."""
+    """Return human-facing field names and values from an MCP tool input."""
     if isinstance(obj, dict):
-        items = [[v] if k.lower() in TEXT_KEYS and isinstance(v, str) else mcp_text(v) for k, v in obj.items()]
+        items = [
+            [(k.lower(), v)] if k.lower() in TEXT_KEYS and isinstance(v, str) else mcp_text(v) for k, v in obj.items()
+        ]
     elif isinstance(obj, list):
         items = [mcp_text(v) for v in obj]
     else:
@@ -339,9 +369,22 @@ def extract(tool, tool_input):
     if isinstance(command, list):  # Codex sends the shell tool an argv array, Claude Code a string
         command = " ".join(str(c) for c in command)
     if tool.startswith("mcp__"):
-        return [Region("tool input", md_text(text)) for text in mcp_text(tool_input)]
+        server = tool.split("__", 2)[1]
+        if server.startswith("claude_ai_"):
+            server = server.removeprefix("claude_ai_")
+        elif server == "codex_apps":
+            server = tool.split("__", 2)[2].split("_", 1)[0]
+        regions = []
+        for field, text in mcp_text(tool_input):
+            kind = (
+                "message"
+                if field in {"body", "text", "markdown_text", "content", "comment", "message"}
+                else field.replace("_", " ")
+            )
+            regions.append(Region(f"{server.replace('_', ' ').title()} {kind}", md_text(text)))
+        return regions
     if tool == "Bash":
-        return [Region("shell message", md_text(text)) for text in bash_text(command)] + heredoc_writes(command)
+        return [Region(source, md_text(text)) for source, text in bash_text(command)] + heredoc_writes(command)
     if tool == "apply_patch":
         return patch_regions(command)
     path = tool_input.get("file_path", "")
@@ -351,25 +394,84 @@ def extract(tool, tool_input):
     return apply_edits(path, [edit for edit in edits if isinstance(edit, dict) and "old_string" in edit])
 
 
+def detect(regions):
+    """Return every rule occurrence with its source span."""
+    findings = []
+    often = []
+    for region in regions:
+        for match in MARK_RE.finditer(region.text):
+            rule, replacement = MARKS[match.group()]
+            findings.append(Finding(region, match.start(), match.end(), rule, replacement))
+        for match in SWAP_RE.finditer(region.text):
+            word = match.group().lower()
+            replacement = SWAP[word]
+            findings.append(
+                Finding(
+                    region,
+                    match.start(),
+                    match.end(),
+                    f'"{word}"',
+                    replacement if replacement == "drop it" else f'use "{replacement}"',
+                )
+            )
+        for pattern, replacement in PHRASES:
+            for match in re.finditer(rf"\b(?:{pattern})\b", region.text, re.IGNORECASE):
+                findings.append(Finding(region, match.start(), match.end(), f'"{match.group()}"', replacement))
+        often += [
+            Finding(region, match.start(), match.end(), f'"{match.group().lower()}"', "vary it", True)
+            for match in OFTEN_RE.finditer(region.text)
+        ]
+    counts = Counter(finding.rule for finding in often)
+    return findings + [finding for finding in often if counts[finding.rule] >= LIMIT]
+
+
+def location(finding):
+    """Format a finding's source, line, and column."""
+    text = finding.region.text
+    return f"{finding.region.source}:{text.count(chr(10), 0, finding.start) + 1}:{finding.start - text.rfind(chr(10), 0, finding.start)}"
+
+
+def context(finding, width=60):
+    """Return short single-line context around a finding."""
+    text = finding.region.text
+    line_start = text.rfind("\n", 0, finding.start) + 1
+    line_end = text.find("\n", finding.end)
+    line_end = len(text) if line_end < 0 else line_end
+    start = max(line_start, finding.start - width // 2)
+    end = min(line_end, finding.end + width // 2)
+    snippet = ("..." if start > line_start else "") + text[start:end].strip() + ("..." if end < line_end else "")
+    return json.dumps(snippet)
+
+
+def format_findings(findings):
+    """Format all findings into one actionable denial message."""
+    lines = [
+        f"- {finding.rule} at {location(finding)}, {finding.replacement}: {context(finding)}"
+        for finding in findings
+        if not finding.pileup
+    ]
+    piles = {}
+    for finding in (finding for finding in findings if finding.pileup):
+        piles.setdefault(finding.rule, []).append(finding)
+    for rule, matches in piles.items():
+        shown = ", ".join(location(finding) for finding in matches[:5])
+        more = f", +{len(matches) - 5} more" if len(matches) > 5 else ""
+        lines.append(f"- {rule} used {len(matches)} times at {shown}{more}, {matches[0].replacement}")
+    return "humanize:\n" + "\n".join(lines)
+
+
 data = json.load(sys.stdin)
 regions = extract(data.get("tool_name", ""), data.get("tool_input") or {})
-text = "\n".join(region.text for region in regions)
+findings = detect(regions)
 
-notes = [f"remove {label}" for ch, label in MARKS.items() if ch in text]
-notes += [f"'{w}' -> {SWAP[w]}" for w in dict.fromkeys(m.group(1).lower() for m in SWAP_RE.finditer(text))]
-notes += [note for pat, note in PHRASES if re.search(rf"\b(?:{pat})\b", text, re.IGNORECASE)]
-counts = Counter(m.group(1).lower() for m in OFTEN_RE.finditer(text))
-notes += [f"'{w}' used {n} times, vary it" for w, n in counts.items() if n >= LIMIT]
-
-if notes:
-    reason = "humanize: " + ", ".join(notes) + ". Applies to markdown, code comments, and message text."
+if findings:
     print(
         json.dumps(
             {
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
-                    "permissionDecisionReason": reason,
+                    "permissionDecisionReason": format_findings(findings),
                 }
             }
         )

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -13,8 +13,7 @@ import json
 import re
 import shlex
 import sys
-from collections import Counter
-from dataclasses import dataclass
+from collections import namedtuple
 from pathlib import Path
 
 # TODO: build a companion guidance skill from that page's pitfalls, not only its word list
@@ -78,8 +77,8 @@ CAT_TEE = re.compile(r"^\s*(cat|tee)\b(.*)$", re.DOTALL)
 REDIRECT = re.compile(r"(?<![0-9&])>>?[ \t]*(\"[^\"]*\"|'[^']*'|[^\s'\"|&;<>]+)")
 
 # MCP input keys that carry human-facing message text, checked as markdown
-TEXT_KEYS = {"body", "text", "markdown_text", "content", "description", "title",
-             "comment", "message", "subject", "note", "summary", "richtext", "rich_text"}
+MESSAGE_KEYS = {"body", "text", "markdown_text", "content", "comment", "message"}
+TEXT_KEYS = MESSAGE_KEYS | {"description", "title", "subject", "note", "summary", "richtext", "rich_text"}
 
 MD_EXT = {".md", ".markdown", ".mdx"}
 HASH_EXT = {".py", ".sh", ".bash", ".zsh", ".rb", ".yaml", ".yml", ".toml"}
@@ -87,38 +86,8 @@ C_EXT = {".js", ".ts", ".jsx", ".tsx", ".c", ".cc", ".cpp", ".h", ".hpp", ".java
 # fmt: on
 
 
-@dataclass(frozen=True)
-class Region:
-    """Store checkable text without losing its source coordinates.
-
-    Attributes:
-        source (str): File path or non-file source label.
-        text (str): Source-length text with excluded content masked.
-    """
-
-    source: str
-    text: str
-
-
-@dataclass(frozen=True)
-class Finding:
-    """Store one detector match and its source span.
-
-    Attributes:
-        region (Region): Source region containing the match.
-        start (int): Match start offset in the region.
-        end (int): Match end offset in the region.
-        rule (str): Human-readable rule name.
-        replacement (str): Suggested correction.
-        pileup (bool): Whether the rule depends on repeated use.
-    """
-
-    region: Region
-    start: int
-    end: int
-    rule: str
-    replacement: str
-    pileup: bool = False
+Region = namedtuple("Region", "source text")
+Finding = namedtuple("Finding", "region start end rule replacement")
 
 
 def masked(text, keep):
@@ -129,10 +98,9 @@ def masked(text, keep):
 def md_text(text):
     """Mask fenced and inline Markdown code without changing source offsets."""
     keep = [True] * len(text)
-    lines = text.splitlines(keepends=True)
     offset = 0
     fence = None
-    for line in lines:
+    for line in text.splitlines(keepends=True):
         match = re.match(r" {0,3}(`{3,}|~{3,})(.*)$", line.rstrip("\r\n"))
         if fence:
             keep[offset : offset + len(line)] = [False] * len(line)
@@ -265,8 +233,7 @@ def bash_text(command):
     gh = re.search(r"\bgh\b", command)
     if not (git_commit or gh):
         return []
-    is_pr = re.search(r"\bgh\s+pr\b", command)
-    body_source = "PR body" if is_pr else "GitHub body"
+    body_source = "PR body" if re.search(r"\bgh\s+pr\b", command) else "GitHub body"
     parts = [
         ("commit message" if re.search(r"\bgit\b", head) else body_source, body)
         for head, body in heredocs(command)
@@ -351,16 +318,16 @@ def patch_regions(patch):
 
 
 def mcp_text(obj):
-    """Return human-facing field names and values from an MCP tool input."""
+    """Yield human-facing field names and values from an MCP tool input."""
     if isinstance(obj, dict):
-        items = [
-            [(k.lower(), v)] if k.lower() in TEXT_KEYS and isinstance(v, str) else mcp_text(v) for k, v in obj.items()
-        ]
+        for key, value in obj.items():
+            if key.lower() in TEXT_KEYS and isinstance(value, str):
+                yield key.lower(), value
+            else:
+                yield from mcp_text(value)
     elif isinstance(obj, list):
-        items = [mcp_text(v) for v in obj]
-    else:
-        return []
-    return [text for group in items for text in group]
+        for value in obj:
+            yield from mcp_text(value)
 
 
 def extract(tool, tool_input):
@@ -369,18 +336,11 @@ def extract(tool, tool_input):
     if isinstance(command, list):  # Codex sends the shell tool an argv array, Claude Code a string
         command = " ".join(str(c) for c in command)
     if tool.startswith("mcp__"):
-        server = tool.split("__", 2)[1]
-        if server.startswith("claude_ai_"):
-            server = server.removeprefix("claude_ai_")
-        elif server == "codex_apps":
-            server = tool.split("__", 2)[2].split("_", 1)[0]
+        namespace, name = tool.split("__", 2)[1:]
+        server = name.split("_", 1)[0] if namespace == "codex_apps" else namespace.removeprefix("claude_ai_")
         regions = []
         for field, text in mcp_text(tool_input):
-            kind = (
-                "message"
-                if field in {"body", "text", "markdown_text", "content", "comment", "message"}
-                else field.replace("_", " ")
-            )
+            kind = "message" if field in MESSAGE_KEYS else field.replace("_", " ")
             regions.append(Region(f"{server.replace('_', ' ').title()} {kind}", md_text(text)))
         return regions
     if tool == "Bash":
@@ -397,32 +357,29 @@ def extract(tool, tool_input):
 def detect(regions):
     """Return every rule occurrence with its source span."""
     findings = []
-    often = []
+    piles = {}
     for region in regions:
         for match in MARK_RE.finditer(region.text):
             rule, replacement = MARKS[match.group()]
-            findings.append(Finding(region, match.start(), match.end(), rule, replacement))
+            findings.append(Finding(region, *match.span(), rule, replacement))
         for match in SWAP_RE.finditer(region.text):
             word = match.group().lower()
             replacement = SWAP[word]
             findings.append(
                 Finding(
                     region,
-                    match.start(),
-                    match.end(),
+                    *match.span(),
                     f'"{word}"',
                     replacement if replacement == "drop it" else f'use "{replacement}"',
                 )
             )
         for pattern, replacement in PHRASES:
             for match in re.finditer(rf"\b(?:{pattern})\b", region.text, re.IGNORECASE):
-                findings.append(Finding(region, match.start(), match.end(), f'"{match.group()}"', replacement))
-        often += [
-            Finding(region, match.start(), match.end(), f'"{match.group().lower()}"', "vary it", True)
-            for match in OFTEN_RE.finditer(region.text)
-        ]
-    counts = Counter(finding.rule for finding in often)
-    return findings + [finding for finding in often if counts[finding.rule] >= LIMIT]
+                findings.append(Finding(region, *match.span(), f'"{match.group()}"', replacement))
+        for match in OFTEN_RE.finditer(region.text):
+            rule = f'"{match.group().lower()}"'
+            piles.setdefault(rule, []).append(Finding(region, *match.span(), rule, "vary it"))
+    return findings, {rule: matches for rule, matches in piles.items() if len(matches) >= LIMIT}
 
 
 def location(finding):
@@ -437,22 +394,18 @@ def context(finding, width=60):
     line_start = text.rfind("\n", 0, finding.start) + 1
     line_end = text.find("\n", finding.end)
     line_end = len(text) if line_end < 0 else line_end
-    start = max(line_start, finding.start - width // 2)
-    end = min(line_end, finding.end + width // 2)
-    snippet = ("..." if start > line_start else "") + text[start:end].strip() + ("..." if end < line_end else "")
+    clip_start = max(line_start, finding.start - width // 2)
+    clip_end = min(line_end, finding.end + width // 2)
+    snippet = ("..." if clip_start > line_start else "") + text[clip_start:clip_end].strip()
+    snippet += "..." if clip_end < line_end else ""
     return json.dumps(snippet)
 
 
-def format_findings(findings):
+def format_findings(findings, piles):
     """Format all findings into one actionable denial message."""
     lines = [
-        f"- {finding.rule} at {location(finding)}, {finding.replacement}: {context(finding)}"
-        for finding in findings
-        if not finding.pileup
+        f"- {finding.rule} at {location(finding)}, {finding.replacement}: {context(finding)}" for finding in findings
     ]
-    piles = {}
-    for finding in (finding for finding in findings if finding.pileup):
-        piles.setdefault(finding.rule, []).append(finding)
     for rule, matches in piles.items():
         shown = ", ".join(location(finding) for finding in matches[:5])
         more = f", +{len(matches) - 5} more" if len(matches) > 5 else ""
@@ -461,17 +414,16 @@ def format_findings(findings):
 
 
 data = json.load(sys.stdin)
-regions = extract(data.get("tool_name", ""), data.get("tool_input") or {})
-findings = detect(regions)
+findings, piles = detect(extract(data.get("tool_name", ""), data.get("tool_input") or {}))
 
-if findings:
+if findings or piles:
     print(
         json.dumps(
             {
                 "hookSpecificOutput": {
                     "hookEventName": "PreToolUse",
                     "permissionDecision": "deny",
-                    "permissionDecisionReason": format_findings(findings),
+                    "permissionDecisionReason": format_findings(findings, piles),
                 }
             }
         )


### PR DESCRIPTION
False denials made the blocking hook hard to trust, while location-free findings made valid blocks slow to fix.

```text
humanize:
- <rule> at README.md:31:17, <replacement>: "<context>"
```

- masks code without losing source positions
- labels files, PR bodies, Slack messages, and heredocs
- reports five pile-up locations before `+N more`

Closes #279
Closes #280