### PR TITLE
Add reusable SEO and writing skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -387,6 +387,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "research"
+    },
+    {
+      "name": "seo-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/seo-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "search"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -166,12 +166,12 @@
     {
       "name": "frontend-design-skills",
       "source": "./plugins/frontend-design-skills",
-      "description": "Design skills from Anthropic and OpenAI for landing pages and web apps.",
-      "version": "1.0.2",
+      "description": "Design distinctive frontends and write clear interface copy.",
+      "version": "1.1.0",
       "license": "Apache-2.0",
-      "keywords": ["frontend", "design", "ui", "landing-page", "web-design"],
+      "keywords": ["frontend", "design", "ui", "landing-page", "web-design", "writing", "interface-copy"],
       "category": "frontend",
-      "tags": ["frontend", "design", "skills"]
+      "tags": ["frontend", "design", "writing"]
     },
     {
       "name": "mongodb-skills",
@@ -492,6 +492,16 @@
       "keywords": ["overleaf", "latex", "review", "comments", "academic", "writing"],
       "category": "research",
       "tags": ["research", "academic", "latex"]
+    },
+    {
+      "name": "seo-skills",
+      "source": "./plugins/seo-skills",
+      "description": "Audit SEO, plan scalable pages, validate schema, and improve site architecture.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": ["seo", "audit", "structured-data", "schema", "site-architecture", "organic-search"],
+      "category": "search",
+      "tags": ["seo", "search", "site-audit"]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -89,8 +89,8 @@
     {
       "name": "frontend-design-skills",
       "source": "./plugins/frontend-design-skills",
-      "description": "Design skills from Anthropic and OpenAI for landing pages and web apps.",
-      "version": "1.0.2",
+      "description": "Design distinctive frontends and write clear interface copy.",
+      "version": "1.1.0",
       "license": "Apache-2.0"
     },
     {
@@ -225,6 +225,13 @@
       "description": "Pull Overleaf review comments into your .tex repo and apply the edits.",
       "version": "1.0.2",
       "license": "Apache-2.0"
+    },
+    {
+      "name": "seo-skills",
+      "source": "./plugins/seo-skills",
+      "description": "Audit SEO, plan scalable pages, validate schema, and improve site architecture.",
+      "version": "1.0.0",
+      "license": "MIT"
     }
   ]
 }

--- a/.github/scripts/_helpers.sh
+++ b/.github/scripts/_helpers.sh
@@ -86,7 +86,8 @@ create_zip() {
   fi
 
   rm -f "$skill_dir/$zip_name"
-  (cd "$skill_dir" && zip -r "$zip_name" . -x '*.zip')
+  find "$skill_dir" -exec touch -t 198001010000 {} +
+  (cd "$skill_dir" && zip -X -r "$zip_name" . -x '*.zip')
 
   echo "Created $1/$zip_name"
 }

--- a/.github/scripts/seo-skills/validate_schema.mjs
+++ b/.github/scripts/seo-skills/validate_schema.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+const MAX_JSON_LENGTH = 100_000;
+const DATE_PROPERTIES = new Set([
+  "datePublished",
+  "dateModified",
+  "startDate",
+  "endDate",
+  "priceValidUntil",
+  "validFrom",
+  "validThrough",
+]);
+const URL_PROPERTIES = new Set(["url", "logo", "image", "item", "target"]);
+const ISO_8601 =
+  /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+const ABSOLUTE_URL = /^https?:\/\//;
+
+const inputPath = process.argv[2];
+if (!inputPath || process.argv.length > 3) {
+  console.error("Usage: node scripts/validate_schema.mjs <jsonld-file|->");
+  process.exit(2);
+}
+
+const result = { errors: [], types: [], valid: false, warnings: [] };
+const finish = (exitCode) => {
+  result.valid = result.errors.length === 0;
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(exitCode ?? (result.valid ? 0 : 1));
+};
+
+let jsonld;
+try {
+  jsonld =
+    inputPath === "-"
+      ? await new Promise((resolve, reject) => {
+          let data = "";
+          process.stdin.setEncoding("utf8");
+          process.stdin.on("data", (chunk) => {
+            data += chunk;
+          });
+          process.stdin.on("end", () => resolve(data));
+          process.stdin.on("error", reject);
+        })
+      : await readFile(inputPath, "utf8");
+} catch (error) {
+  result.errors.push(`Could not read JSON-LD: ${error.message}`);
+  finish();
+}
+
+if (jsonld.length === 0) {
+  result.errors.push("JSON-LD input is empty.");
+  finish();
+}
+if (jsonld.length > MAX_JSON_LENGTH) {
+  result.errors.push(`JSON-LD exceeds ${MAX_JSON_LENGTH} characters.`);
+  finish();
+}
+
+let document;
+try {
+  document = JSON.parse(jsonld);
+} catch (error) {
+  result.errors.push(`Not valid JSON: ${error.message}`);
+  finish();
+}
+
+let required;
+try {
+  required = JSON.parse(
+    await readFile(new URL("../references/required-properties.json", import.meta.url), "utf8")
+  );
+} catch (error) {
+  result.errors.push(`Could not read the required-property map: ${error.message}`);
+  finish();
+}
+
+const isObject = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
+const objectNodes = (values) => values.filter(isObject);
+const nodesOf = (value) => {
+  if (Array.isArray(value)) return objectNodes(value);
+  if (!isObject(value)) return [];
+  return Array.isArray(value["@graph"]) ? objectNodes(value["@graph"]) : [value];
+};
+const typesOf = (node) => {
+  const type = node["@type"];
+  if (typeof type === "string") return [type];
+  return Array.isArray(type) ? type.filter((value) => typeof value === "string") : [];
+};
+
+const nodes = nodesOf(document);
+if (nodes.length === 0) {
+  result.errors.push("No JSON-LD entity found. Expected an object, an array, or an @graph.");
+}
+if (isObject(document) && !document["@context"]) {
+  result.warnings.push('Top level is missing "@context": "https://schema.org".');
+}
+
+for (const node of nodes) {
+  const types = typesOf(node);
+  if (types.length === 0) result.errors.push("An entity has no @type.");
+  result.types.push(...types);
+
+  for (const type of types) {
+    for (const property of required[type] ?? []) {
+      if (node[property] === undefined || node[property] === null) {
+        result.errors.push(`${type} is missing the required property "${property}".`);
+      }
+    }
+  }
+
+  const label = types[0] ?? "node";
+  for (const [key, value] of Object.entries(node)) {
+    if (typeof value !== "string") continue;
+    if (DATE_PROPERTIES.has(key) && !ISO_8601.test(value)) {
+      result.errors.push(`${label}.${key} is not an ISO 8601 date: "${value}".`);
+    }
+    if (URL_PROPERTIES.has(key) && !ABSOLUTE_URL.test(value)) {
+      result.errors.push(`${label}.${key} must be an absolute URL: "${value}".`);
+    }
+  }
+}
+
+finish();

--- a/.github/scripts/sync-frontend-skills.sh
+++ b/.github/scripts/sync-frontend-skills.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Sync frontend design skills from OpenAI and Anthropic into plugins/frontend-design-skills.
+# Sync frontend design and writing skills from OpenAI, Anthropic, and Vercel into plugins/frontend-design-skills.
 # Usage: bash .github/scripts/sync-frontend-skills.sh
 
 set -euo pipefail
@@ -20,6 +20,11 @@ t = open(p).read()
 open(p, 'w').write(t.replace('name: frontend-app-builder', 'name: openai-frontend-design'))
 "
 
+sed -i '' '/^# Frontend App Builder$/a\
+\
+For interface copy and supporting text, read and apply the installed `writing-guidelines` skill.
+' "$REPO_ROOT/plugins/frontend-design-skills/skills/openai-frontend-design/SKILL.md"
+
 create_zip "plugins/frontend-design-skills/skills/openai-frontend-design"
 
 # --- Anthropic frontend skill ---
@@ -37,6 +42,45 @@ t = t.replace('name: frontend-design', 'name: anthropic-frontend-design')
 t = t.replace('license: Complete terms in LICENSE.txt', 'license: Apache-2.0')
 open(p, 'w').write(t)
 "
+
+sed -i '' '/^# Frontend Design$/a\
+\
+For interface copy and supporting text, read and apply the installed `writing-guidelines` skill.
+' "$REPO_ROOT/plugins/frontend-design-skills/skills/anthropic-frontend-design/SKILL.md"
+
 create_zip "plugins/frontend-design-skills/skills/anthropic-frontend-design"
+
+# --- Vercel writing guidelines ---
+clone_or_update https://github.com/vercel-labs/writing-guidelines vercel-writing-guidelines
+
+sync_dir "$HOME/dev/vercel-writing-guidelines" \
+  "plugins/frontend-design-skills/skills/writing-guidelines" \
+  "command.md"
+
+WRITING_DIR="$REPO_ROOT/plugins/frontend-design-skills/skills/writing-guidelines"
+mv "$WRITING_DIR/command.md" "$WRITING_DIR/SKILL.md"
+python3 -c "
+p = '$WRITING_DIR/SKILL.md'
+t = open(p).read()
+t = t.replace('---\ndescription:', '---\nname: writing-guidelines\ndescription:', 1)
+t = t.replace('argument-hint: <file-or-pattern>', 'metadata:\n  argument-hint: <file-or-pattern>', 1)
+open(p, 'w').write(t)
+"
+sed -i '' \
+  -e 's|^description:.*$|description: This skill should be used when the user asks to "review writing", "check documentation style", "audit interface copy", or "apply writing guidelines".|' \
+  -e 's|^Review these files for compliance: \$ARGUMENTS$|Review the files or patterns provided by the user for compliance.|' \
+  -e 's|only for deliberate Vercel actions|only for deliberate organization actions|' \
+  -e 's|^- Dashboard deep links use.*$|- Dashboard links should open the exact destination and preserve required context in the URL.|' \
+  -e 's|^- Link to canonical product docs.*$|- Link to canonical product documentation when relevant.|' \
+  -e 's|^- AI Gateway model catalog:.*$|- Link to the canonical model catalog for the selected provider when examples name models.|' \
+  -e 's|sample repo in `vercel/examples` for multi-step tutorials|a sample repository for multi-step tutorials|' \
+  -e 's|"Vercel Sandbox"|"Cloud Sandbox"|' \
+  "$WRITING_DIR/SKILL.md"
+ensure_license "plugins/frontend-design-skills/skills/writing-guidelines" MIT
+if rg -qi 'vercel' "$WRITING_DIR/SKILL.md"; then
+  echo "ERROR: writing-guidelines must remain vendor-neutral" >&2
+  exit 1
+fi
+create_zip "plugins/frontend-design-skills/skills/writing-guidelines"
 
 echo "Done syncing frontend-design-skills."

