### PR TITLE
Allow semicolons in code references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "humanize",
       "source": "./plugins/humanize",
       "description": "Block a curated list of AI buzzwords on every write with a hook.",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "Apache-2.0"
     },
     {

--- a/.github/scripts/test_humanize.py
+++ b/.github/scripts/test_humanize.py
@@ -8,7 +8,6 @@ import unittest
 from pathlib import Path
 
 HOOK = Path(__file__).parents[2] / "plugins/humanize/hooks/scripts/humanize.py"
-EMDASH = "\u2014"
 SEMICOLON = chr(59)
 
 
@@ -31,24 +30,24 @@ class HumanizeTest(unittest.TestCase):
         """Mask closed, incomplete, and multi-backtick Markdown code."""
         fence = "`" * 3
         for content in (
-            f"Intro.\n{fence}js\nconst a = 1{EMDASH}\n{fence}\n",
-            f"Intro.\n{fence}js\nconst a = 1{EMDASH}\n",
-            f"Use ``leverage`this{EMDASH}`` in a sentence.\n",
+            f"Intro.\n{fence}js\nconst a = 1{SEMICOLON}\n{fence}\n",
+            f"Intro.\n{fence}js\nconst a = 1{SEMICOLON}\n",
+            f"Use ``leverage`this{SEMICOLON}`` in a sentence.\n",
         ):
             self.assertEqual(run_hook("Write", {"file_path": "README.md", "content": content}), "")
 
     def test_ignores_ambiguous_text_files(self):
         """Ignore generic text files that may contain logs or fixtures."""
         self.assertEqual(
-            run_hook("Write", {"file_path": "fixture.txt", "content": f"GET /a 200{EMDASH} GET /b 404{EMDASH}"}),
+            run_hook("Write", {"file_path": "fixture.txt", "content": f"GET /a 200{SEMICOLON} GET /b 404{SEMICOLON}"}),
             "",
         )
 
     def test_comments_are_quote_aware(self):
         """Ignore comment markers inside quoted values and strings."""
         cases = (
-            ("config.yml", f'motd: "welcome # to prod{EMDASH} be careful"\n'),
-            ("app.ts", f'const note = "see {"/" * 2} ref{EMDASH} here"{SEMICOLON}\n'),
+            ("config.yml", f'motd: "welcome # to prod{SEMICOLON} be careful"\n'),
+            ("app.ts", f'const note = "see {"/" * 2} ref{SEMICOLON} here"{SEMICOLON}\n'),
         )
         for path, content in cases:
             self.assertEqual(run_hook("Write", {"file_path": path, "content": content}), "")
@@ -56,9 +55,10 @@ class HumanizeTest(unittest.TestCase):
     def test_checks_real_writing(self):
         """Keep blocking marks in Markdown and code comments."""
         cases = (
-            ("README.md", f"This sentence has an em dash{EMDASH} replace it."),
-            ("config.yml", f"# This comment has an em dash{EMDASH} replace it."),
-            ("app.ts", f"{'/' * 2} This comment has an em dash{EMDASH} replace it."),
+            ("README.md", f"This sentence has a semicolon{SEMICOLON} replace it."),
+            ("config.yml", f"# This comment has a semicolon{SEMICOLON} replace it."),
+            ("app.py", f'"""This docstring has a semicolon{SEMICOLON} replace it."""'),
+            ("app.ts", f"{'/' * 2} This comment has a semicolon{SEMICOLON} replace it."),
         )
         for path, content in cases:
             self.assertTrue(run_hook("Write", {"file_path": path, "content": content}))
@@ -67,16 +67,16 @@ class HumanizeTest(unittest.TestCase):
         """Use the full Markdown file to classify edited text."""
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "README.md"
-            path.write_text(f"Intro.\n```js\nconst value = 1{EMDASH}\n```\nOld sentence.\n")
+            path.write_text(f"Intro.\n```js\nconst value = 1{SEMICOLON}\n```\nOld sentence.\n")
             code_edit = {
                 "file_path": str(path),
-                "old_string": f"const value = 1{EMDASH}",
-                "new_string": f"const value = 2{EMDASH}",
+                "old_string": f"const value = 1{SEMICOLON}",
+                "new_string": f"const value = 2{SEMICOLON}",
             }
             prose_edit = {
                 "file_path": str(path),
                 "old_string": "Old sentence.",
-                "new_string": f"New{EMDASH} sentence.",
+                "new_string": f"New{SEMICOLON} sentence.",
             }
             self.assertEqual(run_hook("Edit", code_edit), "")
             self.assertIn(f"{path}:5:4", run_hook("Edit", prose_edit))
@@ -85,14 +85,14 @@ class HumanizeTest(unittest.TestCase):
         """Use the full Markdown file to classify patched text."""
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "README.md"
-            path.write_text(f"Intro.\n```js\nconst value = 1{EMDASH}\n```\nOld sentence.\n")
+            path.write_text(f"Intro.\n```js\nconst value = 1{SEMICOLON}\n```\nOld sentence.\n")
             code_patch = (
                 f"*** Begin Patch\n*** Update File: {path}\n@@\n ```js\n"
-                f"-const value = 1{EMDASH}\n+const value = 2{EMDASH}\n ```\n*** End Patch"
+                f"-const value = 1{SEMICOLON}\n+const value = 2{SEMICOLON}\n ```\n*** End Patch"
             )
             prose_patch = (
                 f"*** Begin Patch\n*** Update File: {path}\n@@\n ```\n"
-                f"-Old sentence.\n+New{EMDASH} sentence.\n*** End Patch"
+                f"-Old sentence.\n+New{SEMICOLON} sentence.\n*** End Patch"
             )
             self.assertEqual(run_hook("apply_patch", {"command": code_patch}), "")
             self.assertIn(f"{path}:5:4", run_hook("apply_patch", {"command": prose_patch}))
@@ -103,15 +103,14 @@ class HumanizeTest(unittest.TestCase):
             "Write",
             {
                 "file_path": "README.md",
-                "content": f"First line.\nAI sections{EMDASH} it does not{EMDASH}\nWe leverage tools.\nIn conclusion, done.\n",
+                "content": f"First line.\nAI sections{SEMICOLON} it does not{SEMICOLON}\nWe leverage tools.\nIn conclusion, done.\n",
             },
         )
         self.assertIn(
-            "- em-dash at README.md:2:12, use commas or periods: "
-            + json.dumps(f"AI sections{EMDASH} it does not{EMDASH}"),
+            f'- semicolon at README.md:2:12, use a period or comma: "AI sections{SEMICOLON} it does not{SEMICOLON}"',
             reason,
         )
