### PR TITLE
Catch GitHub close comments in Humanize

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/test_humanize.py
+++ b/.github/scripts/test_humanize.py
@@ -144,6 +144,18 @@ class HumanizeTest(unittest.TestCase):
         for tool, tool_input, source in cases:
             self.assertIn(source, run_hook(tool, tool_input))
 
+    def test_checks_github_close_comments_from_shell_tools(self):
+        """Check close comments from Claude and Codex shell calls."""
+        cases = (
+            ("Bash", {"command": f'gh pr close 106 --comment "Old{SEMICOLON} new"'}),
+            ("exec_command", {"cmd": f'gh issue close 105 -c "Fixed{SEMICOLON} thanks"'}),
+        )
+        for tool, tool_input in cases:
+            self.assertIn("semicolon at GitHub comment:1:", run_hook(tool, tool_input))
+        self.assertEqual(run_hook("Bash", {"command": "gh pr review 106 -c"}), "")
+        self.assertEqual(run_hook("Bash", {"command": "gh pr close 106 && gh pr review 106 -c"}), "")
+        self.assertEqual(run_hook("exec_command", {"cmd": "git status --short"}), "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/gemini-extension.json
+++ b/plugins/humanize/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "humanize",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Block a curated list of AI buzzwords on every write with a hook."
 }

--- a/plugins/humanize/hooks/hooks.json
+++ b/plugins/humanize/hooks/hooks.json
@@ -12,7 +12,7 @@
         ]
       },
       {
-        "matcher": "Bash",
+        "matcher": "Bash|exec_command",
         "hooks": [
           {
             "type": "command",

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -247,12 +247,22 @@ def bash_text(command):
         tokens = shlex.split(stripped, comments=False)
     except ValueError:
         tokens = stripped.split()
+    close_comment = False
     for i, tok in enumerate(tokens):
+        if tok in {"&&", "||", ";", "|", "&"}:
+            close_comment = False
+            continue
+        if tokens[i : i + 3] in (["gh", "pr", "close"], ["gh", "issue", "close"]):
+            close_comment = True
         key, sep, val = tok.partition("=")
         if tok in flags and i + 1 < len(tokens):
             parts.append((flags[tok], tokens[i + 1]))
         elif sep and key in flags:
             parts.append((flags[key], val))
+        elif close_comment and tok in {"-c", "--comment"} and i + 1 < len(tokens):
+            parts.append(("GitHub comment", tokens[i + 1]))
+        elif close_comment and sep and key in {"-c", "--comment"}:
+            parts.append(("GitHub comment", val))
         elif gh and tok in FIELD_FLAGS and i + 1 < len(tokens):
             field, _, value = tokens[i + 1].partition("=")
             if field in {"body", "title"} and not value.startswith("@"):
@@ -332,7 +342,7 @@ def mcp_text(obj):
 
 def extract(tool, tool_input):
     """Return source-preserving regions for a tool call."""
-    command = tool_input.get("command", "")
+    command = tool_input.get("command", tool_input.get("cmd", ""))
     if isinstance(command, list):  # Codex sends the shell tool an argv array, Claude Code a string
         command = " ".join(str(c) for c in command)
     if tool.startswith("mcp__"):
@@ -343,7 +353,7 @@ def extract(tool, tool_input):
             kind = "message" if field in MESSAGE_KEYS else field.replace("_", " ")
             regions.append(Region(f"{server.replace('_', ' ').title()} {kind}", md_text(text)))
         return regions
-    if tool == "Bash":
+    if tool in {"Bash", "exec_command"}:
         return [Region(source, md_text(text)) for source, text in bash_text(command)] + heredoc_writes(command)
     if tool == "apply_patch":
         return patch_regions(command)


### PR DESCRIPTION
Humanize checked PR bodies but missed close comments sent through Codex shell calls.

```diff
- Bash only
+ Bash and exec_command
- close comments skipped
+ close comments parsed per gh invocation
```

- keeps overloaded review flags out of comment parsing
- adds regression coverage and bumps Humanize to 1.2.2