--- a/.github/scripts/sync-seo-skills.sh
+++ b/.github/scripts/sync-seo-skills.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Sync SEO skills from Vercel Labs into plugins/seo-skills.
+# Usage: bash .github/scripts/sync-seo-skills.sh
+
+set -euo pipefail
+source "$(dirname "$0")/_helpers.sh"
+
+clone_or_update https://github.com/vercel-labs/marketing-team-eve-template vercel-marketing-team-eve-template
+
+SRC="$HOME/dev/vercel-marketing-team-eve-template/agent/subagents/seo/skills"
+SKILLS=(seo-audit programmatic-seo schema site-architecture)
+
+for skill in "${SKILLS[@]}"; do
+  sync_dir "$SRC/$skill" "plugins/seo-skills/skills/$skill" "SKILL.md" "references/"
+  skill_md="$REPO_ROOT/plugins/seo-skills/skills/$skill/SKILL.md"
+  if ! rg -q '^name:' "$skill_md"; then
+    sed -i '' "1a\\
+name: $skill
+" "$skill_md"
+  fi
+  ensure_license "plugins/seo-skills/skills/$skill" MIT
+done
+
+SCHEMA_DIR="$REPO_ROOT/plugins/seo-skills/skills/schema"
+sed -i '' \
+  's/the form `validate_schema` reads/the form the bundled validator reads/' \
+  "$SCHEMA_DIR/SKILL.md"
+sed -i '' \
+  's/Run `validate_schema` on any block before you hand it over\./From this skill directory, run `node scripts\/validate_schema.mjs <jsonld-file>` on any block before you hand it over./' \
+  "$SCHEMA_DIR/SKILL.md"
+
+mkdir -p "$SCHEMA_DIR/scripts"
+cp "$REPO_ROOT/.github/scripts/seo-skills/validate_schema.mjs" "$SCHEMA_DIR/scripts/"
+chmod +x "$SCHEMA_DIR/scripts/validate_schema.mjs"
+
+for skill in "${SKILLS[@]}"; do
+  create_zip "plugins/seo-skills/skills/$skill"
+done
+
+echo "Done syncing seo-skills."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,6 +398,8 @@ bash .github/scripts/sync-stripe-skills.sh
 bash .github/scripts/sync-polar-skills.sh
 bash .github/scripts/sync-livekit-skills.sh
 bash .github/scripts/sync-react-skills.sh