-        self.assertEqual(reason.count("- em-dash at"), 2)
+        self.assertEqual(reason.count("- semicolon at"), 2)
         self.assertIn('"leverage" at README.md:3:4, use "use"', reason)
         self.assertIn('"In conclusion" at README.md:4:1, drop it', reason)
 
@@ -126,20 +125,22 @@ class HumanizeTest(unittest.TestCase):
     def test_labels_non_file_sources(self):
         """Label PR, Slack, and heredoc findings by their real source."""
         cases = (
-            ("Bash", {"command": f'gh pr create -b "One{EMDASH} two"'}, "PR body:1:4"),
+            ("Bash", {"command": f'git commit -m "One{SEMICOLON} two"'}, "commit message:1:4"),
+            ("Bash", {"command": f'gh pr create -t "One{SEMICOLON} two"'}, "PR title:1:4"),
+            ("Bash", {"command": f'gh pr create -b "One{SEMICOLON} two"'}, "PR body:1:4"),
             (
                 "mcp__claude_ai_Slack__slack_send_message",
-                {"message": f"One{EMDASH} two"},
+                {"message": f"One{SEMICOLON} two"},
                 "Slack message:1:4",
             ),
             (
                 "mcp__codex_apps__slack_slack_send_message",
-                {"message": {"markdown_text": f"One{EMDASH} two"}},
+                {"message": {"markdown_text": f"One{SEMICOLON} two"}},
                 "Slack message:1:4",
             ),
             (
                 "Bash",
-                {"command": f"cat > notes.md <<'EOF'\nOne{EMDASH} two\nEOF"},
+                {"command": f"cat > notes.md <<'EOF'\nOne{SEMICOLON} two\nEOF"},
                 "notes.md:1:4",
             ),
         )
