### PR TITLE
Bind simplify reviews to one worktree

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "simplify",
       "source": "./plugins/simplify",
       "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/test_simplify_guard.py
+++ b/.github/scripts/test_simplify_guard.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import tempfile
 import unittest
@@ -12,18 +13,22 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 GUARD = REPO_ROOT / "plugins" / "simplify" / "hooks" / "scripts" / "guard.py"
-COMPLETION_SIGNAL = "echo simplify-guard:complete"
 BYPASS_SIGNAL = "echo simplify-guard:bypass"
 
 
 class SimplifyGuardTest(unittest.TestCase):
+    """Test the cross-tool commit guard."""
+
     def setUp(self) -> None:
+        """Create an isolated Git worktree and non-repository session directory."""
         self.temp_dir = tempfile.TemporaryDirectory()
-        self.repo = Path(self.temp_dir.name)
+        self.session_dir = Path(self.temp_dir.name)
+        self.repo = self.session_dir / "repo"
         subprocess.run(["git", "init", "-q", str(self.repo)], check=True)
         self.marker = self.repo / ".git" / "simplify-guard.ok"
 
     def tearDown(self) -> None:
+        """Remove the temporary worktree."""
         self.temp_dir.cleanup()
 
     def run_guard(
@@ -33,11 +38,25 @@ class SimplifyGuardTest(unittest.TestCase):
         *,
         codex: bool = False,
         claude: bool = False,
+        cwd: Path | None = None,
         skill: str | None = None,
     ) -> dict | None:
+        """Run the guard with one hook payload.
+
+        Args:
+            event (str): Hook event name.
+            command (str, optional): Shell command supplied to the hook.
+            codex (bool, optional): Whether to send a Codex payload.
+            claude (bool, optional): Whether to set the Claude Code environment.
+            cwd (Path | None, optional): Session working directory.
+            skill (str | None, optional): Claude Code skill name.
+
+        Returns:
+            (dict | None): Hook response when the command is denied.
+        """
         payload = {
             "hook_event_name": event,
-            "cwd": str(self.repo),
+            "cwd": str(cwd or self.repo),
             "tool_input": {"command": command},
         }
         if codex:
@@ -61,13 +80,30 @@ class SimplifyGuardTest(unittest.TestCase):
         )
         return json.loads(result.stdout) if result.stdout else None
 
+    def completion_signal(self, repo: Path | None = None) -> str:
+        """Build a completion signal for a reviewed worktree.
+
+        Args:
+            repo (Path | None, optional): Reviewed worktree path.
+
+        Returns:
+            (str): Shell-safe completion command.
+        """
+        return shlex.join(["echo", "simplify-guard:complete", str(repo or self.repo)])
+
     def assert_denied(self, output: dict | None) -> None:
+        """Assert that a hook response denies the command.
+
+        Args:
+            output (dict | None): Hook response to inspect.
+        """
         self.assertEqual(
             output["hookSpecificOutput"]["permissionDecision"],
             "deny",
         )
 
     def test_claude_and_codex_commits_are_denied_before_simplify(self) -> None:
+        """Deny supported commit forms before simplify runs."""
         for runtime in ("codex", "claude"):
             for command in (
                 "git commit -m test",
@@ -79,9 +115,10 @@ class SimplifyGuardTest(unittest.TestCase):
                     self.assert_denied(self.run_guard("PreToolUse", command, **{runtime: True}))
 
     def test_git_c_uses_the_target_worktree_marker(self) -> None:
+        """Keep completion bound to its reviewed worktree."""
         other_repo = self.repo / "other repo"
         subprocess.run(["git", "init", "-q", str(other_repo)], check=True)
-        self.assertIsNone(self.run_guard("PreToolUse", COMPLETION_SIGNAL, codex=True))
+        self.assertIsNone(self.run_guard("PreToolUse", self.completion_signal(), codex=True))
         self.assert_denied(
             self.run_guard(
                 "PreToolUse",
@@ -91,40 +128,61 @@ class SimplifyGuardTest(unittest.TestCase):
         )
         self.assertTrue(self.marker.exists())
 
-    def test_codex_completion_allows_exactly_one_commit_attempt(self) -> None:
-        self.assertIsNone(self.run_guard("PreToolUse", COMPLETION_SIGNAL, codex=True))
-        self.assertTrue(self.marker.exists())
-
-        self.assertIsNone(self.run_guard("PreToolUse", "git commit -m test", codex=True))
-        self.assertFalse(self.marker.exists())
-        self.assert_denied(self.run_guard("PreToolUse", "git commit -m again", codex=True))
+    def test_completion_allows_exactly_one_commit_attempt(self) -> None:
+        """Allow one commit attempt after completion."""
+        for runtime in ("codex", "claude"):
+            with self.subTest(runtime=runtime):
+                self.assertIsNone(self.run_guard("PreToolUse", self.completion_signal(), **{runtime: True}))
+                self.assertTrue(self.marker.exists())
+                self.assertIsNone(self.run_guard("PreToolUse", "git commit -m test", **{runtime: True}))
+                self.assertFalse(self.marker.exists())
+                self.assert_denied(self.run_guard("PreToolUse", "git commit -m again", **{runtime: True}))
 
     def test_explicit_user_bypass_allows_exactly_one_commit_attempt(self) -> None:
+        """Allow one commit attempt after an explicit bypass."""
+        for runtime in ("codex", "claude"):
+            with self.subTest(runtime=runtime):
+                self.assertIsNone(self.run_guard("PreToolUse", BYPASS_SIGNAL, **{runtime: True}))
+                self.assertTrue(self.marker.exists())
+                self.assertIsNone(self.run_guard("PreToolUse", "git commit -m test", **{runtime: True}))
+                self.assertFalse(self.marker.exists())
+                self.assert_denied(self.run_guard("PreToolUse", "git commit -m again", **{runtime: True}))
+
+    def test_completion_targets_a_repo_outside_the_session_cwd(self) -> None:
+        """Bind completion when the session directory is not a repository."""
         for runtime in ("codex", "claude"):
             with self.subTest(runtime=runtime):
                 self.assertIsNone(
-                    self.run_guard("PreToolUse", BYPASS_SIGNAL, **{runtime: True})
+                    self.run_guard(
+                        "PreToolUse",
+                        self.completion_signal(),
+                        cwd=self.session_dir,
+                        **{runtime: True},
+                    )
                 )
-                self.assertTrue(self.marker.exists())
                 self.assertIsNone(
-                    self.run_guard("PreToolUse", "git commit -m test", **{runtime: True})
+                    self.run_guard(
+                        "PreToolUse",
+                        f"git -C {self.repo} commit -m test",
+                        cwd=self.session_dir,
+                        **{runtime: True},
+                    )
                 )
-                self.assertFalse(self.marker.exists())
                 self.assert_denied(
-                    self.run_guard("PreToolUse", "git commit -m again", **{runtime: True})
+                    self.run_guard(
+                        "PreToolUse",
+                        f"git -C {self.repo} commit -m again",
+                        cwd=self.session_dir,
+                        **{runtime: True},
+                    )
                 )
 
-    def test_claude_skill_event_still_allows_one_commit_attempt(self) -> None:
-        self.assertIsNone(self.run_guard("PostToolUse", skill="simplify", claude=True))
-        self.assertTrue(self.marker.exists())
-        self.assertIsNone(self.run_guard("PreToolUse", "git commit -m test", claude=True))
-        self.assertFalse(self.marker.exists())
-
-    def test_only_runtime_specific_completion_events_mint(self) -> None:
+    def test_only_supported_completion_events_mint(self) -> None:
+        """Ignore incomplete or unsupported completion events."""
         cases = [
-            {"event": "PostToolUse", "skill": "simplify", "codex": True},
-            {"event": "PreToolUse", "command": COMPLETION_SIGNAL, "claude": True},
-            {"event": "PreToolUse", "command": COMPLETION_SIGNAL},
+            {"event": "PostToolUse", "skill": "simplify", "claude": True},
+            {"event": "PreToolUse", "command": "echo simplify-guard:complete", "codex": True},
+            {"event": "PreToolUse", "command": self.completion_signal()},
             {"event": "PreToolUse", "command": BYPASS_SIGNAL},
             {
                 "event": "PreToolUse",
@@ -143,9 +201,11 @@ class SimplifyGuardTest(unittest.TestCase):
                 self.assertFalse(self.marker.exists())
 
     def test_other_runtimes_are_not_blocked_or_minted(self) -> None:
+        """Leave runtimes without a completion path unchanged."""
         self.assertIsNone(self.run_guard("PreToolUse", "git commit -m test"))
 
     def test_quoted_commit_text_and_commit_helpers_are_ignored(self) -> None:
+        """Ignore quoted text and non-commit Git commands."""
         self.assertIsNone(self.run_guard("PreToolUse", 'echo "git commit -m test"', codex=True))
         self.assertIsNone(self.run_guard("PreToolUse", "git commit-tree HEAD^{tree}", codex=True))
         self.assertIsNone(self.run_guard("PreToolUse", "git log commit", codex=True))

--- a/plugins/simplify/.claude-plugin/plugin.json
+++ b/plugins/simplify/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/.codex-plugin/plugin.json
+++ b/plugins/simplify/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/.cursor-plugin/plugin.json
+++ b/plugins/simplify/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "simplify",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/simplify/gemini-extension.json
+++ b/plugins/simplify/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "simplify",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Review changed code for reuse, redundancy, and over-engineering, then apply fixes."
 }

--- a/plugins/simplify/hooks/hooks.json
+++ b/plugins/simplify/hooks/hooks.json
@@ -1,12 +1,6 @@
 {
   "description": "simplify-guard: require /simplify or an explicit one-time user bypass before each git commit attempt in a worktree",
   "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Skill",
-        "hooks": [{ "type": "command", "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/guard.py\"" }]
-      }
-    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/plugins/simplify/hooks/scripts/guard.py
+++ b/plugins/simplify/hooks/scripts/guard.py
@@ -2,10 +2,10 @@
 """Block `git commit` until /simplify runs or the user requests a one-time bypass.
 
 The marker lives in the per-worktree Git directory because /simplify reviews
-the worktree's index. Claude Code mints it through the Skill event; Codex mints
-it through the explicit completion signal at the end of the skill. An agent can
-mint the same one-use permission when the user explicitly asks to skip
-/simplify. Other runtimes remain unblocked because they have no supported path.
+the worktree's index. Claude Code and Codex mint it through an explicit
+completion signal carrying the reviewed worktree. An agent can mint the same
+one-use permission when the user explicitly asks to skip /simplify. Other
+runtimes remain unblocked because they have no supported path.
 """
 
 import json
@@ -19,8 +19,8 @@ data = json.load(sys.stdin)
 event = data.get("hook_event_name", "")
 tool_input = data.get("tool_input") or {}
 
-COMPLETION_SIGNAL = "echo simplify-guard:complete"
-BYPASS_SIGNAL = "echo simplify-guard:bypass"
+COMPLETION_SIGNAL = ("echo", "simplify-guard:complete")
+BYPASS_SIGNAL = ("echo", "simplify-guard:bypass")
 SHELL_OPERATORS = {";", "&&", "||", "|", "(", ")"}
 GIT_OPTIONS_WITH_VALUES = {"-C", "-c", "--config-env", "--git-dir", "--namespace", "--work-tree"}
 GIT_OPTIONS_WITHOUT_SUBCOMMAND = {
@@ -35,6 +35,14 @@ GIT_OPTIONS_WITHOUT_SUBCOMMAND = {
 
 
 def marker(git=("git",)):
+    """Return the one-use marker for a Git worktree.
+
+    Args:
+        git (tuple[str, ...], optional): Git executable and global options.
+
+    Returns:
+        (Path | None): Marker path when the command resolves a Git directory.
+    """
     git_dir = subprocess.run(
         [*git, "rev-parse", "--path-format=absolute", "--git-dir"],
         capture_output=True,
@@ -44,35 +52,15 @@ def marker(git=("git",)):
     return Path(git_dir) / "simplify-guard.ok" if git_dir else None
 
 
-def session_marker():
-    """Fallback for when the session cwd is not a Git repository at all.
+def commit_prefix(tokens):
+    """Return the safe Git prefix for a commit command.
 
-    The per-worktree marker above stays the primary, but minting it resolves a git dir
-    from the SESSION cwd, and that fails outright when the session runs from a plain
-    directory that merely contains checkouts, for example a home directory holding
-    several worktrees. In that layout /simplify can never arm the guard: the mint is a
-    silent no-op while the PreToolUse check still resolves the correct per-worktree path
-    and denies. Every commit is refused no matter how many reviews ran, and the only way
-    through is to create the marker by hand, which defeats the guard.
+    Args:
+        tokens (list[str]): Shell tokens to inspect.
 
-    Keyed by session id where the runtime supplies one, so concurrent sessions cannot
-    spend each other's token. Still consumed on every commit attempt, so the one review
-    per commit rule is unchanged.
+    Returns:
+        (list[str] | None): Git executable and global options before `commit`.
     """
-    session = str(data.get("session_id") or data.get("sessionId") or "shared")
-    safe = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in session)[:64]
-    directory = Path.home() / ".claude" / "simplify-guard"
-    try:
-        directory.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        return None
-    return directory / ("%s.ok" % safe)
-
-
-def commit_prefix(command):
-    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
-    lexer.whitespace_split = True
-    tokens = list(lexer)
     for start, arg in enumerate(tokens):
         if Path(arg).name != "git":
             continue
@@ -91,38 +79,28 @@ def commit_prefix(command):
 
 
 def main():
-    is_claude = os.environ.get("CLAUDECODE") == "1"
-    is_codex = bool(data.get("turn_id"))
-
-    if event == "PostToolUse":
-        # Mint both. The per-worktree marker is the precise one and is preferred when
-        # spending, the session marker only carries the review when the session cwd is
-        # not a repo and the precise path cannot be resolved at all.
-        if is_claude and tool_input.get("skill") == "simplify":
-            for m in (marker(), session_marker()):
-                if m:
-                    m.touch()
-        return
-
-    if event != "PreToolUse" or not (is_claude or is_codex):
+    """Run the guard for one hook event."""
+    if event != "PreToolUse" or not (os.environ.get("CLAUDECODE") == "1" or data.get("turn_id")):
         return
 
     command = tool_input.get("command", "")
-    signal = command.strip()
-    if signal == BYPASS_SIGNAL or (is_codex and signal == COMPLETION_SIGNAL):
-        for m in (marker(), session_marker()):
-            if m:
-                m.touch()
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+    lexer.whitespace_split = True
+    tokens = list(lexer)
+    if len(tokens) == 3 and tuple(tokens[:2]) == COMPLETION_SIGNAL:
+        if m := marker(("git", "-C", tokens[2])):
+            m.touch()
+        return
+    if tuple(tokens) == BYPASS_SIGNAL:
+        if m := marker():
+            m.touch()
         return
 
-    if not (git := commit_prefix(command)):
+    if not (git := commit_prefix(tokens)) or not (m := marker(git)):
         return
 
-    # Prefer the worktree this commit targets, fall back to the session marker.
-    spend = next((m for m in (marker(git), session_marker()) if m and m.exists()), None)
-
-    if spend:
-        spend.unlink()  # spend the token before Git runs; every attempt needs a fresh review
+    if m.exists():
+        m.unlink()  # spend the token before Git runs. Every attempt needs a fresh review
         return
 
     print(

--- a/plugins/simplify/hooks/scripts/guard.py
+++ b/plugins/simplify/hooks/scripts/guard.py
@@ -44,6 +44,31 @@ def marker(git=("git",)):
     return Path(git_dir) / "simplify-guard.ok" if git_dir else None
 
 
+def session_marker():
+    """Fallback for when the session cwd is not a Git repository at all.
+
+    The per-worktree marker above stays the primary, but minting it resolves a git dir
+    from the SESSION cwd, and that fails outright when the session runs from a plain
+    directory that merely contains checkouts, for example a home directory holding
+    several worktrees. In that layout /simplify can never arm the guard: the mint is a
+    silent no-op while the PreToolUse check still resolves the correct per-worktree path
+    and denies. Every commit is refused no matter how many reviews ran, and the only way
+    through is to create the marker by hand, which defeats the guard.
+
+    Keyed by session id where the runtime supplies one, so concurrent sessions cannot
+    spend each other's token. Still consumed on every commit attempt, so the one review
+    per commit rule is unchanged.
+    """
+    session = str(data.get("session_id") or data.get("sessionId") or "shared")
+    safe = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in session)[:64]
+    directory = Path.home() / ".claude" / "simplify-guard"
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    return directory / ("%s.ok" % safe)
+
+
 def commit_prefix(command):
     lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
     lexer.whitespace_split = True
@@ -70,8 +95,13 @@ def main():
     is_codex = bool(data.get("turn_id"))
 
     if event == "PostToolUse":
-        if is_claude and tool_input.get("skill") == "simplify" and (m := marker()):
-            m.touch()
+        # Mint both. The per-worktree marker is the precise one and is preferred when
+        # spending, the session marker only carries the review when the session cwd is
+        # not a repo and the precise path cannot be resolved at all.
+        if is_claude and tool_input.get("skill") == "simplify":
+            for m in (marker(), session_marker()):
+                if m:
+                    m.touch()
         return
 
     if event != "PreToolUse" or not (is_claude or is_codex):
@@ -80,15 +110,19 @@ def main():
     command = tool_input.get("command", "")
     signal = command.strip()
     if signal == BYPASS_SIGNAL or (is_codex and signal == COMPLETION_SIGNAL):
-        if m := marker():
-            m.touch()
+        for m in (marker(), session_marker()):
+            if m:
+                m.touch()
         return
 
-    if not (git := commit_prefix(command)) or not (m := marker(git)):
+    if not (git := commit_prefix(command)):
         return
 
-    if m.exists():
-        m.unlink()  # spend the token before Git runs; every attempt needs a fresh review
+    # Prefer the worktree this commit targets, fall back to the session marker.
+    spend = next((m for m in (marker(git), session_marker()) if m and m.exists()), None)
+
+    if spend:
+        spend.unlink()  # spend the token before Git runs; every attempt needs a fresh review
         return
 
     print(

--- a/plugins/simplify/skills/simplify/SKILL.md
+++ b/plugins/simplify/skills/simplify/SKILL.md
@@ -52,16 +52,14 @@ Check that each change is implemented at the right depth, not as a fragile banda
 
 Wait for all four agents to complete, dedup findings that point at the same line or mechanism, and fix each remaining one directly. Skip any finding whose fix would change intended behavior, require changes well outside the reviewed diff, or that you judge to be a false positive, note the skip rather than arguing with it.
 
-## Phase 3 — Mark completion in Codex
+## Phase 3: Mark completion
 
-In Codex only, after all accepted fixes are applied, run this exact command from the reviewed worktree:
+After all accepted fixes are applied, resolve the reviewed worktree with `git -C '<reviewed-worktree>' rev-parse --show-toplevel`, then put that absolute path in this command:
 
 ```bash
-echo simplify-guard:complete
+echo simplify-guard:complete '/absolute/path/to/reviewed/worktree'
 ```
 
-Codex loads skills as instructions instead of emitting a Skill tool event. This command lets the bundled guard record completion. Do not run it before the review and cleanup phases finish.
-
-Claude Code should skip this phase because its `PostToolUse` Skill hook records completion automatically.
+This lets the bundled guard record completion against the reviewed worktree even when the session started elsewhere. Do not run it before the review and cleanup phases finish.
 
 Finish with a brief summary of what was fixed and what was skipped (or confirm the code was already clean).


### PR DESCRIPTION
Sessions started above a checkout could finish simplify without minting that worktree’s commit marker.

- names the reviewed worktree for Claude Code and Codex
- one marker permits one attempt in one repository
- removes the session marker and Claude-only skill hook