+bash .github/scripts/sync-frontend-skills.sh
+bash .github/scripts/sync-seo-skills.sh
 bash .github/scripts/sync-agent-browser-skills.sh
 bash .github/scripts/sync-anthropic-office-skills.sh
 bash .github/scripts/sync-openai-office-skills.sh

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Browser automation via CLI instead of MCP. [93% less context usage](https://medi
 </details>
 
 <details>
-<summary><strong>frontend-design-skills</strong> - Official frontend design skills (Anthropic + OpenAI)</summary>
+<summary><strong>frontend-design-skills</strong> - Frontend design and writing skills (Anthropic + OpenAI + Vercel)</summary>
 
 | Claude Code                                                    | Codex CLI                                                 | Gemini CLI                                                          |
 | -------------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
@@ -369,12 +369,13 @@ Browser automation via CLI instead of MCP. [93% less context usage](https://medi
 npx skills add https://github.com/fcakyon/claude-codex-settings/tree/main/plugins/frontend-design-skills --skill '*'
 ```
 
-Frontend design skills from [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) and [openai/plugins](https://github.com/openai/plugins).
+Frontend design and writing skills from [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official), [openai/plugins](https://github.com/openai/plugins), and [vercel-labs/writing-guidelines](https://github.com/vercel-labs/writing-guidelines).
 
 | Skill                                                                                                     | Description                                                                       | Install                                                                                                                                                                           |
 | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`openai-frontend-design`](./plugins/frontend-design-skills/skills/openai-frontend-design/SKILL.md)       | Composition-first design: restrained layout, image-led hierarchy, tasteful motion | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/openai-frontend-design.zip)    |
 | [`anthropic-frontend-design`](./plugins/frontend-design-skills/skills/anthropic-frontend-design/SKILL.md) | Bold aesthetic direction, distinctive typography, anti-generic AI aesthetics      | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/anthropic-frontend-design.zip) |
+| [`writing-guidelines`](./plugins/frontend-design-skills/skills/writing-guidelines/SKILL.md)               | Review interface copy and text for clear, consistent writing                      | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/writing-guidelines.zip)        |
 
 </details>
 
@@ -947,6 +948,32 @@ Pull reviewer comments from an Overleaf project, locate each in your local git-t
 
 </details>
 
+<details>
+<summary><strong>seo-skills</strong> - Audit search visibility, structured data, and site architecture</summary>
+
+| Claude Code                                        | Codex CLI                                     | Gemini CLI                                              |
+| -------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------- |
+| `claude plugin install seo-skills@claude-settings` | `codex plugin add seo-skills@claude-settings` | `gemini extensions install --path ./plugins/seo-skills` |
+
+**Skills CLI**
+
+```bash
+npx skills add https://github.com/fcakyon/claude-codex-settings/tree/main/plugins/seo-skills --skill '*'
+```
+
+SEO workflows from [vercel-labs/marketing-team-eve-template](https://github.com/vercel-labs/marketing-team-eve-template). Audit pages in evidence order, plan programmatic page sets, add valid JSON-LD, and improve hierarchy and internal linking. The schema skill includes a dependency-free Node validator for local JSON-LD checks.
+
+**Skills** (ZIP for claude.ai, Claude Code, Cursor, Codex, VS Code):
+
+| Skill                                                                         | Description                                                    | ZIP                                                                                                                                                                       |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`seo-audit`](./plugins/seo-skills/skills/seo-audit/SKILL.md)                 | Prioritized technical, on-page, content, and credibility audit | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/seo-audit.zip)         |
+| [`programmatic-seo`](./plugins/seo-skills/skills/programmatic-seo/SKILL.md)   | Plan template-driven page sets without thin content            | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/programmatic-seo.zip)  |
+| [`schema`](./plugins/seo-skills/skills/schema/SKILL.md)                       | Add and validate JSON-LD structured data                       | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/schema.zip)            |
+| [`site-architecture`](./plugins/seo-skills/skills/site-architecture/SKILL.md) | Plan hierarchy, navigation, URLs, and internal links           | [![ZIP](https://img.shields.io/badge/⬇%20ZIP-2ea44f?style=flat-square)](https://github.com/fcakyon/claude-codex-settings/releases/latest/download/site-architecture.zip) |
+
+</details>
+
 ---
 
 ## Configuration
@@ -1086,7 +1113,7 @@ exec "$@" --thinking-display summarized
 - [x] Deployment: [Cloudflare](https://www.cloudflare.com) platform skill
 - [x] Deployment: [Hetzner Cloud](https://www.hetzner.com/cloud) CLI skill
 - [x] Deployment: [Dokploy](https://github.com/Dokploy/dokploy) deployment skill
-- [x] Frontend design: Anthropic + OpenAI frontend design skills (bundled as `frontend-design-skills`)
+- [x] Frontend design: Anthropic + OpenAI + Vercel skills (bundled as `frontend-design-skills`)
 - [ ] Frontend: [TanStack](https://tanstack.com) (Router, Query, Table, Form)
 - [x] Real-time: [LiveKit](https://livekit.io) voice/video agent skill
 - [x] Documents: Google Docs, PPTX, DOCX, Excel from OpenAI (bundled as `openai-office-skills`)

--- a/plugins/frontend-design-skills/.claude-plugin/plugin.json
+++ b/plugins/frontend-design-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-design-skills",
-  "version": "1.0.2",
-  "description": "Design skills from Anthropic and OpenAI for landing pages and web apps.",
+  "version": "1.1.0",
+  "description": "Design distinctive frontends and write clear interface copy.",
   "license": "Apache-2.0"
 }

--- a/plugins/frontend-design-skills/.codex-plugin/plugin.json
+++ b/plugins/frontend-design-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-design-skills",
-  "version": "1.0.2",
-  "description": "Design skills from Anthropic and OpenAI for landing pages and web apps.",
+  "version": "1.1.0",
+  "description": "Design distinctive frontends and write clear interface copy.",
   "license": "Apache-2.0"
 }

--- a/plugins/frontend-design-skills/.cursor-plugin/plugin.json
+++ b/plugins/frontend-design-skills/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-design-skills",
-  "version": "1.0.2",
-  "description": "Design skills from Anthropic and OpenAI for landing pages and web apps.",
+  "version": "1.1.0",
+  "description": "Design distinctive frontends and write clear interface copy.",
   "license": "Apache-2.0"
 }

--- a/plugins/frontend-design-skills/gemini-extension.json
+++ b/plugins/frontend-design-skills/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "frontend-design-skills",
-  "version": "1.0.2",
-  "description": "Design skills from Anthropic and OpenAI for landing pages and web apps."
+  "version": "1.1.0",
+  "description": "Design distinctive frontends and write clear interface copy."
 }

--- a/plugins/frontend-design-skills/skills/anthropic-frontend-design/SKILL.md
+++ b/plugins/frontend-design-skills/skills/anthropic-frontend-design/SKILL.md
@@ -6,6 +6,8 @@ license: Apache-2.0
 
 # Frontend Design
 
+For interface copy and supporting text, read and apply the installed `writing-guidelines` skill.
+
 Approach this as the design lead at a small studio known for giving every client a visual identity that could not be mistaken for anyone else's. This client has already rejected proposals that felt templated, and is paying for a distinctive point of view: make deliberate, opinionated choices about palette, typography, and layout that are specific to this brief, and take one real aesthetic risk you can justify.
 
 ## Ground it in the subject

--- a/plugins/frontend-design-skills/skills/openai-frontend-design/SKILL.md
+++ b/plugins/frontend-design-skills/skills/openai-frontend-design/SKILL.md
@@ -5,6 +5,8 @@ description: Use for new frontend applications, dashboards, games, creative webs
 
 # Frontend App Builder
 
+For interface copy and supporting text, read and apply the installed `writing-guidelines` skill.
+
 Use this skill to create polished frontend apps, dashboards, games, creative websites, hero sections, redesigns, and other visually driven UI. Act first as a senior front-end designer, then as an engineer implementing an approved design spec.
 
 ## Core Standard

--- a/plugins/frontend-design-skills/skills/writing-guidelines/SKILL.md
+++ b/plugins/frontend-design-skills/skills/writing-guidelines/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: writing-guidelines
+description: This skill should be used when the user asks to "review writing", "check documentation style", "audit interface copy", or "apply writing guidelines".
+metadata:
+  argument-hint: <file-or-pattern>
+license: MIT
+---
+
+# Writing Guidelines
+
+Review the files or patterns provided by the user for compliance.
+
+Read files, check against rules below. Output concise but comprehensive: sacrifice grammar for brevity. High signal-to-noise.
+
+## Rules
+
+### Planning & content type
+
+- Every page has a plan (overview, goal, audience, content plan, open questions) referenced or linked
+- Content type declared in `meta.contentType`: `Tutorial`, `How-to`, `Reference`, `Conceptual`, `Troubleshooting`, or `Landing`
+- Title is user-shaped (the user's question), not feature-shaped (the engineer's name)
+- Page does one job: tutorial OR how-to OR reference, not three at once
+- Goal is verb-driven (Bloom's taxonomy): "configure", "explain", "debug" (testable)
+- Multi-audience pages: short shared opener, then technical subsections
+
+### Voice & tone
+
+- Active voice. Mental test: append "by monkeys". If the sentence parses, rewrite
+- Direct address: `you`, never `the user` or `one can`
+- Imperative for steps: "Click **Add Project**", not "You will need to click **Add Project**"
+- Sentences under 20 words target
+- Contractions encouraged (`you'll`, `it's`) for warmth
+- Present tense unless describing future behavior
+- Limit `we`: only for deliberate organization actions ("we recommend", "we deprecated"), never as a stand-in for "you"
+- No rhetorical questions (sounds like marketing)
+- Second-read test: read each sentence once at speech pace; if you re-read to parse it, name the subject, the action, and the consequence (kill metaphor verbs and pronouns reaching back several sentences)
+
+### Banned words
+
+- `easy`, `simple`, `quick`: puts pressure on the reader and reads as marketing; replace with concrete description ("one command", "default settings", "most projects don't need this")
+- `very`, `just`, `really`: filler; cut or rewrite
+
+### Concision
+
+- Earn every detail: cut a number, name, or implementation detail if a more general phrasing wouldn't change the reader's understanding or action
+- Weasel words: replace vague qualifiers (`significantly`, `many`, `often`, `typically`, `generally`) with a specific number or claim
+- Vague quantifiers: no `near-zero`, `sub-second`, `most requests`; give the figure and cite it (`99.37% of requests see zero cold starts`)
+- Filler/metaphor verbs: name the action instead of reaching for cadence (`moves through`, `lands`, `carries`, `hits` → the literal step)
+
+### AI-generated tells (flag these)
+
+- Summary-style transitions: never open a paragraph by recapping the last one (`With this setup complete…`, `Now that we've explored…`); pivot straight to the next point (`In practice…`, `The catch is…`)
+- Stop-start sentences: don't split one dependent idea into choppy fragments (`Previously this was manual. Now it's automatic. This saves time.` → one sentence); short sentences for emphasis are fine
+- Spec-sheet voice: rewrite sentences that read like a system reading a datasheet (`provides`, `is configurable`, `is explicitly labeled`)
+- Cold-open paragraphs: a body paragraph whose first sentence works as a standalone heading has no antecedent; carry the prior subject forward (`Because…`, `Once…`)
+- Personified artifacts: machines don't perform human-physical actions (`hand the browser a URL` → `the browser fetches the URL`; `the token holds…` → `the token is stored…`)
+- Reused framing: the angle must come from this page, not a template (`The question most teams face is whether…`)
+
+### Tone, by content type
+
+- **Tutorial**: warm, encouraging, predictable structure, no traps
+- **How-to**: terse, direct (reader is mid-task)
+- **Reference**: neutral, exhaustive, quotable
+- **Conceptual**: explain like the reader will teach it back; examples and analogies welcome
+- **Troubleshooting**: empathetic but not apologetic; acknowledge then fix
+
+### Headings
+
+- Sentence case for page headings (`H1` `H2` `H3`): "Configure environment variables", not "Configure Environment Variables"
+- Title case for nav labels: "Configuring Environment Variables"
+- `meta.title` becomes the `H1`; `meta.navLabel` becomes the sidebar entry
+- Subheadings descriptive, not cute: "Caveats when self-hosting on Cloudflare", not "Caveats"
+- Reader should be able to guess section content from the heading alone
+
+### Structure
+
+- Every page opens with a one-paragraph TL;DR of what the page covers
+- Every major section opens with a summary sentence
+- Acronyms spelled out on first use: "Content Security Policy (CSP) blocks inline scripts"
+- Define every term the first time you use it (link to its conceptual page)
+- Reference docs organized by surface; education docs organized by reader task
+- Keep paragraphs to 2 to 4 sentences; split anything longer or covering two ideas
+
+### Lists
+
+- Three or more list-shaped items in a paragraph: convert to a list
+- Bulleted for unordered; numbered for ordered (lifecycles, sequential steps)
+- Always introduce a list with a colon
+- No periods at the end of list items unless they are full sentences
+- Bold/description format: `- **Term**: description here` (colon after bold term)
+
+### Code
+
+- Code blocks need a language tag for syntax highlighting
+- TypeScript is the default for new code unless the surface is genuinely language-agnostic
+- Multi-step flows wrapped in `<Steps/>` so structure is visible
+- Highlight load-bearing lines: `` ```typescript {8-12,23-37} ``
+- ≤80 columns per line in snippets
+- ≤25 lines per snippet; split longer blocks with prose
+- Omit defaults; don't repeat variable definitions, use shared var
+- Minimal comments in code blocks; prefer prose explanation
+- Explain what every code block does in prose (don't drop and run)
+- Don't reference full example files at the end of guides ("See `train.py`"); the guide is the deliverable
+
+### Placeholders
+
+- Text placeholders: `snake_case`, descriptive: `your_access_token_here` (so reader can double-click to select before pasting)
+- Number placeholders: count up `1234567890123` (recognizable as fake, predictable)
+- Never `<TOKEN>`, `xxx`, `your-token`, or generic ALL_CAPS
+
+### Data sizes & units
+
+- Space + uppercase unit: `64 KB`, `5 KB`, `200 ms`
+- Exception: seconds is bare: `30s`
+- Consistent across the corpus so readers can develop scanning habits
+
+### Money & pricing pages
+
+- Uncompromising detail: err on "too much"
+- Use tables for pricing
+- Never assume reader knows the pricing model or whether their workload counts as one invocation or several
+- Clarity and transparency above all else
+
+### Emphasis
+
+- **Bold** means UI element or critical fact, never emphasis-for-emphasis-sake
+- Reaching for bold for tone: the sentence is weak; rewrite it
+- `Inline code` for paths, file extensions, identifiers, short snippets: `/api`, `.tsx`, `body`, `query`, `req`
+- Rule: if it would look weird without a monospace font, monospace it
+
+### Punctuation & typography
+
+- Never em dashes (`—`) or dashes (`-`) as punctuation; use colons, commas, periods, or rephrase
+- Curly quotes `"` `"` and `'` `'`, not straight `"` or `'`
+- Ellipsis `…`, not three dots `...`
+- Loading states end with `…`: `Loading…`, `Saving…`
+- Non-breaking spaces in `10&nbsp;MB`, `⌘&nbsp;K`, brand names
+- `&` over "and" only where space-constrained (nav labels, buttons)
+
+### Source formatting
+
+- Don't hard-wrap paragraphs: each paragraph is one line in source, let the editor wrap
+- One blank line before headings; one blank line before and after code blocks
+- No `---` horizontal rules between sections
+- No extra blank lines between elements that aren't paragraph breaks
+
+### Links
+
+- Define every term the first time it appears, link to its conceptual page
+- Anchor text names the destination; never bare URLs or `here`/`link`
+- Dashboard links should open the exact destination and preserve required context in the URL.
+- Link to canonical product documentation when relevant.
+- Link to the canonical model catalog for the selected provider when examples name models.
+
+### Models in examples
+
+- Always use the latest model strings: `anthropic/claude-opus-4-7`, not `anthropic/claude-sonnet-4` or older
+- For image generation default: `google/gemini-3.1-flash-image-preview`
+
+### AI workflow
+
+- You are accountable for the content you produce, however it is created
+- You are the final arbiter; the model proposes, you dispose
+- Hold technical accuracy to a high standard: docs are also consumed by LLMs, wrong docs train wrong models
+- Use only enterprise models that do not train on your data (especially for unreleased products)
+- Disclose AI use in the PR (model + prompts if useful)
+- Plan first by hand; the plan is the spec the model works against
+- Use plan-mode in your editor (Cursor, Claude) before letting the model write
+- Tell the model to follow `AGENTS.md` and the linting checklist
+- Run a test prompt against the preview: "given this plan's goal, can the model complete the task using only this page?"
+- Final human review always
+
+### Quality checklist (required boxes are non-negotiable)
+
+- **Findability**: sidebar bucket set via `meta.category`; UI links to docs from any dashboard surface that exposes the feature
+- **Accuracy**: code samples actually run; screenshots map 1:1 to current UI and use the ACME demo account
+- **Relevance**: code samples included where applicable (TypeScript first; `<Steps/>` for multi-step flows)
+- **Clarity**: overview addresses who/what/where/why; high-level use cases laid out; quickstart for new products; prerequisites listed on tutorials; a sample repository for multi-step tutorials; steps detailed not vague; visual aids in confusing sections; simplest path recommended when multiple exist
+- **Completeness**: limits documented; all-limits tables updated; content plan followed and goals addressed
+- **Readability**: nav names scannable and use action verbs; content types accurately used; subheadings descriptive; topics start with summaries; code blocks formatted correctly; active voice where warranted
+
+### Review
+
+- PR description links to the content plan, lists what to review, and links the preview URL
+- Ping the team via the PR link (not the plan or preview directly)
+- Author is accountable, not the reviewer; reviewers are liberal with approvals
+- Suggestion comments for small text fixes; preview comments for anything bigger
+- Disagreement is fine; reject with a one-line reason and move on
+
+### Anti-patterns (flag these)
+
+- Em dashes (`—`) or dashes (`-`) used as punctuation
+- `easy`, `simple`, `quick` describing reader actions
+- Passive voice (apply "by monkeys" test)
+- Title Case in page headings (only sentence case in `H1` through `H6`)
+- Generic placeholders: `<TOKEN>`, `xxx`, `your-token`, `ABC123`
+- Code blocks without a language tag
+- JS examples where TypeScript is the convention
+- Code blocks over 25 lines without prose between
+- Hard-wrapped prose paragraphs (multiple lines for one paragraph in source)
+- `---` horizontal rules between sections
+- Subheadings that are single generic words: `Overview`, `Caveats`, `Notes`
+- Bold used for emphasis instead of UI element or critical fact
+- Page or section without an opening summary
+- Straight quotes (`"`, `'`) instead of curly (`"`, `'`)
+- Three dots (`...`) instead of ellipsis (`…`)
+- Acronyms used before being spelled out
+- Bare unit numbers (`64KB`, `5kb`, `200MS`) instead of `64 KB`, `5 KB`, `200 ms`
+- "We" standing in for "you"
+- Rhetorical questions
+- Filler words: `very`, `just`, `really`, `simply`
+- References to "the full example file at the end of the guide" rather than inlining the code
+- Outdated model strings in examples (`anthropic/claude-sonnet-4`, `gpt-4o`, DALL-E)
+- Hardcoded date/number formats instead of `Intl.DateTimeFormat` / `Intl.NumberFormat` in code samples
+- "Loading..." instead of "Loading…"
+- Summary-style transitions recapping the previous paragraph (`With this setup complete…`)
+- Stop-start fragments splitting one dependent idea into choppy sentences
+- Spec-sheet voice reading like a datasheet (`provides`, `is configurable`, `is explicitly labeled`)
+- Cold-open body paragraphs whose first sentence has no antecedent
+- Personified artifacts performing human-physical actions (`hand the browser a URL`)
+- Reused/template framing not specific to the page (`The question most teams face is whether…`)
+- Weasel words instead of a specific claim (`significantly`, `many`, `often`, `typically`, `generally`)
+- Vague quantifiers without a cited figure (`near-zero`, `sub-second`, `most requests`)
+- Filler/metaphor verbs instead of the literal step (`moves through`, `lands`, `carries`, `hits`)
+- Sentences that need a second read to parse
+- Paragraphs over 4 sentences or covering two ideas
+- Bare URLs or `here`/`link` as anchor text
+
+## Output Format
+
+Group by file. Use `file:line` format (VS Code clickable). Terse findings.
+
+```text
+## content/docs/sandbox.mdx
+
+content/docs/sandbox.mdx:1 - missing meta.contentType
+content/docs/sandbox.mdx:12 - title "Cloud Sandbox" is feature-shaped, not user-question
+content/docs/sandbox.mdx:24 - passive voice ("the sandbox is created...")
+content/docs/sandbox.mdx:31 - banned word "easy"
+content/docs/sandbox.mdx:47 - "..." → "…"
+content/docs/sandbox.mdx:58 - code block missing language tag
+content/docs/sandbox.mdx:71 - placeholder <TOKEN> → your_access_token_here
+content/docs/sandbox.mdx:89 - "64KB" → "64 KB"
+content/docs/sandbox.mdx:102 - H2 "Caveats" too generic; add specificity
+content/docs/sandbox.mdx:118 - em dash in prose, replace with colon/comma
+
+## content/docs/ai-gateway.mdx
+
+content/docs/ai-gateway.mdx:5 - title case in H1; sentence case only
+content/docs/ai-gateway.mdx:18 - acronym AI Gateway used before being spelled out
+content/docs/ai-gateway.mdx:34 - bold for emphasis, not UI element
+content/docs/ai-gateway.mdx:52 - `anthropic/claude-sonnet-4` outdated; use `anthropic/claude-opus-4-7`
+content/docs/ai-gateway.mdx:71 - hard-wrapped paragraph (lines 71-74)
+
+## content/docs/cron.mdx
+
+✓ pass
+```
+
+State issue + location. Skip explanation unless fix is non-obvious. No preamble.

--- a/plugins/seo-skills/.claude-plugin/plugin.json
+++ b/plugins/seo-skills/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "seo-skills",
+  "version": "1.0.0",
+  "description": "Audit SEO, plan scalable pages, validate schema, and improve site architecture.",
+  "license": "MIT"
+}

--- a/plugins/seo-skills/.codex-plugin/plugin.json
+++ b/plugins/seo-skills/.codex-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "seo-skills",
+  "version": "1.0.0",
+  "description": "Audit SEO, plan scalable pages, validate schema, and improve site architecture.",
+  "license": "MIT"
+}

--- a/plugins/seo-skills/.cursor-plugin/plugin.json
+++ b/plugins/seo-skills/.cursor-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "seo-skills",
+  "version": "1.0.0",
+  "description": "Audit SEO, plan scalable pages, validate schema, and improve site architecture.",
+  "license": "MIT"
+}

