### PR TITLE
Stop sharing Claude session links

### DIFF
--- a/.claude/settings-kimi.json
+++ b/.claude/settings-kimi.json
@@ -24,7 +24,8 @@
   },
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "permissions": {
     "defaultMode": "default",

--- a/.claude/settings-minimax.json
+++ b/.claude/settings-minimax.json
@@ -24,7 +24,8 @@
   },
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "permissions": {
     "defaultMode": "default",

--- a/.claude/settings-zai.json
+++ b/.claude/settings-zai.json
@@ -23,7 +23,8 @@
   },
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "permissions": {
     "defaultMode": "default",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
   },
   "attribution": {
     "commit": "",
-    "pr": ""
+    "pr": "",
+    "sessionUrl": false
   },
   "permissions": {
     "defaultMode": "auto",


### PR DESCRIPTION
Claude Code can attach session URLs to generated commit and PR attribution, which should stay private in shared settings.

- sets attribution.sessionUrl to false in all 4 variants
- keeps existing blank commit and PR attribution