@@ -149,22 +150,24 @@ class HumanizeTest(unittest.TestCase):
     def test_checks_github_close_comments_from_shell_tools(self):
         """Check close comments from Claude and Codex shell calls."""
         cases = (
-            ("Bash", {"command": f'gh pr close 106 --comment "Old{EMDASH} new"'}),
-            ("exec_command", {"cmd": f'gh issue close 105 -c "Fixed{EMDASH} thanks"'}),
+            ("Bash", {"command": f'gh pr close 106 --comment "Old{SEMICOLON} new"'}),
+            ("exec_command", {"cmd": f'gh issue close 105 -c "Fixed{SEMICOLON} thanks"'}),
         )
         for tool, tool_input in cases:
-            self.assertIn("em-dash at GitHub comment:1:", run_hook(tool, tool_input))
+            self.assertIn("semicolon at GitHub comment:1:", run_hook(tool, tool_input))
         self.assertEqual(run_hook("Bash", {"command": "gh pr review 106 -c"}), "")
         self.assertEqual(run_hook("Bash", {"command": "gh pr close 106 && gh pr review 106 -c"}), "")
         self.assertEqual(run_hook("exec_command", {"cmd": "git status --short"}), "")
 
-    def test_allows_semicolons(self):
-        """Allow ordinary semicolons in prose, comments, and commit messages."""
+    def test_allows_formatted_code_references(self):
+        """Allow semicolons in formatted code references."""
         cases = (
-            ("Write", {"file_path": "README.md", "content": f"Fixed the timeout{SEMICOLON} added a retry.\n"}),
-            ("Write", {"file_path": "app.php", "content": f"// call $db->begin(){SEMICOLON} then commit()\n"}),
-            ("Write", {"file_path": "main.css", "content": f"/* was: display: none{SEMICOLON} now in main.css */\n"}),
-            ("Bash", {"command": f"git commit -m 'Fix timeout{SEMICOLON} add retry'"}),
+            ("Write", {"file_path": "app.py", "content": f'"""Call `run(){SEMICOLON}` after setup."""\n'}),
+            ("Write", {"file_path": "app.php", "content": f"// call `$db->begin(){SEMICOLON}` then commit()\n"}),
+            ("Write", {"file_path": "main.css", "content": f"/* keep `display: none{SEMICOLON}` for print */\n"}),
+            ("Bash", {"command": f"git commit -m 'Use `run(){SEMICOLON}` for startup'"}),
+            ("Bash", {"command": f"gh pr create -b 'Use `run(){SEMICOLON}` for startup'"}),
+            ("mcp__codex_apps__slack_slack_send_message", {"message": f"Use `run(){SEMICOLON}` for startup"}),
         )
         for tool, tool_input in cases:
             self.assertEqual(run_hook(tool, tool_input), "")

--- a/.github/scripts/test_humanize.py
+++ b/.github/scripts/test_humanize.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 
 HOOK = Path(__file__).parents[2] / "plugins/humanize/hooks/scripts/humanize.py"
+EMDASH = "\u2014"
 SEMICOLON = chr(59)
 
 