--- a/plugins/seo-skills/gemini-extension.json
+++ b/plugins/seo-skills/gemini-extension.json
@@ -1,0 +1,5 @@
+{
+  "name": "seo-skills",
+  "version": "1.0.0",
+  "description": "Audit SEO, plan scalable pages, validate schema, and improve site architecture."
+}

--- a/plugins/seo-skills/skills/programmatic-seo/SKILL.md
+++ b/plugins/seo-skills/skills/programmatic-seo/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: programmatic-seo
+description: "Use when planning many similar pages from a template and a data set: choosing the pattern, deciding whether the data can carry it, and avoiding the thin-content failure that gets page sets deindexed."
+license: MIT
+---
+
+# Programmatic SEO
+
+Building pages from a template and a data set works when each page answers a real query with something only your data can say. It fails the same way every time: a template with the variable swapped, published at volume, on queries nobody searches. That is the definition of a doorway page, and Google's spam policies name it.
+
+So the question to settle before any of the mechanics is whether the data is worth a page.
+
+## Does the data carry it
+
+Defensibility runs in this order, strongest first:
+
+1. Proprietary, because you generated it.
+2. Product-derived, from how your own users behave.
+3. User-generated, from your community.
+4. Licensed, where the license is exclusive.
+5. Public, which anyone can use and everyone already has.
+
+A set built on public data competes with every other set built on the same public data, so it has to win on presentation, freshness, or aggregation instead. That is possible and it is a much harder brief. Say so rather than shipping 5,000 pages that restate a public API.
+
+Then check demand actually exists: aggregate volume across the pattern, how it splits between head and long tail, and whether the trend is going anywhere. A pattern with 10,000 combinations and no searches for 9,000 of them is a 1,000-page opportunity.
+
+## Choosing a pattern
+
+| You have | Consider |
+| --- | --- |
+| Proprietary data set | Directory, Profiles |
+| A product with integrations | Integrations |
+| A design or creative product | Templates, Examples |
+| Several distinct audience segments | Personas |
+| A local footprint | Locations |
+| A utility or calculator | Conversions |
+| Deep subject expertise | Glossary, Curation |
+| A crowded competitive field | Comparisons |
+
+`references/playbooks.md` covers the twelve patterns, each with its query shape, what data it needs, and how it usually fails.
+
+Patterns layer, and layering is often where the real opportunity is: "best coworking spaces in Austin" is Curation crossed with Locations.
+
+## Making each page worth indexing
+
+- Every page needs something specific to it beyond the substituted variable: a number, a comparison, a list, an image, a genuine answer.
+- Write the introduction per page, or generate it from enough fields that no two read alike. A shared paragraph with one word swapped is the tell.
+- Vary structure by what the data supports. A page with three data points shouldn't use the layout built for thirty; branch the template instead of padding.
+- Give each page a unique title and meta description built from its variables, not one pattern with the variable appended.
+- Match the query's intent. A comparison query wants a comparison, not a signup page.
+
+## Structure and indexation
+
+- Subfolders, not subdomains, so the pages build authority on the same domain rather than splitting it.
+- Hub and spoke: a category page linking to every page in the set, each page linking back, and related pages cross-linking. Otherwise the set is orphaned and only the sitemap points at it.
+- Own sitemap for the set, or a sitemap per pattern, so indexing rates per pattern are readable.
+- Ship the strongest slice first rather than the whole set. Publish the highest-demand pages, confirm they get indexed and ranked, then expand. A set that goes out all at once gives no signal about which part worked.
+- Leave the thinnest variations out entirely. That is better than publishing them and noindexing them later, since crawl spent on pages you didn't want is crawl not spent on pages you did.
+
+## Before it ships
+
+Check that each page has unique value and answers its query, that titles and descriptions are unique, that heading structure and schema are in place, that the set is linked from the site rather than only the sitemap, that no page has a conflicting noindex, and that nothing in the set competes with an existing page for the same query.
+
+After launch, watch what fraction of the set gets indexed, which patterns rank, and whether engagement holds up. Thin-content warnings, a drop across the set, or an indexing rate that stalls well below 100% all mean the same thing: cut, don't add.
+
+## What this hands off
+
+Programmatic SEO decides the pattern, the data, the URL shape, the template's sections, and the linking. The words inside a template section are copy: hand the content marketer the template, the target query, and the fields available per page.
+
+## Sources
+
+- Google Search Central, Spam policies: https://developers.google.com/search/docs/essentials/spam-policies
+- Google Search Central, Creating helpful, reliable, people-first content: https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+- Google Search Central, Sitemaps overview: https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview

--- a/plugins/seo-skills/skills/programmatic-seo/references/playbooks.md
+++ b/plugins/seo-skills/skills/programmatic-seo/references/playbooks.md
@@ -1,0 +1,96 @@
+# The twelve playbooks
+
+Each entry gives the query shape, the data it needs, and how it usually fails. The failure line matters more than the pattern: every one of these works when the data is real and fails the same way when it isn't.
+
+## 1. Templates
+
+Query: "[type] template", "[type] template free".
+Data: the templates themselves, plus a preview image and the fields describing each.
+Page: a preview, what it's for, how to use it, and the download or copy action above the fold.
+Fails when: the template is a thin table nobody would use, or the page makes you sign up to see anything. Search intent here is transactional, so a gate before the preview loses both the ranking and the visitor.
+
+## 2. Curation
+
+Query: "best [category]", "top [category] for [use case]".
+Data: a scored comparison across real options, ideally with your own testing behind it.
+Page: the criteria, the picks with reasons, and where each one is the wrong choice.
+Fails when: it lists every option with no opinion, or ranks by affiliate payout. Naming who should not pick your top choice is what makes the rest credible.
+
+## 3. Conversions
+
+Query: "[X] to [Y]", "[N] [unit] in [unit]".
+Data: a conversion rate or formula, ideally live.
+Page: the answer at the top, then the formula, then common values nearby.
+Fails when: the answer is below the fold, or the rate is stale. These queries have enormous volume and near-zero patience.
+
+## 4. Comparisons
+
+Query: "[X] vs [Y]", "[competitor] alternative".
+Data: verified feature, pricing, and limit data for both sides, with a date.
+Page: an honest table, where each option wins, and who should pick the other one.
+Fails when: the competitor's column is out of date or unfair. A comparison that only your product could win reads that way, and it dates badly the moment the competitor ships.
+
+## 5. Examples
+
+Query: "[type] examples", "[type] examples that work".
+Data: real examples with images and a note on why each is included.
+Page: the example, what it does well, and what to copy from it.
+Fails when: it's a gallery with no analysis. The screenshots are the draw; the reason each one is there is the value.
+
+## 6. Locations
+
+Query: "[service] in [city]", "[service] near me".
+Data: something genuinely local per page: real listings, local pricing, local regulation, coverage.
+Page: local specifics first, then the general information.
+Fails when: the city name is the only difference. This is the canonical thin-content case and the one Google's doorway-page policy describes most directly. If you cannot say something true about that city, don't make the page.
+
+## 7. Personas
+
+Query: "[product category] for [audience]".
+Data: how the product is actually used by that segment, with real examples.
+Page: that segment's problem, the workflow that solves it, proof from someone like them.
+Fails when: it's the homepage with the audience noun swapped. If the screenshots and the objections don't change per persona, the segments aren't distinct enough for separate pages.
+
+## 8. Integrations
+
+Query: "[product A] [product B] integration", "connect [A] to [B]".
+Data: your integration catalog plus what each integration actually does.
+Page: what the connection enables, setup steps, what syncs and what doesn't.
+Fails when: it lists integrations you don't have, or every page says "seamlessly connect" with no mechanics. What syncs, in which direction, how often, is the whole reason someone searched.
+
+## 9. Glossary
+
+Query: "what is [term]", "[term] meaning".
+Data: subject expertise and a consistent structure.
+Page: a direct one-paragraph definition, then why it matters, an example, and related terms.
+Fails when: definitions are paraphrased from other glossaries. Answer in the first paragraph and add the thing only a practitioner would know.
+
+## 10. Translations
+
+Query: existing winning queries, in another language.
+Data: real translation, not just the interface strings.
+Page: the source page's value, fully localized.
+Fails when: only the chrome is translated, or hreflang and canonical are wrong. Read `../../seo-audit/references/international-seo.md` before starting: the technical failure modes here void whole locale clusters silently.
+
+## 11. Directory
+
+Query: "[category] tools", "[category] companies".
+Data: a maintained listing set with enough fields to filter and sort.
+Page: the filtered list plus what's true of this slice specifically.
+Fails when: listings go stale or every filter combination becomes a page. Index the combinations with demand; leave the rest to filtering that doesn't generate URLs.
+
+## 12. Profiles
+
+Query: "[entity name]", "[entity] [attribute]".
+Data: a reliable entity data set you can keep current.
+Page: the facts, sourced, with the update date visible.
+Fails when: facts are wrong or unattributed. Profile pages about real people and companies carry accuracy obligations well beyond SEO, so cite the source and date every claim.
+
+## Layering
+
+Combining two patterns usually beats extending one, because the combined query is more specific and less contested. Curation plus Locations gives "best [category] in [city]". Personas plus Integrations gives "[product] for [audience] with [tool]". The constraint is data: each added dimension multiplies the pages and divides the evidence you have per page, so layer only while each cell still has something real in it.
+
+## Sources
+
+- Google Search Central, Spam policies (doorway pages, scaled content abuse): https://developers.google.com/search/docs/essentials/spam-policies
+- Google Search Central, Creating helpful, reliable, people-first content: https://developers.google.com/search/docs/fundamentals/creating-helpful-content

--- a/plugins/seo-skills/skills/schema/SKILL.md
+++ b/plugins/seo-skills/skills/schema/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: schema
+description: "Use when adding, fixing, or reviewing structured data: JSON-LD for articles, products, FAQs, breadcrumbs, organizations, and local businesses, and what to do when markup doesn't earn a rich result."
+license: MIT
+---
+
+# Schema markup
+
+Structured data tells a search engine what a page is rather than making it rank. Done right it earns a richer result and makes the page easier for an engine to summarize. Done wrong it earns a manual action.
+
+Four rules govern everything below:
+
+- Mark up only what the page visibly shows. Schema describing content a reader can't see is a spam signal, and it's the single most common reason markup gets penalized rather than ignored.
+- Use JSON-LD, in a `<script type="application/ld+json">` in the head or at the end of the body. Google recommends it, and it's the only format you can add without touching the page's markup.
+- Only claim types and properties the engine actually supports for a rich result. Valid schema.org markup with no supported result does nothing for search, which is fine, but don't promise a rich result it can't produce.
+- Validate before it ships, then watch Search Console. Markup that validates can still be wrong about the page.
+
+## Choosing the type
+
+| Type | Use on | Required |
+| --- | --- | --- |
+| Organization | Homepage, about page | `name`, `url` |
+| WebSite | Homepage, to declare a site search | `name`, `url` |
+| Article, BlogPosting | Posts and news | `headline`, `image`, `datePublished`, `author` |
+| Product | Product pages | `name`, `image`, `offers` |
+| SoftwareApplication | App and SaaS pages | `name`, `offers` |
+| FAQPage | A page with real questions and answers | `mainEntity` |
+| HowTo | Step-by-step instructions | `name`, `step` |
+| BreadcrumbList | Any page with breadcrumbs | `itemListElement` |
+| LocalBusiness | A location page | `name`, `address` |
+| Event | Events and webinars | `name`, `startDate`, `location` |
+
+`references/schema-examples.md` has a complete, valid block for each of these plus a combined `@graph` and a Next.js pattern. `references/required-properties.json` is the same table in the form the bundled validator reads, so adding a type means editing both.
+
+When a page needs several types, prefer one `@graph` array over several separate script tags: entities can then reference each other by `@id` instead of repeating themselves.
+
+## Reviewing existing markup
+
+A fetch of the page shows only server-rendered JSON-LD. CMS SEO plugins commonly inject it client side, so absence in fetched HTML is not absence on the page. Report what the server HTML contained, then send them to the Rich Results Test, which renders JavaScript.
+
+When markup exists but earns nothing, check in this order: a required property missing, a value in the wrong shape (dates must be ISO 8601, URLs absolute, enumerations exact), the type having no rich result to earn, or the markup describing something the page doesn't show.
+
+From this skill directory, run `node scripts/validate_schema.mjs <jsonld-file>` on any block before you hand it over. It parses the JSON, checks each type against the required properties in `references/required-properties.json`, and catches the two value shapes that fail most often: a date that isn't ISO 8601 and a relative URL. It's mechanical, so a clean result means the syntax is right and nothing more.
+
+Then point the user at the Rich Results Test at https://search.google.com/test/rich-results for eligibility, and the schema.org validator at https://validator.schema.org/ for correctness against the vocabulary. Those answer different questions from each other and from the tool, so a block can pass one and fail another. None of the three can tell you whether the markup describes what the page actually shows, which is the accuracy rule above and still yours to check.
+
+## Handing it over
+
+Give the complete block, ready to paste, with the page's real values filled in rather than placeholders. Say where it goes, name any property you had to leave out and why, and note which rich result it makes the page eligible for, with eligible being the honest word. Google decides whether to show one.
+
+## Sources
+
+- Google Search Central, Intro to how structured data works: https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data
+- Google Search Central, Structured data general guidelines: https://developers.google.com/search/docs/appearance/structured-data/sd-policies
+- Google Search Central, Search gallery of supported result types: https://developers.google.com/search/docs/appearance/structured-data/search-gallery
+- schema.org: https://schema.org/

--- a/plugins/seo-skills/skills/schema/references/required-properties.json
+++ b/plugins/seo-skills/skills/schema/references/required-properties.json
@@ -1,0 +1,13 @@
+{
+  "Article": ["headline", "image", "datePublished", "author"],
+  "BlogPosting": ["headline", "image", "datePublished", "author"],
+  "BreadcrumbList": ["itemListElement"],
+  "Event": ["name", "startDate", "location"],
+  "FAQPage": ["mainEntity"],
+  "HowTo": ["name", "step"],
+  "LocalBusiness": ["name", "address"],
+  "Organization": ["name", "url"],
+  "Product": ["name", "image", "offers"],
+  "SoftwareApplication": ["name", "offers"],
+  "WebSite": ["name", "url"]
+}

