### PR TITLE
Make Fable the Claude default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -227,8 +227,8 @@
   "ultracode": false,
   "enableWorkflows": true,
   "outputStyle": "Concise",
-  "model": "opus",
-  "advisorModel": "claude-opus-5",
+  "model": "fable",
+  "advisorModel": "fable",
   "autoScrollEnabled": false,
   "statusLine": {
     "type": "command",
@@ -238,9 +238,15 @@
   },
   "enabledPlugins": {
     "intelligent-compact@claude-settings": true,
-    "github-dev@claude-settings": true,
-    "humanize@claude-settings": true,
     "simplify@claude-settings": true,
+    "humanize@claude-settings": true,
+    "openai-office-skills@claude-settings": true,
+    "python-skills@claude-settings": true,
+    "agent-browser@claude-settings": true,
+    "frontend-design-skills@claude-settings": true,
+    "seo-skills@claude-settings": true,
+    "github-dev@claude-settings": true,
+    "ultralytics-dev@claude-settings": true,
     "codex-advisor@claude-settings": true
   },
   "extraKnownMarketplaces": {

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Runs on Claude Code and Gemini. Unlike a markdown rule the model can ignore, the
 | ----------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------- |
 | `claude plugin install fable-advisor@claude-settings` | `codex plugin add fable-advisor@claude-settings` | `gemini extensions install --path ./plugins/fable-advisor` |
 
-Ask a Fable 5 reviewer to challenge a plan or conclusion before you commit, a drop-in for the built-in advisor when the Opus-main plus Fable-advisor pairing fails with a bare "unavailable" ([#73365](https://github.com/anthropics/claude-code/issues/73365)). Claude Code uses a native Fable agent with the recent conversation attached. Codex, Cursor, and Gemini call the same model through an authenticated Claude Code CLI with `claude -p --model fable`.
+Ask a Fable 5 reviewer to challenge a plan or conclusion before you commit. Claude Code now supports Fable through its built-in advisor, while Codex, Cursor, and Gemini call the same model through an authenticated Claude Code CLI with `claude -p --model fable`.
 
 **Agents:**
 
@@ -985,12 +985,12 @@ SEO workflows from [vercel-labs/marketing-team-eve-template](https://github.com/
 
 Configuration in [`.claude/settings.json`](./.claude/settings.json):
 
-- **Model**: OpusPlan mode (plan: Opus 5, execute: Opus 5, fast: Sonnet 4.6) - [source](https://github.com/anthropics/claude-code/blob/4dc23d0275ff615ba1dccbdd76ad2b12a3ede591/CHANGELOG.md?plain=1#L61)
+- **Model**: Fable 5
 - **Environment**: bash working directory, telemetry disabled, MCP output limits
 - **Permissions**: bash commands, git operations, MCP tools
 - **Auto mode**: `auto` permission mode with a custom `autoMode` classifier block in [`.claude/settings.json`](./.claude/settings.json) - see the [auto mode config reference](https://code.claude.com/docs/en/auto-mode-config) for what each rule section does, and run `claude auto-mode defaults` to print the current built-in block and allow rules
-- **Advisor**: a stronger model reviews key decisions via the [advisor tool](https://code.claude.com/docs/en/advisor), paired as Opus main plus Opus advisor. Fable 5 as advisor currently fails with a bare "unavailable" ([#73365](https://github.com/anthropics/claude-code/issues/73365)), so for an on-demand Fable second opinion use the standalone [`fable-advisor`](./plugins/fable-advisor) plugin. The advisor only pairs Claude with Claude, so for a review from outside that family use [`codex-advisor`](./plugins/codex-advisor)
-- **Plugins**: All plugins enabled
+- **Advisor**: the built-in [advisor tool](https://code.claude.com/docs/en/advisor) uses Fable 5. For a review outside the Claude family, use [`codex-advisor`](./plugins/codex-advisor)
+- **Plugins**: Codex defaults plus `intelligent-compact` and `codex-advisor`. Standalone `fable-advisor` stays enabled only in Codex
 
 </details>
 


### PR DESCRIPTION
Claude Code now supports Fable as both the main model and built-in advisor, so the repo can use it directly instead of the standalone Fable advisor.

```diff
- "model": "opus"
- "advisorModel": "claude-opus-5"
+ "model": "fable"
+ "advisorModel": "fable"
```

- aligns shared Claude plugins with Codex defaults
- keeps intelligent-compact and codex-advisor enabled in Claude
- keeps fable-advisor enabled only in Codex