### PR TITLE
Use the PR base for visual proof

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -362,7 +362,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "Git and GitHub workflow skills for commits, PRs, code review, and comment resolution.",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -167,7 +167,7 @@
       "name": "github-dev",
       "source": "./plugins/github-dev",
       "description": "Git and GitHub workflow skills for commits, PRs, code review, and comment resolution.",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/test_require_visual_proof.py
+++ b/.github/scripts/test_require_visual_proof.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the GitHub visual-proof hook."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+HOOK = REPO_ROOT / "plugins" / "github-dev" / "hooks" / "scripts" / "require_visual_proof.py"
+
+
+class RequireVisualProofTest(unittest.TestCase):
+    """Test visual-proof behavior."""
+
+    def setUp(self) -> None:
+        """Create a repository whose integration branch contains a design change."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp_dir.name)
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.repo)], check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=self.repo, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=self.repo, check=True)
+        (self.repo / "README.md").write_text("base\n")
+        subprocess.run(["git", "add", "README.md"], cwd=self.repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "base"], cwd=self.repo, check=True)
+        subprocess.run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
+            cwd=self.repo,
+            check=True,
+        )
+        subprocess.run(["git", "switch", "-qc", "development"], cwd=self.repo, check=True)
+        (self.repo / "site.css").write_text("body {}\n")
+        subprocess.run(["git", "add", "site.css"], cwd=self.repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "design"], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/development", "HEAD"],
+            cwd=self.repo,
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        """Remove the temporary repository."""
+        self.temp_dir.cleanup()
+
+    def run_hook(self, command: str | list[str]) -> dict | None:
+        """Run the hook with a shell command.
+
+        Args:
+            command (str | list[str]): Command supplied to the hook.
+
+        Returns:
+            (dict | None): Hook response when the command is denied.
+        """
+        payload = {"cwd": str(self.repo), "tool_input": {"command": command}}
+        result = subprocess.run(
+            ["python3", str(HOOK)],
+            input=json.dumps(payload),
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        return json.loads(result.stdout) if result.stdout else None
+
+    def test_explicit_base_excludes_changes_already_on_that_branch(self) -> None:
+        """Use the PR base instead of the repository default."""
+        for command in (
+            'gh pr create --base development --body "plain"',
+            ["gh", "pr", "create", "--base=development", "--body", "plain"],
+        ):
+            with self.subTest(command=command):
+                self.assertIsNone(self.run_hook(command))
+
+    def test_body_text_cannot_override_the_base(self) -> None:
+        """Ignore base-like text inside the PR body."""
+        output = self.run_hook('gh pr create --body "mentions --base missing"')
+        self.assertEqual(output["hookSpecificOutput"]["permissionDecision"], "deny")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -56,3 +56,6 @@ jobs:
 
       - name: Test simplify guard
         run: python .github/scripts/test_simplify_guard.py
+
+      - name: Test visual proof guard
+        run: python .github/scripts/test_require_visual_proof.py

--- a/plugins/github-dev/.claude-plugin/plugin.json
+++ b/plugins/github-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Git and GitHub workflow skills for commits, PRs, code review, and comment resolution.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/github-dev/.codex-plugin/plugin.json
+++ b/plugins/github-dev/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Git and GitHub workflow skills for commits, PRs, code review, and comment resolution.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/github-dev/.cursor-plugin/plugin.json
+++ b/plugins/github-dev/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dev",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Git and GitHub workflow skills for commits, PRs, code review, and comment resolution.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/github-dev/gemini-extension.json
+++ b/plugins/github-dev/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "github-dev",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Git and GitHub workflow skills for commits, PRs, code review, and comment resolution."
 }

--- a/plugins/github-dev/hooks/scripts/require_visual_proof.py
+++ b/plugins/github-dev/hooks/scripts/require_visual_proof.py
@@ -40,9 +40,17 @@ if "--body-file" in text or ("$(" in text and "<<" not in text) or re.search(r"g
 
 import subprocess  # noqa: E402  deferred, this hook runs on every Bash call and reaches here on almost none
 
-# rev-parse of a missing origin/HEAD exits non-zero, leaving no files and letting the command through
+# Diff against the base the PR actually targets, not the repo default. A repo with a long-lived
+# integration branch (development, staging, next) merges into it rather than into main, so
+# origin/HEAD...HEAD attributes every design change already sitting in that base to this branch and
+# demands screenshots of somebody else's merged work. Falls back to origin/HEAD when no base is
+# given, which is what gh itself defaults to.
+base = re.search(r"(?:^|\s)(?:-B|--base)(?:[=\s]+)['\"]?([^\s'\"]+)", text)
+base_ref = "origin/" + base.group(1).removeprefix("origin/") if base else "origin/HEAD"
+
+# rev-parse of a missing base exits non-zero, leaving no files and letting the command through
 changed = "" if IMAGE.search(text) else subprocess.run(
-    ["git", "-C", data.get("cwd") or ".", "diff", "--name-only", "origin/HEAD...HEAD"],
+    ["git", "-C", data.get("cwd") or ".", "diff", "--name-only", f"{base_ref}...HEAD"],
     capture_output=True,
     text=True,
     timeout=5,

--- a/plugins/github-dev/hooks/scripts/require_visual_proof.py
+++ b/plugins/github-dev/hooks/scripts/require_visual_proof.py
@@ -7,6 +7,7 @@ the branch changes a webpage or stylesheet and the body carries no image at all.
 command (Claude Code) and an argv array (Codex). Lets the command through when git cannot list the
 branch files.
 """