@@ -30,24 +31,24 @@ class HumanizeTest(unittest.TestCase):
         """Mask closed, incomplete, and multi-backtick Markdown code."""
         fence = "`" * 3
         for content in (
-            f"Intro.\n{fence}js\nconst a = 1{SEMICOLON}\n{fence}\n",
-            f"Intro.\n{fence}js\nconst a = 1{SEMICOLON}\n",
-            f"Use ``leverage`this{SEMICOLON}`` in a sentence.\n",
+            f"Intro.\n{fence}js\nconst a = 1{EMDASH}\n{fence}\n",
+            f"Intro.\n{fence}js\nconst a = 1{EMDASH}\n",
+            f"Use ``leverage`this{EMDASH}`` in a sentence.\n",
         ):
             self.assertEqual(run_hook("Write", {"file_path": "README.md", "content": content}), "")
 
     def test_ignores_ambiguous_text_files(self):
         """Ignore generic text files that may contain logs or fixtures."""
         self.assertEqual(
-            run_hook("Write", {"file_path": "fixture.txt", "content": f"GET /a 200{SEMICOLON} GET /b 404{SEMICOLON}"}),
+            run_hook("Write", {"file_path": "fixture.txt", "content": f"GET /a 200{EMDASH} GET /b 404{EMDASH}"}),
             "",
         )
 
     def test_comments_are_quote_aware(self):
         """Ignore comment markers inside quoted values and strings."""
         cases = (
-            ("config.yml", f'motd: "welcome # to prod{SEMICOLON} be careful"\n'),
-            ("app.ts", f'const note = "see {"/" * 2} ref{SEMICOLON} here"{SEMICOLON}\n'),
+            ("config.yml", f'motd: "welcome # to prod{EMDASH} be careful"\n'),
+            ("app.ts", f'const note = "see {"/" * 2} ref{EMDASH} here"{SEMICOLON}\n'),
         )
         for path, content in cases:
             self.assertEqual(run_hook("Write", {"file_path": path, "content": content}), "")
@@ -55,9 +56,9 @@ class HumanizeTest(unittest.TestCase):
     def test_checks_real_writing(self):
         """Keep blocking marks in Markdown and code comments."""
         cases = (
-            ("README.md", f"This sentence has a semicolon{SEMICOLON} replace it."),
-            ("config.yml", f"# This comment has a semicolon{SEMICOLON} replace it."),
-            ("app.ts", f"{'/' * 2} This comment has a semicolon{SEMICOLON} replace it."),
+            ("README.md", f"This sentence has an em dash{EMDASH} replace it."),
+            ("config.yml", f"# This comment has an em dash{EMDASH} replace it."),
+            ("app.ts", f"{'/' * 2} This comment has an em dash{EMDASH} replace it."),
         )
         for path, content in cases:
             self.assertTrue(run_hook("Write", {"file_path": path, "content": content}))
@@ -66,16 +67,16 @@ class HumanizeTest(unittest.TestCase):
         """Use the full Markdown file to classify edited text."""
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "README.md"
-            path.write_text(f"Intro.\n```js\nconst value = 1{SEMICOLON}\n```\nOld sentence.\n")
+            path.write_text(f"Intro.\n```js\nconst value = 1{EMDASH}\n```\nOld sentence.\n")
             code_edit = {
                 "file_path": str(path),
-                "old_string": f"const value = 1{SEMICOLON}",
-                "new_string": f"const value = 2{SEMICOLON}",
+                "old_string": f"const value = 1{EMDASH}",
+                "new_string": f"const value = 2{EMDASH}",
             }
             prose_edit = {
                 "file_path": str(path),
                 "old_string": "Old sentence.",
-                "new_string": f"New{SEMICOLON} sentence.",
+                "new_string": f"New{EMDASH} sentence.",
             }
             self.assertEqual(run_hook("Edit", code_edit), "")
             self.assertIn(f"{path}:5:4", run_hook("Edit", prose_edit))
@@ -84,14 +85,14 @@ class HumanizeTest(unittest.TestCase):
         """Use the full Markdown file to classify patched text."""
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "README.md"
-            path.write_text(f"Intro.\n```js\nconst value = 1{SEMICOLON}\n```\nOld sentence.\n")
+            path.write_text(f"Intro.\n```js\nconst value = 1{EMDASH}\n```\nOld sentence.\n")
             code_patch = (
                 f"*** Begin Patch\n*** Update File: {path}\n@@\n ```js\n"
-                f"-const value = 1{SEMICOLON}\n+const value = 2{SEMICOLON}\n ```\n*** End Patch"
+                f"-const value = 1{EMDASH}\n+const value = 2{EMDASH}\n ```\n*** End Patch"
             )
             prose_patch = (
                 f"*** Begin Patch\n*** Update File: {path}\n@@\n ```\n"
-                f"-Old sentence.\n+New{SEMICOLON} sentence.\n*** End Patch"
+                f"-Old sentence.\n+New{EMDASH} sentence.\n*** End Patch"
             )
             self.assertEqual(run_hook("apply_patch", {"command": code_patch}), "")
             self.assertIn(f"{path}:5:4", run_hook("apply_patch", {"command": prose_patch}))
