### PR TITLE
Load SEO skills by default

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -18,14 +18,13 @@ Ask yourself: "What can I delete instead of add, and does this trace to what was
 
 ## Working Rules
 
-- Reflect on tool results before acting, then plan and take the best next action.
-- Run independent operations in parallel.
-- Verify your solution before finishing.
+- Reflect on tool results, run independent operations in parallel, and verify before finishing.
 - Before committing to an approach, and after two failed attempts at the same problem, get a second opinion with `/codex-advisor` or `/fable-advisor` if either is installed.
-- Never create files unless necessary. Prefer editing. Never create docs (*.md, README) unless asked.
+- Prefer editing existing files, and check related code for consistency. Never create docs (*.md, README) unless asked.
 - Prefer `rg` over `grep`.
-- When updating code, check related code in the same and other files for consistency.
-- Never use `consolidate`, `modernize`, `streamline`, `flexible`, `delve`, `establish`, `enhanced`, `comprehensive`, `optimize`, or em-dashes in docstrings, commit messages, or comments.
+- Use the `writing-guidelines` skill to review documentation or interface copy, and the `humanize` skill to remove generic or machine-written phrasing.
+- For SEO, use the `seo-audit`, `site-architecture`, `programmatic-seo`, or `schema` skill based on the task.
+- Use the `anthropic-frontend-design` or `openai-frontend-design` skill when creating or reshaping a UI.
 
 ## MCP Tools
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -9,9 +9,6 @@ model_auto_compact_token_limit = 400000
 model_auto_compact_token_limit_scope = "body_after_prefix"
 service_tier = "default"
 
-# Guidance for the auto_review guardian subagent. Replaces the bundled tenant
-# policy, so the defaults are inlined here alongside the workspace specifics.
-# Mirrors the autoMode block in .claude/settings.json.
 [auto_review]
 policy = """
 ## Environment Profile
@@ -94,6 +91,9 @@ enabled = true
 enabled = true
 
 [plugins."frontend-design-skills@claude-settings"]
+enabled = true
+
+[plugins."seo-skills@claude-settings"]
 enabled = true
 
 [plugins."github-dev@claude-settings"]

--- a/README.md
+++ b/README.md
@@ -1119,15 +1119,11 @@ exec "$@" --thinking-display summarized
 - [x] Documents: Google Docs, PPTX, DOCX, Excel from OpenAI (bundled as `openai-office-skills`)
 - [ ] Auth: Clerk, Firebase patterns
 - [ ] Fullstack: FastAPI, NodeJS backends, Tailwind CSS v4, [shadcn/ui](https://github.com/shadcn-ui/ui), Sentry monitoring, [Web Vitals](https://nextjs.org/docs/app/api-reference/functions/use-report-web-vitals)
-- [ ] Productivity: [Caveman](https://github.com/JuliusBrussee/caveman) compressed output style saving ~75% of tokens
 
 **Static website:**
 
-- [ ] Publish `agentplugins.net` as a plugin catalog site with search, category filtering, per-tool install snippets, and GitHub Pages hosting
-
-**Other:**
-
-- [ ] Change marketplace and repo name to Agent Plugins instead of Claude Settings or Claude Codex Settings, and update the repo thumbnail
+- [x] Publish `agentplugins.net` as a plugin catalog site with search, category filtering, per-tool install snippets, and GitHub Pages hosting
+- [x] SEO: Vercel's suggested SEO guidelines
 
 ## References
 


### PR DESCRIPTION
Codex now references SEO workflows in shared guidance, so the project config should load the plugin that provides them.

```toml
[plugins."seo-skills@claude-settings"]
enabled = true
```

- route writing and frontend work through named skills
- remove the static Humanize word blacklist
- clear completed roadmap items and stale config comments