+
 import json
 import re
 import sys
@@ -26,7 +27,11 @@ command = (data.get("tool_input") or {}).get("command", "")
 text = " ".join(map(str, command)) if isinstance(command, list) else str(command)
 
 # anchor per command segment so `cd site && gh pr create` matches but `gh issue comment -b "pr create"` does not
-if not any(part.strip().startswith(("gh pr create", "gh pr edit")) for part in SEGMENT.split(text)):
+pr_command = next(
+    (part.strip() for part in SEGMENT.split(text) if part.strip().startswith(("gh pr create", "gh pr edit"))),
+    "",
+)
+if not pr_command:
     sys.exit(0)
 
 # only a command writing an inline body can be judged, label or reviewer edits carry none
@@ -38,23 +43,25 @@ if not re.search(r"(^|\s)(-b|--body)(\s|=)", text):
 if "--body-file" in text or ("$(" in text and "<<" not in text) or re.search(r"gh pr edit\s+\d", text):
     sys.exit(0)
 
-import subprocess  # noqa: E402  deferred, this hook runs on every Bash call and reaches here on almost none
+import shlex
+import subprocess
 
-# Diff against the base the PR actually targets, not the repo default. A repo with a long-lived
-# integration branch (development, staging, next) merges into it rather than into main, so
-# origin/HEAD...HEAD attributes every design change already sitting in that base to this branch and
-# demands screenshots of somebody else's merged work. Falls back to origin/HEAD when no base is
-# given, which is what gh itself defaults to.
-base = re.search(r"(?:^|\s)(?:-B|--base)(?:[=\s]+)['\"]?([^\s'\"]+)", text)
-base_ref = "origin/" + base.group(1).removeprefix("origin/") if base else "origin/HEAD"
+args = list(map(str, command)) if isinstance(command, list) else shlex.split(pr_command)
+base = next((value for option, value in zip(args, args[1:]) if option in {"-B", "--base"}), None)
+base = next((arg.removeprefix("--base=") for arg in args if arg.startswith("--base=")), base)
+base_ref = f"origin/{base.removeprefix('origin/') if base else 'HEAD'}"
 
 # rev-parse of a missing base exits non-zero, leaving no files and letting the command through
-changed = "" if IMAGE.search(text) else subprocess.run(
-    ["git", "-C", data.get("cwd") or ".", "diff", "--name-only", f"{base_ref}...HEAD"],
-    capture_output=True,
-    text=True,
-    timeout=5,
-).stdout
+changed = (
+    ""
+    if IMAGE.search(text)
+    else subprocess.run(
+        ["git", "-C", data.get("cwd") or ".", "diff", "--name-only", f"{base_ref}...HEAD"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    ).stdout
+)
 design = [path for path in changed.split() if DESIGN.search(path)]
 
 if COMMITTED_IMAGE.search(text):
@@ -68,4 +75,14 @@ elif design:
 else:
     sys.exit(0)
 
-print(json.dumps({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}}))
+print(
+    json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": reason,
+            }
+        }
+    )
+)


### PR DESCRIPTION
Visual proof compared every branch with the repository default, so PRs targeting an integration branch inherited unrelated design changes.

- reads -B and --base from shell tokens, never PR body text
- covers string and argv commands across 2 regression cases
- bumps github-dev to 2.7.2 and runs the checks in CI