@@ -102,14 +103,15 @@ class HumanizeTest(unittest.TestCase):
             "Write",
             {
                 "file_path": "README.md",
-                "content": f"First line.\nAI sections{SEMICOLON} it does not{SEMICOLON}\nWe leverage tools.\nIn conclusion, done.\n",
+                "content": f"First line.\nAI sections{EMDASH} it does not{EMDASH}\nWe leverage tools.\nIn conclusion, done.\n",
             },
         )
         self.assertIn(
-            f'- semicolon at README.md:2:12, use a period or comma: "AI sections{SEMICOLON} it does not{SEMICOLON}"',
+            "- em-dash at README.md:2:12, use commas or periods: "
+            + json.dumps(f"AI sections{EMDASH} it does not{EMDASH}"),
             reason,
         )
-        self.assertEqual(reason.count("- semicolon at"), 2)
+        self.assertEqual(reason.count("- em-dash at"), 2)
         self.assertIn('"leverage" at README.md:3:4, use "use"', reason)
         self.assertIn('"In conclusion" at README.md:4:1, drop it', reason)
 
@@ -124,20 +126,20 @@ class HumanizeTest(unittest.TestCase):
     def test_labels_non_file_sources(self):
         """Label PR, Slack, and heredoc findings by their real source."""
         cases = (
-            ("Bash", {"command": f'gh pr create -b "One{SEMICOLON} two"'}, "PR body:1:4"),
+            ("Bash", {"command": f'gh pr create -b "One{EMDASH} two"'}, "PR body:1:4"),
             (
                 "mcp__claude_ai_Slack__slack_send_message",
-                {"message": f"One{SEMICOLON} two"},
+                {"message": f"One{EMDASH} two"},
                 "Slack message:1:4",
             ),
             (
                 "mcp__codex_apps__slack_slack_send_message",
-                {"message": {"markdown_text": f"One{SEMICOLON} two"}},
+                {"message": {"markdown_text": f"One{EMDASH} two"}},
                 "Slack message:1:4",
             ),
             (
                 "Bash",
-                {"command": f"cat > notes.md <<'EOF'\nOne{SEMICOLON} two\nEOF"},
+                {"command": f"cat > notes.md <<'EOF'\nOne{EMDASH} two\nEOF"},
                 "notes.md:1:4",
             ),
         )
@@ -147,14 +149,25 @@ class HumanizeTest(unittest.TestCase):
     def test_checks_github_close_comments_from_shell_tools(self):
         """Check close comments from Claude and Codex shell calls."""
         cases = (
-            ("Bash", {"command": f'gh pr close 106 --comment "Old{SEMICOLON} new"'}),
-            ("exec_command", {"cmd": f'gh issue close 105 -c "Fixed{SEMICOLON} thanks"'}),
+            ("Bash", {"command": f'gh pr close 106 --comment "Old{EMDASH} new"'}),
+            ("exec_command", {"cmd": f'gh issue close 105 -c "Fixed{EMDASH} thanks"'}),
         )
         for tool, tool_input in cases:
-            self.assertIn("semicolon at GitHub comment:1:", run_hook(tool, tool_input))
+            self.assertIn("em-dash at GitHub comment:1:", run_hook(tool, tool_input))
         self.assertEqual(run_hook("Bash", {"command": "gh pr review 106 -c"}), "")
         self.assertEqual(run_hook("Bash", {"command": "gh pr close 106 && gh pr review 106 -c"}), "")
         self.assertEqual(run_hook("exec_command", {"cmd": "git status --short"}), "")
