### PR TITLE
Move js-yaml to the patched release

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -2770,9 +2770,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
The site lockfile still resolved `js-yaml` 4.3.0, which is covered by GHSA-5p4m-2wfm-xmqj despite Astro already allowing the patched 4.x release.

```diff
- js-yaml 4.3.0
+ js-yaml 4.3.1
```

- removes the reported advisory from `npm audit`
- leaves package declarations and the dependency graph unchanged

Closes #299