--- a/plugins/seo-skills/skills/schema/references/schema-examples.md
+++ b/plugins/seo-skills/skills/schema/references/schema-examples.md
@@ -1,0 +1,342 @@
+# Schema examples
+
+Valid JSON-LD for the types that come up most. Replace every value with the page's real content. Each block goes in a `<script type="application/ld+json">` tag.
+
+## Organization
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://example.com/#organization",
+  "name": "Example",
+  "url": "https://example.com",
+  "logo": "https://example.com/logo.png",
+  "description": "One sentence on what the company does.",
+  "sameAs": [
+    "https://x.com/example",
+    "https://www.linkedin.com/company/example"
+  ],
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "contactType": "customer support",
+    "email": "support@example.com"
+  }
+}
+```
+
+## WebSite with site search
+
+The `SearchAction` only matters if the site has a working search results page at that URL pattern.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": "https://example.com/#website",
+  "name": "Example",
+  "url": "https://example.com",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://example.com/search?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+}
+```
+
+## Article or BlogPosting
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "The post title, under 110 characters",
+  "description": "The meta description or a one-sentence summary.",
+  "image": ["https://example.com/images/post-16x9.jpg"],
+  "datePublished": "2026-07-25T09:00:00-07:00",
+  "dateModified": "2026-07-25T09:00:00-07:00",
+  "author": {
+    "@type": "Person",
+    "name": "Author Name",
+    "url": "https://example.com/authors/author-name"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Example",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/blog/post-slug"
+  }
+}
+```
+
+`author` as a real `Person` with a URL to a real author page carries more weight than a bare string, and it's what makes the experience and expertise signals legible.
+
+## Product
+
+`offers` is required. Omit `aggregateRating` and `review` unless real ratings exist on the page.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "Product Name",
+  "image": ["https://example.com/images/product.jpg"],
+  "description": "What the product is.",
+  "sku": "SKU-123",
+  "brand": { "@type": "Brand", "name": "Example" },
+  "offers": {
+    "@type": "Offer",
+    "url": "https://example.com/products/product-name",
+    "priceCurrency": "USD",
+    "price": "49.00",
+    "availability": "https://schema.org/InStock",
+    "priceValidUntil": "2027-01-01"
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.6",
+    "reviewCount": "127"
+  }
+}
+```
+
+## SoftwareApplication
+
+For a SaaS or app page. A free tier is `price: "0"`, not an omitted `offers`.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Product Name",
+  "applicationCategory": "BusinessApplication",
+  "operatingSystem": "Web",
+  "description": "What the product does.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  }
+}
+```
+
+## FAQPage
+
+Only for questions and answers actually visible on the page. An FAQPage describing hidden or invented questions is the classic penalized case.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How long does setup take?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Most teams finish in under ten minutes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a free plan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, with up to three projects."
+      }
+    }
+  ]
+}
+```
+
+## HowTo
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to do the thing",
+  "totalTime": "PT15M",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "First step",
+      "text": "What to do.",
+      "url": "https://example.com/guide#step-1"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Second step",
+      "text": "What to do next.",
+      "url": "https://example.com/guide#step-2"
+    }
+  ]
+}
+```
+
+## BreadcrumbList
+
+`position` starts at 1. The current page is the last item and conventionally omits `item`.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://example.com"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Features",
+      "item": "https://example.com/features"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Analytics"
+    }
+  ]
+}
+```
+
+## LocalBusiness
+
+Name, address, and phone must match what the page shows and what other listings say.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "Example Studio",
+  "image": "https://example.com/images/storefront.jpg",
+  "url": "https://example.com/locations/austin",
+  "telephone": "+1-512-555-0100",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "100 Congress Ave",
+    "addressLocality": "Austin",
+    "addressRegion": "TX",
+    "postalCode": "78701",
+    "addressCountry": "US"
+  },
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+      "opens": "09:00",
+      "closes": "17:00"
+    }
+  ]
+}
+```
+
+## Event
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Event",
+  "name": "Event Name",
+  "startDate": "2026-09-15T10:00:00-07:00",
+  "endDate": "2026-09-15T11:00:00-07:00",
+  "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+  "eventStatus": "https://schema.org/EventScheduled",
+  "location": {
+    "@type": "VirtualLocation",
+    "url": "https://example.com/webinars/event-name"
+  },
+  "organizer": {
+    "@type": "Organization",
+    "name": "Example",
+    "url": "https://example.com"
+  }
+}
+```
+
+## Several types on one page
+
+Use one `@graph` and let entities reference each other by `@id` rather than repeating the organization on every entity.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://example.com/#organization",
+      "name": "Example",
+      "url": "https://example.com"
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://example.com/#website",
+      "url": "https://example.com",
+      "publisher": { "@id": "https://example.com/#organization" }
+    },
+    {
+      "@type": "BlogPosting",
+      "headline": "The post title",
+      "datePublished": "2026-07-25T09:00:00-07:00",
+      "image": ["https://example.com/images/post.jpg"],
+      "author": { "@type": "Person", "name": "Author Name" },
+      "publisher": { "@id": "https://example.com/#organization" },
+      "isPartOf": { "@id": "https://example.com/#website" }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://example.com"
+        },
+        { "@type": "ListItem", "position": 2, "name": "Blog" }
+      ]
+    }
+  ]
+}
+```
+
+## Next.js
+
+Render it server side so it's in the HTML a crawler receives. In the App Router, a script tag in the page or layout is enough.
+
+```tsx
+export default function Page() {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    datePublished: post.publishedAt,
+    author: { "@type": "Person", name: post.author.name },
+  };
+
+  return (
+    <>
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD has no safe typed alternative
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+        type="application/ld+json"
+      />
+      <article>{/* ... */}</article>
+    </>
+  );
+}
+```
+
+Build the object from the same data that renders the page, so the two can't drift apart. Hard-coding schema values separately from the visible content is how markup ends up describing a page that has since changed.

--- a/plugins/seo-skills/skills/schema/scripts/validate_schema.mjs
+++ b/plugins/seo-skills/skills/schema/scripts/validate_schema.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+const MAX_JSON_LENGTH = 100_000;
+const DATE_PROPERTIES = new Set([
+  "datePublished",
+  "dateModified",
+  "startDate",
+  "endDate",
+  "priceValidUntil",
+  "validFrom",
+  "validThrough",
+]);
+const URL_PROPERTIES = new Set(["url", "logo", "image", "item", "target"]);
+const ISO_8601 =
+  /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+const ABSOLUTE_URL = /^https?:\/\//;
+
+const inputPath = process.argv[2];
+if (!inputPath || process.argv.length > 3) {
+  console.error("Usage: node scripts/validate_schema.mjs <jsonld-file|->");
+  process.exit(2);
+}
+
+const result = { errors: [], types: [], valid: false, warnings: [] };
+const finish = (exitCode) => {
+  result.valid = result.errors.length === 0;
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(exitCode ?? (result.valid ? 0 : 1));
+};
+
+let jsonld;
+try {
+  jsonld =
+    inputPath === "-"
+      ? await new Promise((resolve, reject) => {
+          let data = "";
+          process.stdin.setEncoding("utf8");
+          process.stdin.on("data", (chunk) => {
+            data += chunk;
+          });
+          process.stdin.on("end", () => resolve(data));
+          process.stdin.on("error", reject);
+        })
+      : await readFile(inputPath, "utf8");
+} catch (error) {
+  result.errors.push(`Could not read JSON-LD: ${error.message}`);
+  finish();
+}
+
+if (jsonld.length === 0) {
+  result.errors.push("JSON-LD input is empty.");
+  finish();
+}
+if (jsonld.length > MAX_JSON_LENGTH) {
+  result.errors.push(`JSON-LD exceeds ${MAX_JSON_LENGTH} characters.`);
+  finish();
+}
+
+let document;
+try {
+  document = JSON.parse(jsonld);
+} catch (error) {
+  result.errors.push(`Not valid JSON: ${error.message}`);
+  finish();
+}
+
+let required;
+try {
+  required = JSON.parse(
+    await readFile(new URL("../references/required-properties.json", import.meta.url), "utf8")
+  );
+} catch (error) {
+  result.errors.push(`Could not read the required-property map: ${error.message}`);
+  finish();
+}
+
+const isObject = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
+const objectNodes = (values) => values.filter(isObject);
+const nodesOf = (value) => {
+  if (Array.isArray(value)) return objectNodes(value);
+  if (!isObject(value)) return [];
+  return Array.isArray(value["@graph"]) ? objectNodes(value["@graph"]) : [value];
+};
+const typesOf = (node) => {
+  const type = node["@type"];
+  if (typeof type === "string") return [type];
+  return Array.isArray(type) ? type.filter((value) => typeof value === "string") : [];
+};
+
+const nodes = nodesOf(document);
+if (nodes.length === 0) {
+  result.errors.push("No JSON-LD entity found. Expected an object, an array, or an @graph.");
+}
+if (isObject(document) && !document["@context"]) {
+  result.warnings.push('Top level is missing "@context": "https://schema.org".');
+}
+
+for (const node of nodes) {
+  const types = typesOf(node);
+  if (types.length === 0) result.errors.push("An entity has no @type.");
+  result.types.push(...types);
+
+  for (const type of types) {
+    for (const property of required[type] ?? []) {
+      if (node[property] === undefined || node[property] === null) {
+        result.errors.push(`${type} is missing the required property "${property}".`);
+      }
+    }
+  }
+
+  const label = types[0] ?? "node";
+  for (const [key, value] of Object.entries(node)) {
+    if (typeof value !== "string") continue;
+    if (DATE_PROPERTIES.has(key) && !ISO_8601.test(value)) {
+      result.errors.push(`${label}.${key} is not an ISO 8601 date: "${value}".`);
+    }
+    if (URL_PROPERTIES.has(key) && !ABSOLUTE_URL.test(value)) {
+      result.errors.push(`${label}.${key} must be an absolute URL: "${value}".`);
+    }
+  }
+}
+
+finish();

--- a/plugins/seo-skills/skills/seo-audit/SKILL.md
+++ b/plugins/seo-skills/skills/seo-audit/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: seo-audit
+description: "Use when reviewing a page or site for organic search, or diagnosing why something isn't ranking: crawl and index signals, on-page elements, content quality, and how to order the fixes."
+license: MIT
+---
+
+# SEO audit
+
+Audit in priority order, because the layers depend on each other. A page that can't be indexed doesn't benefit from a better title.
+
+1. Can it be found and indexed? Robots rules, canonical tags, noindex, redirect chains.
+2. Is the foundation sound? HTTPS, mobile rendering, speed, URL structure.
+3. Is the page optimized? Title, meta description, headings, keyword alignment, internal links, images.
+4. Does it deserve to rank? Depth, first-hand experience, sourcing, whether it beats what already ranks.
+5. Does it have credibility? Who links to it, who cites it.
+
+Work down the list and stop where the evidence stops. Most asks are answered at layers 3 and 4.
+
+## What a fetch can and can't tell you
+
+`web_fetch` returns the server's HTML as text. Everything you report as observed has to come from that, from a source you read, or from the caller.
+
+Readable from a fetch: title tag, meta description, heading order and text, body copy, visible links and their anchor text, canonical tag, `robots` meta, `hreflang` in the HTML head, server-rendered JSON-LD, `robots.txt` and `sitemap.xml` when you fetch them directly.
+
+Not readable, so not yours to assert: anything JavaScript injects after load, Core Web Vitals and any speed measurement, whether Google has actually indexed a URL, rank position, search volume, traffic, backlink counts, and whole-site facts like orphan pages or crawl budget that need a crawl you can't run.
+
+The trap worth naming: CMS SEO plugins commonly inject JSON-LD client side, so a fetch shows no schema on a page that has plenty. Never conclude "no schema" from a fetch. Report that the server HTML carried none, and send them to the Rich Results Test at https://search.google.com/test/rich-results, which renders JavaScript.
+
+For a check you can't run, name the check and the tool rather than skipping it silently. Search Console covers index coverage and queries; PageSpeed Insights covers Core Web Vitals; a crawler like Screaming Frog covers site-wide structure.
+
+## Diagnosing a page that isn't ranking
+
+Work outward from the page before reaching for site-wide theories.
+
+- Does the page target one query, and do the title, H1, URL, and opening paragraph agree on which one? Disagreement here explains more ranking problems than anything technical.
+- Is another page on the site competing for the same query? Two mediocre pages on one keyword lose to one good one, and the fix is usually to merge them and redirect.
+- Is the intent right? A product page will not rank for a question query however well optimized it is.
+- Is it thinner than what ranks? Compare against the pages currently ranking rather than against a word count.
+- Did something change? A migration, a redesign, or a template change dated near the drop is the first thing to check, and a drop that starts on a single date usually has a single cause.
+
+## References
+
+- `references/audit-checklist.md`: the per-area checks, each marked with whether a fetch can verify it.
+- `references/international-seo.md`: hreflang, canonical interaction, and locale URL structure for multi-language sites, with the errors that silently void a whole cluster.
+
+## Reporting
+
+Give each finding the problem, why it matters for search, the evidence, the fix, and its rank against the others. Open with the few things worth doing first, and close with what you couldn't check and what it would take. Group by layer, not by page, so someone can fix a class of problem once.

--- a/plugins/seo-skills/skills/seo-audit/references/audit-checklist.md
+++ b/plugins/seo-skills/skills/seo-audit/references/audit-checklist.md
@@ -1,0 +1,86 @@
+# Audit checklist
+
+Per-area checks in priority order. The Evidence column says what it takes to verify the check honestly: `fetch` means a single `web_fetch` of the page or file is enough, `tool` means it needs access you don't have, so name it as unchecked rather than asserting it.
+
+## 1. Crawl and index
+
+| Check | Evidence |
+| --- | --- |
+| `robots.txt` exists and doesn't block anything important | fetch |
+| `robots.txt` references the sitemap | fetch |
+| `sitemap.xml` exists, parses, and lists canonical indexable URLs only | fetch |
+| Sitemap has no redirected, 404, or noindexed URLs in it | fetch |
+| Page has a canonical tag, self-referencing when the page is the original | fetch |
+| No `noindex` on a page that should rank | fetch |
+| One canonical host (www or not, http or https) with the others redirecting | fetch |
+| Trailing-slash handling is consistent | fetch |
+| No redirect chains or loops on key paths | fetch |
+| The URL is actually indexed | tool: Search Console |
+| Indexed count matches expected count | tool: Search Console |
+| Crawl budget, faceted-navigation explosion, parameter duplication | tool: crawler |
+| Orphan pages across the site | tool: crawler |
+
+Soft 404s and near-duplicate clusters need Search Console. A page that returns 200 with no real content is visible from a fetch, so call that out directly.
+
+## 2. Foundations
+
+| Check | Evidence |
+| --- | --- |
+| HTTPS everywhere, valid certificate, no mixed content | fetch |
+| Viewport meta present, layout not fixed-width | fetch |
+| URLs readable, lowercase, hyphenated, no session IDs or content in query strings | fetch |
+| Largest Contentful Paint under 2.5s | tool: PageSpeed Insights |
+| Interaction to Next Paint under 200ms | tool: PageSpeed Insights |
+| Cumulative Layout Shift under 0.1 | tool: PageSpeed Insights |
+| Server response time, caching headers, CDN, font loading | tool: PageSpeed Insights or WebPageTest |
+
+Page weight and blocking scripts are partly visible in fetched HTML: a head full of synchronous third-party scripts is worth flagging as a likely speed problem, framed as a hypothesis for them to confirm.
+
+## 3. On-page
+
+| Check | Target |
+| --- | --- |
+| Title tag | Unique per page, primary keyword near the front, roughly 50 to 60 characters, brand at the end if included |
+| Meta description | Unique, roughly 150 characters or under since mobile truncates near 120, states the value and earns the click. Not a ranking factor |
+| H1 | Exactly one, describes the page, contains the target query or its clear paraphrase |
+| Heading order | H1 then H2 then H3 with no skipped levels, subheads readable as a map of the page |
+| Target query | Appears in the first 100 words, naturally, along with the phrasings a reader would actually use |
+| Keyword alignment | Title, H1, URL, and opening all point at the same query |
+| Cannibalization | No other page on the site targets the same query |
+| Internal links | Descriptive anchor text, no "click here", important pages linked more often, no broken links |
+| Images | Descriptive filenames, alt text that describes the image, compressed, modern format, lazy loaded below the fold |
+
+All of the above are fetch-verifiable except cannibalization, which needs either a site-wide crawl or the caller telling you what else exists. Ask.
+
+## 4. Content quality
+
+Judge against the pages currently ranking for the query, not against a word count. Google is explicit that word count is not a ranking factor.
+
+- Experience: does it show first-hand use, original data, or real examples, or does it read assembled from other pages?
+- Expertise: is the author named and credentialed where that matters, and are claims sourced?
+- Trust: is there a real business behind it, contact details, a privacy policy, and no contradiction between what the page claims and what it shows?
+- Depth: does it answer the obvious follow-up question, or stop at the headline answer?
+- Currency: is anything dated, superseded, or describing a product that has changed?
+- Thin pages: tag and category pages with nothing unique, doorway pages, and pages that exist only to hold a keyword.
+
+## 5. Authority
+
+Off-page work needs a backlink tool, so treat this as scoping rather than measurement: name whether the page has any obvious reason to be linked or cited, and what asset would earn links if it doesn't. Do not estimate a domain metric you cannot read.
+
+## Common patterns by site type
+
+- SaaS: thin feature pages, blog disconnected from product pages, missing comparison and alternative pages, no glossary.
+- Ecommerce: thin category pages, duplicated manufacturer descriptions, missing product schema, faceted navigation generating duplicates, out-of-stock pages left to rot.
+- Content sites: stale posts never refreshed, several posts competing for one query, no topic clustering, weak internal linking, missing author pages.
+- Local: inconsistent name, address, and phone across pages, missing LocalBusiness schema, no location pages.
+- Multi-locale: see `international-seo.md`, since the failure modes there are specific and severe.
+
+## Sources
+
+- Google Search Central, Search Essentials: https://developers.google.com/search/docs/essentials
+- Google Search Central, Creating helpful, reliable, people-first content: https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+- Google Search Central, Robots.txt introduction: https://developers.google.com/search/docs/crawling-indexing/robots/intro
+- Google Search Central, Consolidate duplicate URLs: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
+- Google Search Central, Sitemaps overview: https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview
+- web.dev, Core Web Vitals: https://web.dev/articles/vitals
+- Google Rich Results Test: https://search.google.com/test/rich-results

--- a/plugins/seo-skills/skills/seo-audit/references/international-seo.md
+++ b/plugins/seo-skills/skills/seo-audit/references/international-seo.md
@@ -1,0 +1,62 @@
+# International SEO
+
+For sites serving several languages or regions. The failure modes here are unusually severe: a single missing annotation can void a whole locale cluster, and thin locale pages drag on site-wide quality rather than just their own rankings. Most of this is fetch-verifiable, since hreflang and canonical tags are in the served HTML.
+
+## Hreflang
+
+Three placements are equivalent: a `<link>` in the head, an HTTP `Link` header, or `<xhtml:link>` in the sitemap. Pick one. If you use more than one and they disagree, the conflicting pair gets dropped. Past roughly ten locales, prefer the sitemap: it costs no page weight and no per-request work.
+
+What has to be true:
+
+- Every page includes a self-referencing entry. Without it, all hreflang on the page is ignored.
+- Links are reciprocal. If A points to B, B points back to A, or the pair is discarded.
+- Codes are ISO 639-1 language plus optional ISO 3166-1 alpha-2 region: `en`, `en-GB`. Never `en-UK`.
+- `x-default` is present and points at the fallback, either a language selector or the default locale.
+- Every target returns 200, is indexable, and matches its own canonical.
+- No duplicate language-region code points at two different URLs.
+
+The five errors worth checking first, because each is silent: a missing self-reference, a one-directional pair, an invalid code like `en-UK`, a target that is non-canonical or 404 or blocked, and HTML annotations that disagree with the sitemap.
+
+At scale, `<xhtml:link>` children don't count toward the 50,000-URL sitemap limit, but the 50 MB file limit becomes the binding constraint, so plan 2,000 to 5,000 URLs per file once every entry carries full hreflang. Hreflang is not required on every page: concentrate it where wrong-language traffic actually lands. Bing treats hreflang as a weak signal, so supplement with `<html lang>` for it.
+
+## Canonical interaction
+
+This is where most multi-locale sites break, because canonical beats hreflang when the two disagree.
+
+- Each locale page self-canonicals: `/ar/page` points at `/ar/page`.
+- Never canonical across locales. Pointing French at English suppresses the French page entirely.
+- The canonical URL must appear in the page's own hreflang set. If it doesn't, all hreflang on the page is ignored.
+- Protocol and domain have to match across canonical, hreflang, and sitemap.
+- Paginated locale pages self-canonical per page. Never point page 2 at page 1.
+
+Common causes: a CMS canonicalizing every deep page to the homepage, a template canonicalizing all locales to English, and a protocol mismatch between canonical and hreflang.
+
+## Locale URLs
+
+Subdirectories (`/en/`, `/ar/`) are the recommended default. Subdomains and ccTLDs work. Query parameters (`?lang=en`) do not.
+
+- Prefix every locale, including the default. Hiding the default locale's prefix stops Google distinguishing the versions.
+- Handle the root either as `x-default` with a redirect, or as the default locale's content.
+- Don't negotiate content by IP or `Accept-Language`. Googlebot crawls from US IPs and sends no `Accept-Language`, so it will only ever see one version.
+- Keep trailing-slash and case consistent across paths, canonicals, hreflang, and sitemaps, and 301 the non-canonical form.
+
+Search Console's International Targeting report is deprecated, so geotargeting now rests on hreflang, content signals, and linking patterns.
+
+## Content across locales
+
+- Translate the whole page, not the chrome. Google reads visible content to determine language, so translating navigation while the body stays in the source language produces duplicates.
+- Machine translation is not inherently spam, but translations published at scale with no review can fall under scaled content abuse.
+- Don't create a locale you can't make genuinely useful. Thin locale pages are the worst of the options: noindexing them wastes crawl budget, and cross-locale canonicalizing them conflicts with hreflang.
+- Localize the details that signal a real regional presence: currency, phone format, address, date format.
+
+## Framework note
+
+Next.js `alternates.languages` does not add a self-referencing `<xhtml:link>` for the `<loc>` URL. Add the current locale explicitly, or every page in the set ships without its self-reference and all hreflang is ignored.
+
+## Sources
+
+- Google Search Central, Localized versions of your pages: https://developers.google.com/search/docs/specialty/international/localized-versions
+- Google Search Central, Managing multi-regional and multilingual sites: https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites
+- Google Search Central, Consolidate duplicate URLs: https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls
+- Google Search Central, Spam policies (scaled content abuse): https://developers.google.com/search/docs/essentials/spam-policies
+- Next.js, Internationalization metadata: https://nextjs.org/docs/app/api-reference/functions/generate-metadata

--- a/plugins/seo-skills/skills/site-architecture/SKILL.md
+++ b/plugins/seo-skills/skills/site-architecture/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: site-architecture
+description: "Use when planning or restructuring what pages a site has and how they connect: hierarchy, navigation, URL patterns, breadcrumbs, and internal linking. Not for XML sitemaps, which are in seo-audit."
+license: MIT
+---
+
+# Site architecture
+
+Architecture is one decision repeated: how does someone get from the homepage to the page that answers their question, and how does a crawler follow the same path. Depth, navigation, URLs, and internal links are four views of that one structure, so change them together or they drift.
+
+## Depth
+
+Aim to put any page that matters within three clicks of the homepage. It isn't a law, but a critical page four or more levels down is a symptom worth chasing.
+
+| Shape | Fits | Costs |
+| --- | --- | --- |
+| Flat, 2 levels | Small sites, portfolios | Stops scaling once a nav item has 20 children |
+| Moderate, 3 levels | Most SaaS and content sites | Usually the right answer |
+| Deep, 4 or more | Large catalogs, big docs | Scales, but buries things without strong linking |
+
+Go as flat as the navigation tolerates. When a dropdown passes roughly 20 items, that's the signal to add a level rather than keep the list flat.
+
+Levels: L0 is the homepage, L1 is a primary section (`/features`, `/blog`), L2 is a page within it (`/features/analytics`), L3 and beyond are detail pages (`/docs/api/authentication`).
+
+## Site types as starting points
+
+| Type | Depth | Sections | URL shape |
+| --- | --- | --- | --- |
+| SaaS marketing | 2 to 3 | Home, Features, Pricing, Blog, Docs | `/features/{name}`, `/blog/{slug}` |
+| Content site | 2 to 3 | Home, Blog, Categories, About | `/blog/{slug}`, `/blog/category/{slug}` |
+| Ecommerce | 3 to 4 | Home, Categories, Products | `/{category}/{subcategory}/{product}` |
+| Documentation | 3 to 4 | Home, Guides, Reference | `/docs/{section}/{page}` |
+| SaaS plus content | 3 to 4 | Home, Product, Blog, Resources, Docs | `/product/{feature}`, `/blog/{slug}` |
+| Small business | 1 to 2 | Home, Services, About, Contact | `/services/{name}` |
+
+## URLs
+
+Readable, lowercase, hyphenated, mirroring the hierarchy, with one trailing-slash policy enforced everywhere. Short but still descriptive: `/blog/landing-page-conversions` beats `/blog/how-to-improve-your-landing-page-conversion-rates`.
+
+The mistakes that cost the most:
+
+- Dates in blog URLs. `/blog/2026/07/25/title` adds nothing and ages the post visibly.
+- IDs or query strings carrying content. `/product/12345` and `/blog?id=123` should be slugs.
+- Over-nesting past what the hierarchy needs.
+- Mixing parents for the same kind of page, like `/features/analytics` alongside `/product/automation`.
+- Changing a URL without a 301. Every old URL needs one, or the links pointing at it stop counting and anyone who bookmarked it gets a 404. This is the single most common cause of traffic loss after a redesign.
+
+`references/patterns.md` has the URL pattern per page type, navigation layouts, and the diagram formats to hand back.
+
+## Navigation
+
+Primary navigation holds 4 to 7 items, ordered by importance, with the logo linking home and the call to action rightmost. Past 7, people stop reading the list and start hunting.
+
+Footers group into columns: product, resources, company, legal. Sidebars carry within-section navigation for docs and long content. Breadcrumbs mirror the URL path exactly, with every segment linked except the current page, and they pair with `BreadcrumbList` schema.
+
+Breadcrumbs are the cheapest structural win available: they add internal links on every page, they make hierarchy legible to a crawler, and they can earn a richer result.
+
+## Internal linking
+
+- No orphans. Every page needs at least one internal link pointing at it, and the sitemap is not a link.
+- Anchor text describes the destination. Never "click here" or "read more".
+- How many contextual links a single page carries is a decision for whoever owns that page's format, so recommend the connections worth making rather than a density target.
+- Link the pages that matter more often. Inbound internal links are how you tell a crawler what's important.
+- Hub and spoke for content clusters: one comprehensive hub, spokes covering sub-topics, each spoke linking back to the hub, the hub linking to all spokes, and spokes cross-linking where a reader would actually want it.
+
+Hub and spoke is what makes a set of posts add up to more than its pages, because it concentrates the signal on the hub rather than spreading it across a dozen equal posts competing with each other.
+
+## What to hand back
+
+An ASCII tree of the hierarchy with the URL at each node, a URL map table (page, URL, parent, where it appears in navigation, priority), the redirect list when anything moves, and a Mermaid diagram when the structure is worth seeing rather than reading. `references/patterns.md` has the formats.
+
+## Sources
+
+- Google Search Central, URL structure best practices: https://developers.google.com/search/docs/crawling-indexing/url-structure
+- Google Search Central, Redirects and Google Search: https://developers.google.com/search/docs/crawling-indexing/301-redirects
+- Google Search Central, Breadcrumb structured data: https://developers.google.com/search/docs/appearance/structured-data/breadcrumb
+- Nielsen Norman Group, Flat vs deep website hierarchies: https://www.nngroup.com/articles/flat-vs-deep-hierarchy/

--- a/plugins/seo-skills/skills/site-architecture/references/patterns.md
+++ b/plugins/seo-skills/skills/site-architecture/references/patterns.md
@@ -1,0 +1,174 @@
+# Architecture patterns and output formats
+
+## URL pattern per page type
+
+| Page type | Pattern | Example |
+| --- | --- | --- |
+| Homepage | `/` | `example.com` |
+| Feature | `/features/{name}` | `/features/analytics` |
+| Pricing | `/pricing` | `/pricing` |
+| Blog post | `/blog/{slug}` | `/blog/seo-guide` |
+| Blog category | `/blog/category/{slug}` | `/blog/category/seo` |
+| Case study | `/customers/{slug}` | `/customers/acme` |
+| Documentation | `/docs/{section}/{page}` | `/docs/api/authentication` |
+| Comparison | `/compare/{competitor}` | `/compare/competitor-name` |
+| Integration | `/integrations/{name}` | `/integrations/slack` |
+| Template | `/templates/{slug}` | `/templates/marketing-plan` |
+| Landing page | `/{slug}` or `/lp/{slug}` | `/free-trial` |
+| Legal | `/{page}` | `/privacy`, `/terms` |
+
+Pick one parent per page class and keep it. Half the site under `/features/` and half under `/product/` is the most common inconsistency, and it splits the internal linking that should have accumulated on one section.
+
+## Navigation layouts
+
+Header, 4 to 7 items, ordered by importance:
+
+```text
+[Logo]   Product   Solutions   Pricing   Resources   Docs        [Sign in] [Start free]
+```
+
+Mega menu, at most 3 to 4 columns, each with a heading so the group is scannable:
+
+```text
+Product ▾
+  Platform            Use cases           Resources
+  Analytics           For marketing       Docs
+  Automation          For sales           Changelog
+  Integrations        For support         Status
+```
+
+Footer, grouped:
+
+```text
+Product          Resources        Company          Legal
+Features         Blog             About            Privacy
+Pricing          Case studies     Careers          Terms
+Integrations     Templates        Contact          Security
+Changelog        Docs             Press
+```
+
+Breadcrumbs mirror the URL, current page unlinked:
+
+```text
+Home > Features > Analytics
+Home > Blog > SEO > Internal linking that actually works
+Home > Docs > API > Authentication
+```
+
+| URL | Breadcrumb |
+| --- | --- |
+| `/features/analytics` | Home > Features > Analytics |
+| `/blog/seo-guide` | Home > Blog > SEO Guide |
+| `/docs/api/auth` | Home > Docs > API > Authentication |
+
+## ASCII tree
+
+The default for handing back a hierarchy. Put the URL beside every node so it doubles as the URL map.
+
+```text
+Homepage (/)
+├── Features (/features)
+│   ├── Analytics (/features/analytics)
+│   ├── Automation (/features/automation)
+│   └── Integrations (/features/integrations)
+├── Pricing (/pricing)
+├── Blog (/blog)
+│   ├── SEO (/blog/category/seo)
+│   └── Growth (/blog/category/growth)
+├── Resources (/resources)
+│   ├── Case studies (/customers)
+│   └── Templates (/templates)
+├── Docs (/docs)
+│   ├── Getting started (/docs/getting-started)
+│   └── API reference (/docs/api)
+├── About (/about)
+│   └── Careers (/about/careers)
+└── Contact (/contact)
+```
+
+Use ASCII for a quick draft or anywhere the output is text. Use Mermaid when the point is the shape rather than the list, or when navigation zones and cross-links matter.
+
+## Mermaid diagrams
+
+Hierarchy:
+
+```mermaid
+graph TD
+    HOME[Homepage] --> FEAT[Features]
+    HOME --> PRICE[Pricing]
+    HOME --> BLOG[Blog]
+    HOME --> DOCS[Docs]
+    FEAT --> F1[Analytics]
+    FEAT --> F2[Automation]
+    FEAT --> F3[Integrations]
+    BLOG --> B1[SEO category]
+    BLOG --> B2[Growth category]
+```
+
+Navigation zones, to show what's reachable from where:
+
+```mermaid
+graph TD
+    subgraph Header
+        HOME[Homepage]
+        FEAT[Features]
+        PRICE[Pricing]
+        CTA[Start free]
+    end
+    subgraph Footer
+        ABOUT[About]
+        CAREERS[Careers]
+        PRIVACY[Privacy]
+    end
+    HOME --> FEAT
+    HOME --> PRICE
+    HOME --> ABOUT
+    FEAT --> F1[Analytics]
+```
+
+Hub and spoke, to show a content cluster's linking:
+
+```mermaid
+graph TD
+    HUB[Hub: complete guide to X] --> S1[Spoke: sub-topic one]
+    HUB --> S2[Spoke: sub-topic two]
+    HUB --> S3[Spoke: sub-topic three]
+    S1 --> HUB
+    S2 --> HUB
+    S3 --> HUB
+    S1 <--> S2
+```
+
+## URL map table
+
+The deliverable a developer or a CMS owner can work from directly.
+
+| Page | URL | Parent | Navigation | Priority |
+| --- | --- | --- | --- | --- |
+| Homepage | `/` | none | Header | High |
+| Features | `/features` | Homepage | Header | High |
+| Analytics | `/features/analytics` | Features | Header dropdown | High |
+| Pricing | `/pricing` | Homepage | Header | High |
+| Blog | `/blog` | Homepage | Header | Medium |
+| About | `/about` | Homepage | Footer | Low |
+
+## Redirect list
+
+Required output whenever a URL moves. Without it, the links pointing at the old URL stop counting.
+
+| Old URL | New URL | Type |
+| --- | --- | --- |
+| `/product/analytics` | `/features/analytics` | 301 |
+| `/blog/2026/07/post-title` | `/blog/post-title` | 301 |
+
+Redirect to the final destination rather than through a chain, and check that no redirect target is itself redirected.
+
+## Link audit checks
+
+- Every page has at least one inbound internal link.
+- No internal link returns a 404 or lands on a redirect.
+- Anchor text describes the destination.
+- The pages that matter most have the most inbound internal links.
+- Breadcrumbs exist site-wide and carry `BreadcrumbList` schema.
+- Posts have related-content links, and clusters link back to their hub.
+- Cross-section links exist where a reader would want one: features to case studies, blog to product.


### PR DESCRIPTION
Frontend design and SEO work now get reusable checks that ship together with the marketplace.

`claude plugin install seo-skills@claude-settings`

- installs four SEO skills with local schema validation
- adds a vendor-neutral writing guide to frontend design
- rebuilds identical ZIP packages on every sync