+
+    def test_allows_semicolons(self):
+        """Allow ordinary semicolons in prose, comments, and commit messages."""
+        cases = (
+            ("Write", {"file_path": "README.md", "content": f"Fixed the timeout{SEMICOLON} added a retry.\n"}),
+            ("Write", {"file_path": "app.php", "content": f"// call $db->begin(){SEMICOLON} then commit()\n"}),
+            ("Write", {"file_path": "main.css", "content": f"/* was: display: none{SEMICOLON} now in main.css */\n"}),
+            ("Bash", {"command": f"git commit -m 'Fix timeout{SEMICOLON} add retry'"}),
+        )
+        for tool, tool_input in cases:
+            self.assertEqual(run_hook(tool, tool_input), "")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_humanize.py
+++ b/.github/scripts/test_humanize.py
@@ -172,6 +172,32 @@ class HumanizeTest(unittest.TestCase):
         for tool, tool_input in cases:
             self.assertEqual(run_hook(tool, tool_input), "")
 
+    def test_allows_code_shaped_comment_references(self):
+        """Allow unformatted code-shaped references in comments and docstrings."""
+        cases = (
+            ("app.php", f"// call $db->begin(){SEMICOLON} then commit()\n"),
+            ("app.js", f"// previous code used const active = true{SEMICOLON} here\n"),
+            ("app.ts", f"// call client.start(){SEMICOLON} after setup\n"),
+            ("main.css", f"/* was: display: none{SEMICOLON} now in main.css */\n"),
+            ("main.scss", f"/* keep gap: var(--space){SEMICOLON} between items */\n"),
+            ("app.py", f'"""Call client.start(){SEMICOLON} after setup."""\n'),
+        )
+        for path, content in cases:
+            self.assertEqual(run_hook("Write", {"file_path": path, "content": content}), "")
+
+    def test_keeps_blocking_text_beside_code_references(self):
+        """Keep blocking text semicolons near code-shaped references."""
+        cases = (
+            ("app.php", f"// call $db->begin(){SEMICOLON} then wait{SEMICOLON} retry\n"),
+            ("app.js", f"// first do this{SEMICOLON} then that\n"),
+            ("main.css", f"/* Note: first{SEMICOLON} then second */\n"),
+            ("main.css", f"/* reason: unclear{SEMICOLON} try again */\n"),
+            ("app.py", f'"""First do this{SEMICOLON} then that."""\n'),
+            ("app.js", f"// {'a' * 10000}{SEMICOLON}\n"),
+        )
+        for path, content in cases:
+            self.assertTrue(run_hook("Write", {"file_path": path, "content": content}))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 | ------------------------------------------------ | ------------------------------------------- | ----------------------------------------------------- |
 | `claude plugin install humanize@claude-settings` | `codex plugin add humanize@claude-settings` | `gemini extensions install --path ./plugins/humanize` |
 
-Before a Write or Edit saves, humanize scans the new text and blocks whatever reads like a machine wrote it, each hit paired with a plain-word swap. It reads markdown files whole and, in code, only the comments and docstrings, never the code:
+Before a Write or Edit saves, humanize scans the new text and blocks whatever reads like a machine wrote it, each hit paired with a plain-word swap. It reads Markdown files whole and checks comments and docstrings in code files while skipping source code and recognized code-shaped references:
 
 - **3 marks**: the em-dash, section sign, and stray semicolon (the en-dash stays)
 - **53 stock words** like `leverage`, `seamlessly`, `vibrant`, `game-changing`, each mapped to a plain swap

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 
 Before a Write or Edit saves, humanize scans the new text and blocks whatever reads like a machine wrote it, each hit paired with a plain-word swap. It reads markdown files whole and, in code, only the comments and docstrings, never the code:
 
