### PR TITLE
Show the real plugin install flow everywhere

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -422,7 +422,7 @@
       "name": "claude-tools",
       "source": "./plugins/claude-tools",
       "description": "Sync CLAUDE.md and the permissions allowlist, and refresh context on demand.",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "author": {
         "name": "Fatih C. Akyon"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -195,7 +195,7 @@
       "name": "claude-tools",
       "source": "./plugins/claude-tools",
       "description": "Sync CLAUDE.md and the permissions allowlist, and refresh context on demand.",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "Apache-2.0"
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,12 +269,10 @@ Commands are Claude Code only. Gemini CLI uses TOML commands. Other tools use sk
 
 ### Installation
 
-```
-Claude Code: /plugin marketplace add fcakyon/claude-codex-settings
-Codex CLI:   codex plugin marketplace add fcakyon/claude-codex-settings, then codex plugin add <name>@claude-settings
-Cursor:      import marketplace or /add-plugin
-Gemini CLI:  gemini extensions install --path ./plugins/<name>
-```
+- Claude Code: run `claude plugin marketplace add fcakyon/claude-codex-settings`, then `claude plugin install plugin-name@claude-settings`
+- Codex CLI: run `codex plugin marketplace add fcakyon/claude-codex-settings`, then `codex plugin add plugin-name@claude-settings`
+- Cursor: run `cursor-agent plugin marketplace add https://github.com/fcakyon/claude-codex-settings`, start `cursor-agent`, then enter `/plugin`
+- Gemini CLI: run `gemini extensions install --path ./plugins/plugin-name`
 
 ### Updating
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-Complete installation guide for Claude Code, dependencies, and this configuration.
+Installation guide for Claude Code, OpenAI Codex, Cursor, Gemini CLI, dependencies, and this configuration.
 
 > Use the [plugin marketplace](README.md#installation) to install agents/commands/hooks/MCP. You'll still need to complete prerequisites and set up the shared guidance file.
 
@@ -55,6 +55,18 @@ Optionally install IDE extension:
 
 - [Codex VSCode extension](https://developers.openai.com/codex/ide) for IDE integration
 
+### Claude Code Plugins
+
+```bash
+# Add marketplace (one time)
+claude plugin marketplace add fcakyon/claude-codex-settings
+
+# Install any plugin by name
+claude plugin install simplify@claude-settings
+```
+
+In Claude Code desktop, select **+** beside the prompt, then **Plugins** and **Add plugin**.
+
 ### Codex Plugins
 
 ```bash
@@ -64,6 +76,20 @@ codex plugin marketplace add fcakyon/claude-codex-settings
 # Install any plugin by name
 codex plugin add simplify@claude-settings
 ```
+
+In the Codex desktop app, open **Plugins**, find the plugin, and select **Install**.
+
+### Cursor Plugins
+
+```bash
+# Add marketplace (one time)
+cursor-agent plugin marketplace add https://github.com/fcakyon/claude-codex-settings
+
+# Start the interactive CLI
+cursor-agent
+```
+
+Enter `/plugin`, open the marketplace, and install the plugin at user or project scope. In the Cursor app, open **Customize** and select **Install**.
 
 ### Gemini CLI
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ claude plugin marketplace add fcakyon/claude-codex-settings
 claude plugin install fable-advisor@claude-settings
 ```
 
+In Claude Code desktop, select **+** beside the prompt, then **Plugins** and **Add plugin**.
+
 </details>
 
 <details>
@@ -52,6 +54,8 @@ codex plugin marketplace add fcakyon/claude-codex-settings
 # Install any plugin by name
 codex plugin add simplify@claude-settings
 ```
+
+In the Codex desktop app, open **Plugins**, find the plugin, and select **Install**.
 
 </details>
 
@@ -69,9 +73,14 @@ gemini extensions install --path ./plugins/simplify
 <summary><strong>Cursor</strong></summary>
 
 ```bash
-# Install any plugin by name
-cursor plugin install simplify@claude-settings
+# Add marketplace (one time)
+cursor-agent plugin marketplace add https://github.com/fcakyon/claude-codex-settings
+
+# Start the interactive CLI
+cursor-agent
 ```
+
+Enter `/plugin`, open the marketplace, and install the plugin at user or project scope. In the Cursor app, open **Customize** and select **Install**.
 
 </details>
 

--- a/plugins/claude-tools/.claude-plugin/plugin.json
+++ b/plugins/claude-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tools",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Sync CLAUDE.md and the permissions allowlist, and refresh context on demand.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-tools/.codex-plugin/plugin.json
+++ b/plugins/claude-tools/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tools",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Sync CLAUDE.md and the permissions allowlist, and refresh context on demand.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-tools/.cursor-plugin/plugin.json
+++ b/plugins/claude-tools/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tools",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Sync CLAUDE.md and the permissions allowlist, and refresh context on demand.",
   "author": {
     "name": "Fatih C. Akyon"

--- a/plugins/claude-tools/commands/update-readme.md
+++ b/plugins/claude-tools/commands/update-readme.md
@@ -24,9 +24,9 @@ Regenerate the Plugins section of README.md based on current plugin structure an
 <details>
 <summary><strong>plugin-name</strong> - Short description</summary>
 
-| Claude Code                                   | Codex CLI                                                                     | Gemini CLI                                               |
-| --------------------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `/plugin install plugin-name@claude-settings` | Open `/plugins` -> `Claude & Codex Settings` -> install `plugin-name` | `gemini extensions install --path ./plugins/plugin-name` |
+| Claude Code                                         | Codex CLI                                      | Cursor                                                   | Gemini CLI                                               |
+| --------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------- |
+| `claude plugin install plugin-name@claude-settings` | `codex plugin add plugin-name@claude-settings` | Run `cursor-agent`, enter `/plugin`, and install by name | `gemini extensions install --path ./plugins/plugin-name` |
 
 **Skills CLI**
 
@@ -69,5 +69,7 @@ One-line description.
 ```
 
 6. Also update the Installation section if plugin names have changed.
+   - Cursor installation is interactive. Do not invent a direct Cursor install command.
+   - Add the marketplace with `cursor-agent plugin marketplace add https://github.com/fcakyon/claude-codex-settings`, then tell the reader to run `cursor-agent` and enter `/plugin`.
 
 7. Do NOT modify non-plugin sections (header, Configuration, Statusline, TODO, References, Star History).

--- a/plugins/claude-tools/gemini-extension.json
+++ b/plugins/claude-tools/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "claude-tools",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Sync CLAUDE.md and the permissions allowlist, and refresh context on demand."
 }

--- a/site/src/components/ContentPage.astro
+++ b/site/src/components/ContentPage.astro
@@ -4,6 +4,7 @@ import Icon from "./Icon.astro"
 import SkillDownload from "./SkillDownload.astro"
 import Layout from "../layouts/Layout.astro"
 import {
+  codingTools,
   configurationDocuments,
   pluginByName,
   plugins,
@@ -19,6 +20,7 @@ interface Props {
 }
 
 const { page } = Astro.props
+const marketplaceCommands = Object.fromEntries(codingTools.map((tool) => [tool.id, tool.marketplace]))
 const canonical = `${site.url}/${page.path}/`
 const homeCrumb = { label: "Home", href: "/" }
 const pluginCategories = Object.entries(Object.groupBy(plugins, (plugin) => plugin.category || "other")).sort(([a], [b]) =>
@@ -159,10 +161,10 @@ if (page.kind === "pluginHub") {
   intro = "A CLAUDE.md file gives coding agents repository-specific instructions. Use this guide to choose rules that are concrete, testable, and relevant to the codebase."
   breadcrumbs = [homeCrumb, { label: "CLAUDE.md" }]
 } else if (page.kind === "installGuide") {
-  title = "Install agent skills in ChatGPT and Claude.ai"
-  description = "Download an agent skill ZIP, review its contents, and upload it through the current ChatGPT or Claude.ai skills interface."
-  intro = "The same skill ZIP works in ChatGPT and Claude.ai. Keep the archive intact: it contains a named skill folder with SKILL.md and any supporting files."
-  breadcrumbs = [homeCrumb, { label: "Install agent skills" }]
+  title = "Install agent skills and plugins in Claude, Codex, and Cursor"
+  description = "Add the Claude Settings marketplace to Claude Code, OpenAI Codex, or Cursor, install plugins, and upload skill ZIPs to ChatGPT or Claude.ai."
+  intro = "Use plugin marketplaces with coding agents. Upload a skill ZIP when you work in ChatGPT or Claude.ai. This guide covers both paths and how to use what you install."
+  breadcrumbs = [homeCrumb, { label: "Install agent skills and plugins" }]
 }
 
 const breadcrumbSchema = {
@@ -191,10 +193,11 @@ if (page.kind === "installGuide") {
     name: title,
     description,
     step: [
-      { "@type": "HowToStep", name: "Choose and review a skill", text: "Choose a skill, open its source, and review every included file." },
-      { "@type": "HowToStep", name: "Download the ZIP", text: "Download the release ZIP without extracting it." },
-      { "@type": "HowToStep", name: "Upload the skill", text: "Open the Skills area in ChatGPT or Claude.ai, choose the upload action, and select the ZIP." },
-      { "@type": "HowToStep", name: "Test the skill", text: "Enable the skill and run a prompt that matches its description." },
+      { "@type": "HowToStep", name: "Choose the installation path", text: "Install a plugin in a coding agent, or upload a skill ZIP to ChatGPT or Claude.ai." },
+      { "@type": "HowToStep", name: "Add the marketplace", text: "Add the Claude Settings marketplace to Claude Code, OpenAI Codex, or Cursor." },
+      { "@type": "HowToStep", name: "Install a plugin", text: "Install the plugin from the marketplace in your terminal or desktop app." },
+      { "@type": "HowToStep", name: "Start a new session", text: "Start a new session, then ask the agent to use the installed skill or workflow." },
+      { "@type": "HowToStep", name: "Upload a skill ZIP", text: "Download a skill ZIP without extracting it, then upload it to ChatGPT or Claude.ai." },
     ],
   })
 }
@@ -355,9 +358,54 @@ const pluginSkills = plugin ? skills.filter((item) => item.plugin === plugin.nam
 
     {page.kind === "installGuide" && (
       <div class="content-sections install-guide">
+        <section class="content-section" id="choose-installation-path">
+          <h2>Choose the installation path for your app</h2>
+          <p>Install a plugin when you use a coding agent. Upload a ZIP when you use Skills in ChatGPT or Claude.ai.</p>
+          <div class="reference-grid">
+            <a class="reference-card" href="#coding-agent-plugins"><h3>Claude Code, Codex, and Cursor</h3><p>Add this repository as a marketplace, then install the plugins you need.</p><span>Install coding-agent plugins <Icon name="arrow" size={16} /></span></a>
+            <a class="reference-card" href="#web-skill-uploads"><h3>ChatGPT and Claude.ai</h3><p>Download one skill as a ZIP, then upload it through the Skills interface.</p><span>Upload a skill ZIP <Icon name="arrow" size={16} /></span></a>
+          </div>
+        </section>
+        <section class="content-section" id="coding-agent-plugins">
+          <h2>Add this marketplace to Claude Code</h2>
+          <p>Claude Code uses the same configured marketplaces in the terminal and desktop app for local sessions.</p>
+          <p>From the terminal, add the marketplace once, then install each plugin by name.</p>
+          <pre class="code-sample"><code>{`${marketplaceCommands.claude}
+claude plugin install simplify@claude-settings`}</code></pre>
+          <p>In Claude Code desktop, select <strong>+</strong> beside the prompt, then <strong>Plugins</strong> and <strong>Add plugin</strong>. Choose a plugin from the configured marketplace.</p>
+          <p>Run <code>/reload-plugins</code> after an install in an open session. New sessions load installed plugins automatically.</p>
+          <a class="official-link" href="https://code.claude.com/docs/en/discover-plugins">Read the official Claude Code plugin guide</a>
+        </section>
         <section class="content-section">
+          <h2>Add this marketplace to OpenAI Codex</h2>
+          <p>Codex supports this marketplace in the terminal and the Codex desktop app. The Codex IDE extension doesn’t support plugins.</p>
+          <p>From the terminal, add the marketplace once, then install each plugin by name.</p>
+          <pre class="code-sample"><code>{`${marketplaceCommands.codex}
+codex plugin add simplify@claude-settings`}</code></pre>
+          <p>Enter <code>/plugins</code> in Codex CLI to browse configured marketplaces interactively. Start a new session after installing a plugin.</p>
+          <p>In the Codex desktop app, open <strong>Plugins</strong>, find the plugin, and select <strong>Install</strong>. Start a new task before you use its skills or tools.</p>
+          <a class="official-link" href="https://learn.chatgpt.com/docs/plugins">Read the official OpenAI plugin guide</a>
+        </section>
+        <section class="content-section">
+          <h2>Add this marketplace to Cursor</h2>
+          <p>Cursor installs personal plugins interactively. User-scope plugins work in the Cursor app and Cursor Agent CLI.</p>
+          <p>From the terminal, add the repository and start Cursor Agent. Enter <code>/plugin</code> to choose and install a plugin.</p>
+          <pre class="code-sample"><code>{`${marketplaceCommands.cursor}
+cursor-agent`}</code></pre>
+          <p>In the Cursor app, open <strong>Customize</strong>, find the plugin, and select <strong>Install</strong>. Choose user or project scope when prompted.</p>
+          <p>The marketplace command only adds the catalog.</p>
+          <a class="official-link" href="https://cursor.com/docs/plugins">Read the official Cursor plugin guide</a>
+        </section>
+        <section class="content-section">
+          <h2>Use an installed plugin in a new session</h2>
+          <p>Start a new session so the agent loads the plugin. Describe the task or name the skill in your prompt.</p>
+          <pre class="code-sample"><code>{`Use the simplify skill to review my staged diff.
+Use the humanize skill to revise this README.`}</code></pre>
+          <p>Some plugins also add slash commands. Open the <a href="/plugins/">plugin catalog</a> to see each plugin’s components and install commands.</p>
+        </section>
+        <section class="content-section" id="web-skill-uploads">
           <h2>Choose and review a skill</h2>
-          <p>Open the source before uploading code from any publisher. Check SKILL.md, scripts, references, and external tool requirements.</p>
+          <p>Open the source before uploading code from any publisher. Check <code>SKILL.md</code>, scripts, references, and external tool requirements.</p>
           <a class="button secondary" href="/skills/">Browse all skill downloads <Icon name="arrow" size={18} /></a>
         </section>
         <section class="content-section">

--- a/site/src/lib/content.ts
+++ b/site/src/lib/content.ts
@@ -178,7 +178,7 @@ export const plugins = marketplace.plugins
         : undefined;
     const claudeCommand = `claude plugin install ${plugin.name}@${marketplaceName}`;
     const codexCommand = hasCodex ? `codex plugin add ${plugin.name}@${marketplaceName}` : undefined;
-    const cursorCommand = hasCursor ? `cursor plugin install ${plugin.name}@${marketplaceName}` : undefined;
+    const cursorCommand = hasCursor ? `cursor-agent # enter /plugin, then install ${plugin.name}` : undefined;
     const geminiCommand = hasGemini ? `gemini extensions install --path ./plugins/${plugin.name}` : undefined;
     const components = directory
       ? {
@@ -341,7 +341,12 @@ export const codingTools = [
     marketplace: `claude plugin marketplace add ${marketplaceSlug}`,
   },
   { id: "codex", icon: "openai", label: "Codex CLI", marketplace: `codex plugin marketplace add ${marketplaceSlug}` },
-  { id: "cursor", icon: "cursor", label: "Cursor", marketplace: undefined },
+  {
+    id: "cursor",
+    icon: "cursor",
+    label: "Cursor",
+    marketplace: `cursor-agent plugin marketplace add ${repositoryUrl}`,
+  },
   { id: "gemini", icon: "gemini", label: "Gemini CLI", marketplace: undefined },
 ] as const;
 

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -91,7 +91,7 @@ ${authorContext}
 - [Settings reference](${site.url}/settings/): Claude Code, OpenAI Codex, and provider configuration pages.
 - [Plugin catalog](${site.url}/plugins/): Manifest-backed plugin pages with install commands and components.
 - [Skill downloads](${site.url}/skills/): Release ZIPs for ChatGPT and Claude.ai.
-- [Skill install guide](${site.url}/guides/install-agent-skills/): Current upload steps for ChatGPT and Claude.ai.
+- [Skill and plugin install guide](${site.url}/guides/install-agent-skills/): Marketplace setup for Claude Code, OpenAI Codex, and Cursor, plus skill uploads for ChatGPT and Claude.ai.
 - [GitHub repository](${repositoryUrl}): Canonical source history and repository files.
 - [Agent Plugins LLM catalog](https://agentplugins.net/llms.txt): Plugin descriptions, search terms, compatibility, components, and install commands.
 - [Claude marketplace](${rawRepositoryUrl}/.claude-plugin/marketplace.json): Canonical plugin metadata.


### PR DESCRIPTION
The install guide stopped at web uploads, while Cursor showed a command its CLI does not support.

```diff
- cursor plugin install simplify@claude-settings
+ cursor-agent plugin marketplace add https://github.com/fcakyon/claude-codex-settings
+ cursor-agent  # enter /plugin, then install simplify
```

- covers terminal and desktop flows for Claude, Codex, and Cursor
- aligns the site, README, install guide, and repo guidance
- keeps future README generation on Cursor's interactive flow
