### PR TITLE
Use Claude Code's new Concise style

### DIFF
--- a/.claude/settings-kimi.json
+++ b/.claude/settings-kimi.json
@@ -157,10 +157,9 @@
       }
     ]
   },
-  "outputStyle": "ADHD Explanatory",
+  "outputStyle": "Concise",
   "model": "opus",
   "enabledPlugins": {
-    "adhd-output-style@claude-settings": true,
     "intelligent-compact@claude-settings": true,
     "github-dev@claude-settings": true,
     "humanize@claude-settings": true,

--- a/.claude/settings-minimax.json
+++ b/.claude/settings-minimax.json
@@ -157,10 +157,9 @@
       }
     ]
   },
-  "outputStyle": "ADHD Explanatory",
+  "outputStyle": "Concise",
   "model": "opus",
   "enabledPlugins": {
-    "adhd-output-style@claude-settings": true,
     "intelligent-compact@claude-settings": true,
     "github-dev@claude-settings": true,
     "humanize@claude-settings": true,

--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -156,10 +156,9 @@
       }
     ]
   },
-  "outputStyle": "ADHD Explanatory",
+  "outputStyle": "Concise",
   "model": "opus",
   "enabledPlugins": {
-    "adhd-output-style@claude-settings": true,
     "intelligent-compact@claude-settings": true,
     "github-dev@claude-settings": true,
     "humanize@claude-settings": true,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -226,7 +226,7 @@
   },
   "ultracode": false,
   "enableWorkflows": true,
-  "outputStyle": "ADHD Explanatory",
+  "outputStyle": "Concise",
   "model": "opus",
   "advisorModel": "claude-opus-5",
   "autoScrollEnabled": false,
@@ -237,7 +237,6 @@
     "refreshInterval": 60
   },
   "enabledPlugins": {
-    "adhd-output-style@claude-settings": true,
     "intelligent-compact@claude-settings": true,
     "github-dev@claude-settings": true,
     "humanize@claude-settings": true,


### PR DESCRIPTION
Claude Code 2.1.237 adds a built-in Concise style, so the shared profiles can drop the plugin-forced explanatory override.

- selects Concise in all 4 Claude settings profiles
- removes the ADHD output plugin entry that forced its own style