-- **3 marks**: the em-dash, section sign, and stray semicolon (the en-dash stays)
+- **2 marks**: the em-dash and section sign (the en-dash stays)
 - **53 stock words** like `leverage`, `seamlessly`, `vibrant`, `game-changing`, each mapped to a plain swap
 - **16 openers and cliches** like `in conclusion`, `a testament to`, `aims to bridge`
 - **10 pile-up words** like `crucial` or `significant`, flagged at 3+ uses in one write

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Run `/simplify` to review your staged or committed diff across four angles (reus
 
 Before a Write or Edit saves, humanize scans the new text and blocks whatever reads like a machine wrote it, each hit paired with a plain-word swap. It reads markdown files whole and, in code, only the comments and docstrings, never the code:
 
-- **2 marks**: the em-dash and section sign (the en-dash stays)
+- **3 marks**: the em-dash, section sign, and stray semicolon (the en-dash stays)
 - **53 stock words** like `leverage`, `seamlessly`, `vibrant`, `game-changing`, each mapped to a plain swap
 - **16 openers and cliches** like `in conclusion`, `a testament to`, `aims to bridge`
 - **10 pile-up words** like `crucial` or `significant`, flagged at 3+ uses in one write

--- a/plugins/humanize/.claude-plugin/plugin.json
+++ b/plugins/humanize/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.codex-plugin/plugin.json
+++ b/plugins/humanize/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/.cursor-plugin/plugin.json
+++ b/plugins/humanize/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Block a curated list of AI buzzwords on every write with a hook.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/humanize/gemini-extension.json
+++ b/plugins/humanize/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "humanize",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Block a curated list of AI buzzwords on every write with a hook."
 }

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -64,6 +64,17 @@ OFTEN = ["crucial", "essential", "vital", "significant", "moreover", "furthermor
 
 MARKS = {"—": ("em-dash", "use commas or periods"), "§": ("section sign", "remove it"), ";": ("semicolon", "use a period or comma")}
 MARK_RE = re.compile("|".join(map(re.escape, MARKS)))
+CODE_REFERENCE_RE = re.compile(
+    r"(?<![\w$])(?:[$A-Za-z_]\w*(?:(?:->|::|\.)[$A-Za-z_]\w*)*(?:\([^;\n]*\))|"
+    r"[$A-Za-z_]\w*(?:(?:->|::|\.)[$A-Za-z_]\w*)+|"
+    r"[$A-Za-z_]\w*(?:\[[^;\n]*\])?\s*[-+*/%?]?=\s*[^;\n]+)\s*;"
+)
+CSS_REFERENCE_RE = re.compile(
+    r"\b[-A-Za-z_]\w*(?:-[-\w]+)*\s*:\s*(?:none|block|inline(?:-block)?|flex|grid|auto|inherit|initial|"
+    r"unset|transparent|currentcolor|[-+]?(?:\d*\.)?\d+(?:px|rem|em|%|vh|vw|s|ms)?|#[0-9a-f]{3,8}|"
+    r"(?:var|calc|url|rgba?|hsla?)\([^;\n]*\))\s*;",
+    re.IGNORECASE,
+)
 SWAP_RE = re.compile(r"\b(" + "|".join(SWAP) + r")\b", re.IGNORECASE)
 OFTEN_RE = re.compile(r"\b(" + "|".join(OFTEN) + r")\b", re.IGNORECASE)
 
@@ -134,6 +145,14 @@ def md_text(text):
     return masked(text, keep)
 
 
+def code_refs(text, ext):
+    """Mask code-shaped references in comments and docstrings without changing source offsets."""
+    patterns = (CODE_REFERENCE_RE, CSS_REFERENCE_RE) if ext in {".css", ".scss"} else (CODE_REFERENCE_RE,)
+    for pattern in patterns:
+        text = pattern.sub(lambda match: " " * len(match.group()), text)
+    return text
+
+
 def hash_comments(text):
     """Mask everything except docstrings and quote-aware hash comments."""
     keep = [False] * len(text)
@@ -197,9 +216,9 @@ def checked(path, text, selected=None):
     if ext in MD_EXT:
         text = md_text(text)
     elif ext in HASH_EXT:
-        text = md_text(hash_comments(text))
+        text = code_refs(md_text(hash_comments(text)), ext)
     elif ext in C_EXT:
-        text = md_text(c_comments(text))
+        text = code_refs(md_text(c_comments(text)), ext)
     else:
         return []
     if selected is not None:

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -62,7 +62,7 @@ PHRASES = [
 LIMIT = 3
 OFTEN = ["crucial", "essential", "vital", "significant", "moreover", "furthermore", "additionally", "aligns", "explore", "prompted"]
 
-MARKS = {"—": ("em-dash", "use commas or periods"), "§": ("section sign", "remove it")}
+MARKS = {"—": ("em-dash", "use commas or periods"), "§": ("section sign", "remove it"), ";": ("semicolon", "use a period or comma")}
 MARK_RE = re.compile("|".join(map(re.escape, MARKS)))
 SWAP_RE = re.compile(r"\b(" + "|".join(SWAP) + r")\b", re.IGNORECASE)
 OFTEN_RE = re.compile(r"\b(" + "|".join(OFTEN) + r")\b", re.IGNORECASE)
@@ -197,9 +197,9 @@ def checked(path, text, selected=None):
     if ext in MD_EXT:
         text = md_text(text)
     elif ext in HASH_EXT:
-        text = hash_comments(text)
+        text = md_text(hash_comments(text))
     elif ext in C_EXT:
-        text = c_comments(text)
+        text = md_text(c_comments(text))
     else:
         return []
     if selected is not None:

--- a/plugins/humanize/hooks/scripts/humanize.py
+++ b/plugins/humanize/hooks/scripts/humanize.py
@@ -62,7 +62,7 @@ PHRASES = [
 LIMIT = 3
 OFTEN = ["crucial", "essential", "vital", "significant", "moreover", "furthermore", "additionally", "aligns", "explore", "prompted"]
 
-MARKS = {"—": ("em-dash", "use commas or periods"), "§": ("section sign", "remove it"), ";": ("semicolon", "use a period or comma")}
+MARKS = {"—": ("em-dash", "use commas or periods"), "§": ("section sign", "remove it")}
 MARK_RE = re.compile("|".join(map(re.escape, MARKS)))
 SWAP_RE = re.compile(r"\b(" + "|".join(SWAP) + r")\b", re.IGNORECASE)
 OFTEN_RE = re.compile(r"\b(" + "|".join(OFTEN) + r")\b", re.IGNORECASE)

--- a/plugins/humanize/skills/humanize/SKILL.md
+++ b/plugins/humanize/skills/humanize/SKILL.md
@@ -173,7 +173,7 @@ Do not begin paragraphs mechanically with `Additionally`, `Moreover`, `Furthermo
 - Use headings only when they help navigation. A short answer usually needs none.
 - Use bold for rare emphasis, not as a label on every bullet.
 - Avoid lists made of repeated `Label: explanation` items when a sentence reads better.
-- Do not use an em dash or semicolon. Use a comma, colon, parentheses, or a new sentence.
+- Do not use an em dash. Use a comma, colon, parentheses, or a new sentence.
 - Do not decorate headings or bullets with emoji.
 - Do not use a table for a few facts that fit in one sentence.
 - Do not place thematic separators between every section.

--- a/plugins/humanize/skills/humanize/SKILL.md
+++ b/plugins/humanize/skills/humanize/SKILL.md
@@ -173,7 +173,7 @@ Do not begin paragraphs mechanically with `Additionally`, `Moreover`, `Furthermo
 - Use headings only when they help navigation. A short answer usually needs none.
 - Use bold for rare emphasis, not as a label on every bullet.
 - Avoid lists made of repeated `Label: explanation` items when a sentence reads better.
-- Do not use an em dash. Use a comma, colon, parentheses, or a new sentence.
+- Do not use an em dash or semicolon. Use a comma, colon, parentheses, or a new sentence.
 - Do not decorate headings or bullets with emoji.
 - Do not use a table for a few facts that fit in one sentence.
 - Do not place thematic separators between every section.


### PR DESCRIPTION
Humanize should reject semicolons in human-facing text without blocking code examples inside comments and docstrings.

- keeps semicolon blocking for docs, normal comments and docstrings, commit messages, PR text, GitHub comments, and Slack messages
- allows source code, fenced and inline code, plus recognized PHP, CSS, JavaScript, and similar code-shaped references
- masks only the detected code fragment so nearby text is still checked
- keeps long comments fast
- bumps Humanize to 1.2.3