### PR TITLE
Make plugin installs feel live

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -224,7 +224,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "keywords": ["livekit", "voice-ai", "agents", "webrtc", "realtime"],
-      "category": "ai",
+      "category": "voice-agents",
       "tags": ["voice-ai", "best-practices"]
     },
     {

--- a/site/src/components/ContentPage.astro
+++ b/site/src/components/ContentPage.astro
@@ -1,6 +1,6 @@
 ---
 import Breadcrumbs from "./Breadcrumbs.astro"
-import Icon from "./Icon.astro"
+import Icon, { type IconName } from "./Icon.astro"
 import SkillDownload from "./SkillDownload.astro"
 import Layout from "../layouts/Layout.astro"
 import {
@@ -125,7 +125,7 @@ if (page.kind === "pluginHub") {
   if (!plugin) throw new Error(`Unknown plugin: ${page.plugin}`)
   title = `${plugin.name} plugin for AI coding agents`
   description = `${plugin.description} Review supported tools, install commands, components, source, and skill ZIP downloads.`
-  intro = `${plugin.description} This page is generated from the plugin manifest and files in the repository.`
+  intro = plugin.description
   breadcrumbs = [homeCrumb, { label: "Plugins", href: "/plugins/" }, { label: plugin.name }]
 } else if (page.kind === "skill") {
   skill = skills.find((item) => item.key === page.skill)
@@ -206,6 +206,12 @@ const providerFiles = page.kind === "provider"
   ? configurationDocuments.filter((file) => file.provider === page.provider)
   : []
 const pluginSkills = plugin ? skills.filter((item) => item.plugin === plugin.name) : []
+const codingToolIcons = new Map(codingTools.map(({ id, icon }) => [id, icon]))
+const installDemoCommands = plugin?.installCommands.map((item) => ({
+  ...item,
+  icon: codingToolIcons.get(item.id) as IconName,
+})) || []
+const initialInstallDemo = installDemoCommands[0]
 ---
 
 <Layout locale="en" variant="settings" {title} {description} {canonical} alternates={{ en: canonical }} {structuredData}>
@@ -296,11 +302,64 @@ const pluginSkills = plugin ? skills.filter((item) => item.plugin === plugin.nam
 
     {plugin && (
       <div class="content-sections">
-        <section class="content-section">
+        <section class="content-section install-terminal-section" data-install-terminal>
           <h2>Install the plugin in your coding agent</h2>
-          <p>Add the marketplace once, then run the command for your tool.</p>
-          <div class="command-list">
-            {plugin.installCommands.map(({ tool, command }) => <div><span>{tool}</span><code>{command}</code></div>)}
+          <p><a class="inline-link" href="/guides/install-agent-skills/#coding-agent-plugins">Add the marketplace once</a>, then run the command for your tool.</p>
+          <div class="install-tool-tabs" role="tablist" aria-label="Choose a coding agent">
+            {installDemoCommands.map(({ tool, command, icon, output }, index) => (
+              <button
+                id={`install-tab-${plugin.name}-${index}`}
+                class:list={["install-tool-tab", { "is-active": index === 0 }]}
+                type="button"
+                role="tab"
+                aria-controls={`install-terminal-${plugin.name}`}
+                aria-selected={index === 0 ? "true" : "false"}
+                tabindex={index === 0 ? 0 : -1}
+                data-install-tab
+                data-command={command}
+                data-output-primary={output[0]}
+                data-output-secondary={output[1]}
+              >
+                <Icon name={icon} size={22} />
+                <span>{tool}</span>
+              </button>
+            ))}
+          </div>
+          <div
+            id={`install-terminal-${plugin.name}`}
+            class="install-terminal"
+            role="tabpanel"
+            aria-labelledby={`install-tab-${plugin.name}-0`}
+            data-install-panel
+          >
+            <div class="install-terminal-bar">
+              <span class="terminal-lights" aria-hidden="true"><i></i><i></i><i></i></span>
+              <span class="install-terminal-title">Terminal · <strong data-install-title>{initialInstallDemo.tool}</strong></span>
+              <button class="terminal-copy" type="button" data-copy={initialInstallDemo.command} aria-label={`Copy ${initialInstallDemo.tool} install command`}>
+                <Icon name="copy" size={18} />
+                <span data-install-copy-label>Copy command</span>
+              </button>
+            </div>
+            <div class="install-terminal-body">
+              <div class="install-command-line">
+                <span class="install-prompt" aria-hidden="true">$</span>
+                <code data-install-command aria-label={initialInstallDemo.command}>{initialInstallDemo.command}</code>
+                <span class="typing-cursor" aria-hidden="true"></span>
+              </div>
+              <div class="install-output" aria-hidden="true">
+                <p data-install-output-primary>{initialInstallDemo.output[0]}</p>
+                <p class="install-success" data-install-output-secondary>{initialInstallDemo.output[1]}</p>
+              </div>
+              <span class="sr-only" aria-live="polite" data-install-announcement></span>
+            </div>
+            <div class="install-terminal-progress">
+              <span class="install-progress-track" aria-hidden="true"><i data-install-progress></i></span>
+              <span data-install-count>1 of {installDemoCommands.length}</span>
+              <button type="button" data-install-toggle aria-label="Pause installation demo" title="Pause installation demo">
+                <span class="pause-glyph"><Icon name="pause" size={16} /></span>
+                <span class="play-glyph"><Icon name="play" size={16} /></span>
+              </button>
+            </div>
           </div>
         </section>
         <section class="content-section">
@@ -362,7 +421,7 @@ const pluginSkills = plugin ? skills.filter((item) => item.plugin === plugin.nam
           <h2>Choose the installation path for your app</h2>
           <p>Install a plugin when you use a coding agent. Upload a ZIP when you use Skills in ChatGPT or Claude.ai.</p>
           <div class="reference-grid">
-            <a class="reference-card" href="#coding-agent-plugins"><h3>Claude Code, Codex, and Cursor</h3><p>Add this repository as a marketplace, then install the plugins you need.</p><span>Install coding-agent plugins <Icon name="arrow" size={16} /></span></a>
+            <a class="reference-card" href="#coding-agent-plugins"><h3>Claude Code, Codex, Cursor, and Gemini CLI</h3><p>Add the marketplace where supported, or install a local Gemini extension.</p><span>Install coding-agent plugins <Icon name="arrow" size={16} /></span></a>
             <a class="reference-card" href="#web-skill-uploads"><h3>ChatGPT and Claude.ai</h3><p>Download one skill as a ZIP, then upload it through the Skills interface.</p><span>Upload a skill ZIP <Icon name="arrow" size={16} /></span></a>
           </div>
         </section>
@@ -395,6 +454,15 @@ cursor-agent`}</code></pre>
           <p>In the Cursor app, open <strong>Customize</strong>, find the plugin, and select <strong>Install</strong>. Choose user or project scope when prompted.</p>
           <p>The marketplace command only adds the catalog.</p>
           <a class="official-link" href="https://cursor.com/docs/plugins">Read the official Cursor plugin guide</a>
+        </section>
+        <section class="content-section">
+          <h2>Install a local extension in Gemini CLI</h2>
+          <p>Gemini CLI installs extensions from local plugin folders. Clone the repository, then run the extension command from its root.</p>
+          <pre class="code-sample"><code>{`git clone ${repositoryUrl}.git
+cd claude-codex-settings
+gemini extensions install --path ./plugins/simplify`}</code></pre>
+          <p>Replace <code>simplify</code> with the plugin you want. Start a new Gemini CLI session after installation.</p>
+          <a class="official-link" href="https://geminicli.com/docs/extensions/reference/">Read the official Gemini CLI extension reference</a>
         </section>
         <section class="content-section">
           <h2>Use an installed plugin in a new session</h2>
@@ -441,3 +509,118 @@ Use the humanize skill to revise this README.`}</code></pre>
     )}
   </article>
 </Layout>
+
+<script>
+  document.querySelectorAll<HTMLElement>("[data-install-terminal]").forEach((demo) => {
+    const tabs = [...demo.querySelectorAll<HTMLButtonElement>("[data-install-tab]")]
+    const panel = demo.querySelector<HTMLElement>("[data-install-panel]")!
+    const title = demo.querySelector<HTMLElement>("[data-install-title]")!
+    const command = demo.querySelector<HTMLElement>("[data-install-command]")!
+    const primaryOutput = demo.querySelector<HTMLElement>("[data-install-output-primary]")!
+    const secondaryOutput = demo.querySelector<HTMLElement>("[data-install-output-secondary]")!
+    const announcement = demo.querySelector<HTMLElement>("[data-install-announcement]")!
+    const progress = demo.querySelector<HTMLElement>("[data-install-progress]")!
+    const count = demo.querySelector<HTMLElement>("[data-install-count]")!
+    const copyButton = demo.querySelector<HTMLButtonElement>("[data-install-copy]")!
+    const toggle = demo.querySelector<HTMLButtonElement>("[data-install-toggle]")!
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)")
+    let current = 0
+    let paused = false
+    let visible = false
+    const timers = new Set<number>()
+
+    const clearTimers = () => {
+      timers.forEach(window.clearTimeout)
+      timers.clear()
+    }
+    const later = (callback: () => void, delay: number) => {
+      const timer = window.setTimeout(() => {
+        timers.delete(timer)
+        callback()
+      }, delay)
+      timers.add(timer)
+    }
+    const showComplete = (tab: HTMLButtonElement) => {
+      demo.dataset.phase = "complete"
+      announcement.textContent = tab.dataset.outputSecondary || "Installation complete"
+    }
+    const activate = (index: number) => {
+      clearTimers()
+      current = (index + tabs.length) % tabs.length
+      const tab = tabs[current]
+      const fullCommand = tab.dataset.command || ""
+      tabs.forEach((item, tabIndex) => {
+        const active = tabIndex === current
+        item.classList.toggle("is-active", active)
+        item.setAttribute("aria-selected", String(active))
+        item.tabIndex = active ? 0 : -1
+      })
+      panel.setAttribute("aria-labelledby", tab.id)
+      title.textContent = tab.textContent?.trim() || "Terminal"
+      command.setAttribute("aria-label", fullCommand)
+      copyButton.dataset.copy = fullCommand
+      copyButton.setAttribute("aria-label", `Copy ${title.textContent} install command`)
+      copyButton.classList.remove("is-copied")
+      count.textContent = `${current + 1} of ${tabs.length}`
+      progress.classList.remove("is-counting")
+      demo.dataset.phase = "typing"
+      announcement.textContent = ""
+      command.textContent = fullCommand
+      primaryOutput.textContent = tab.dataset.outputPrimary || ""
+      secondaryOutput.textContent = tab.dataset.outputSecondary || ""
+
+      if (reducedMotion.matches || paused) {
+        showComplete(tab)
+        return
+      }
+
+      command.textContent = ""
+      let character = 0
+      const typeNext = () => {
+        command.textContent = fullCommand.slice(0, ++character)
+        if (character < fullCommand.length) later(typeNext, 24)
+        else later(() => {
+          demo.dataset.phase = "output"
+          later(() => {
+            demo.dataset.phase = "complete"
+            announcement.textContent = tab.dataset.outputSecondary || "Installation complete"
+            progress.classList.add("is-counting")
+            if (tabs.length > 1) later(() => activate(current + 1), 2600)
+          }, 620)
+        }, 320)
+      }
+      later(typeNext, 260)
+    }
+    const resume = () => {
+      clearTimers()
+      if (visible && !document.hidden && !paused) activate(current)
+    }
+
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("click", () => activate(index))
+      tab.addEventListener("keydown", (event) => {
+        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return
+        event.preventDefault()
+        const next = index + (event.key === "ArrowRight" ? 1 : -1)
+        tabs[(next + tabs.length) % tabs.length].focus()
+        activate(next)
+      })
+    })
+    toggle.addEventListener("click", () => {
+      paused = !paused
+      demo.toggleAttribute("data-paused", paused)
+      toggle.setAttribute("aria-label", `${paused ? "Play" : "Pause"} installation demo`)
+      toggle.title = `${paused ? "Play" : "Pause"} installation demo`
+      if (paused) {
+        clearTimers()
+        showComplete(tabs[current])
+      } else activate(current)
+    })
+    new IntersectionObserver(([entry]) => {
+      visible = entry.isIntersecting
+      resume()
+    }).observe(demo)
+    document.addEventListener("visibilitychange", resume)
+    reducedMotion.addEventListener("change", resume)
+  })
+</script>

--- a/site/src/components/Editor.astro
+++ b/site/src/components/Editor.astro
@@ -112,13 +112,6 @@ const initialFile = lines[0]
     activate(editor.dataset.initialFile!)
   }
 
-  document.querySelectorAll<HTMLElement>("[data-copy]").forEach((button) =>
-    button.addEventListener("click", async () => {
-      await navigator.clipboard.writeText(button.dataset.copy || "")
-      button.classList.add("is-copied")
-      setTimeout(() => button.classList.remove("is-copied"), 1200)
-    }),
-  )
 </script>
 
 <style is:global>

--- a/site/src/components/Icon.astro
+++ b/site/src/components/Icon.astro
@@ -1,6 +1,6 @@
 ---
 export type IconName =
-  | "arrow" | "chevron" | "copy" | "file" | "folder" | "github" | "linkedin" | "search" | "star" | "x"
+  | "arrow" | "chevron" | "copy" | "file" | "folder" | "github" | "linkedin" | "pause" | "play" | "search" | "star" | "x"
   | "claude" | "openai" | "cursor" | "gemini";
 
 interface Props {
@@ -23,6 +23,8 @@ const { name, size = 20 } = Astro.props;
   {name === "arrow" && <path d="m9 18 6-6-6-6M5 12h10" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />}
   {name === "chevron" && <path d="m9 18 6-6-6-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />}
   {name === "copy" && <path d="M8 8h10v11H8zM5 5h10v3M5 5v11h3" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" />}
+  {name === "pause" && <path d="M8 6v12M16 6v12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />}
+  {name === "play" && <path d="m9 6 9 6-9 6Z" fill="currentColor" />}
   {name === "search" && <path d="m20 20-4.6-4.6M10.8 18a7.2 7.2 0 1 1 0-14.4 7.2 7.2 0 0 1 0 14.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />}
   {name === "folder" && <path d="M3 6.5h6l1.7 2H21v9.5H3z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />}
   {name === "file" && <path d="M6 3h8l4 4v14H6zM14 3v5h4" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />}

--- a/site/src/components/PluginDirectory.astro
+++ b/site/src/components/PluginDirectory.astro
@@ -170,14 +170,5 @@ const initialCommand = plugins[0].claudeCommand
       }),
     )
 
-    browser.querySelectorAll("[data-copy-command]").forEach((button) =>
-      button.addEventListener("click", async (event) => {
-        const trigger = event.currentTarget as HTMLElement
-        const code = trigger.closest(".command-line")?.querySelector("code")
-        await navigator.clipboard.writeText(code?.textContent || "")
-        trigger.classList.add("is-copied")
-        setTimeout(() => trigger.classList.remove("is-copied"), 1200)
-      }),
-    )
   }
 </script>

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -114,5 +114,20 @@ const structuredData = pageGraph.length
         </div>
       </footer>
     </div>
+    <script>
+      document.addEventListener("click", async (event) => {
+        const button = (event.target as Element).closest<HTMLElement>("[data-copy], [data-copy-command]")
+        if (!button) return
+        const label = button.querySelector<HTMLElement>("[data-install-copy-label]")
+        const text = button.dataset.copy || button.closest(".command-line")?.querySelector("code")?.textContent || ""
+        await navigator.clipboard.writeText(text)
+        button.classList.add("is-copied")
+        if (label) label.textContent = "Copied"
+        window.setTimeout(() => {
+          button.classList.remove("is-copied")
+          if (label) label.textContent = "Copy command"
+        }, 1200)
+      })
+    </script>
   </body>
 </html>

--- a/site/src/lib/content.ts
+++ b/site/src/lib/content.ts
@@ -202,10 +202,42 @@ export const plugins = marketplace.plugins
       cursorCommand,
       geminiCommand,
       installCommands: [
-        { tool: "Claude Code", command: claudeCommand },
-        ...(codexCommand ? [{ tool: "OpenAI Codex", command: codexCommand }] : []),
-        ...(cursorCommand ? [{ tool: "Cursor", command: cursorCommand }] : []),
-        ...(geminiCommand ? [{ tool: "Gemini CLI", command: geminiCommand }] : []),
+        {
+          id: "claude",
+          tool: "Claude Code",
+          command: claudeCommand,
+          output: [`Resolving ${plugin.name}@claude-settings…`, `✓ Installed ${plugin.name}`],
+        },
+        ...(codexCommand
+          ? [
+              {
+                id: "codex",
+                tool: "OpenAI Codex",
+                command: codexCommand,
+                output: [`Resolving ${plugin.name}@claude-settings…`, `✓ Added ${plugin.name}`],
+              },
+            ]
+          : []),
+        ...(cursorCommand
+          ? [
+              {
+                id: "cursor",
+                tool: "Cursor",
+                command: cursorCommand,
+                output: [`Opening ${plugin.name} in Cursor Agent…`, `Type /plugin and choose ${plugin.name}`],
+              },
+            ]
+          : []),
+        ...(geminiCommand
+          ? [
+              {
+                id: "gemini",
+                tool: "Gemini CLI",
+                command: geminiCommand,
+                output: [`Reading ./plugins/${plugin.name}/gemini-extension.json…`, `✓ Installed ${plugin.name}`],
+              },
+            ]
+          : []),
       ],
     };
   })

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -57,6 +57,7 @@ button { color: inherit; }
 .button:focus-visible,
 .editor button:focus-visible,
 .plugin-browser button:focus-visible,
+.install-terminal-section button:focus-visible,
 .plugin-search:focus-within {
   outline: 3px solid color-mix(in srgb, var(--accent), transparent 55%);
   outline-offset: 3px;
@@ -291,7 +292,6 @@ button.tree-row { cursor: pointer; }
 }
 .catalog-list,
 .file-list,
-.command-list,
 .component-list {
   border-top: 1px solid var(--border);
 }
@@ -373,7 +373,6 @@ button.tree-row { cursor: pointer; }
 .code-sample code {
   font: 14px/1.7 var(--mono);
 }
-.command-list > div,
 .component-list > div {
   min-height: 82px;
   display: grid;
@@ -382,13 +381,234 @@ button.tree-row { cursor: pointer; }
   align-items: center;
   border-bottom: 1px solid var(--border);
 }
-.command-list span,
 .component-list dt {
   color: var(--muted);
 }
-.command-list code {
-  overflow-x: auto;
-  font: 14px/1.5 var(--mono);
+.install-terminal-section > p .inline-link {
+  color: var(--link);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+.install-terminal-section > p .inline-link:hover {
+  color: var(--accent);
+}
+.install-tool-tabs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 42px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+}
+.install-tool-tab {
+  min-height: 82px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 16px 20px;
+  border: 0;
+  border-right: 1px solid var(--border-strong);
+  background: #fff;
+  color: #171b20;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
+}
+.install-tool-tab:last-child {
+  border-right: 0;
+}
+.install-tool-tab:hover {
+  background: #f4f6f8;
+}
+.install-tool-tab.is-active {
+  background: #11161c;
+  color: #fff;
+}
+.install-terminal {
+  margin-top: 14px;
+  overflow: hidden;
+  border: 1px solid #29323c;
+  border-radius: 16px;
+  background: #0d1117;
+  color: #f7f9fb;
+  box-shadow: 0 18px 44px rgb(15 23 32 / 14%);
+}
+.install-terminal-bar {
+  min-height: 70px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 20px;
+  padding: 0 22px;
+  border-bottom: 1px solid #252d36;
+  background: #11161c;
+}
+.terminal-lights {
+  display: flex;
+  gap: 8px;
+}
+.terminal-lights i {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #ff625a;
+}
+.terminal-lights i:nth-child(2) {
+  background: #f4bf4f;
+}
+.terminal-lights i:nth-child(3) {
+  background: #58c968;
+}
+.install-terminal-title {
+  color: #8f99a5;
+  font-size: 13px;
+  font-weight: 650;
+}
+.install-terminal-title strong {
+  color: #cbd2da;
+}
+.terminal-copy {
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  justify-self: end;
+  gap: 9px;
+  padding: 0 14px;
+  border: 1px solid #3b4652;
+  border-radius: 10px;
+  background: #181f27;
+  color: #e5e9ed;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease;
+}
+.terminal-copy:hover {
+  border-color: #5b6877;
+  background: #202832;
+}
+.terminal-copy.is-copied {
+  border-color: #49d66f;
+  color: #66e184;
+}
+.install-terminal-body {
+  min-height: 286px;
+  padding: 48px 38px 42px;
+}
+.install-command-line {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  min-width: 0;
+}
+.install-prompt {
+  flex: 0 0 auto;
+  color: #727d89;
+  font: 18px/1.6 var(--mono);
+}
+.install-command-line code {
+  min-width: 0;
+  color: #f6f8fa;
+  font: 17px/1.6 var(--mono);
+  letter-spacing: -0.02em;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+.typing-cursor {
+  width: 9px;
+  height: 22px;
+  flex: 0 0 auto;
+  background: #5ad978;
+  animation: terminal-cursor 720ms step-end infinite;
+}
+[data-phase="complete"] .typing-cursor {
+  opacity: 0;
+}
+.install-output {
+  margin-top: 30px;
+  font: 15px/1.6 var(--mono);
+}
+.install-output p {
+  margin: 0 0 14px;
+  color: #8f99a5;
+  opacity: 0;
+  transform: translateY(5px);
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+[data-phase="output"] .install-output p:first-child,
+[data-phase="complete"] .install-output p {
+  opacity: 1;
+  transform: translateY(0);
+}
+.install-output .install-success {
+  color: #61df80;
+}
+.install-terminal-progress {
+  min-height: 52px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 14px;
+  padding: 0 20px 0 38px;
+  border-top: 1px solid #252d36;
+  color: #7f8995;
+  font: 12px/1 var(--mono);
+}
+.install-progress-track {
+  height: 2px;
+  overflow: hidden;
+  background: #2d3742;
+}
+.install-progress-track i {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: #5ad978;
+  transform: scaleX(0);
+  transform-origin: left;
+}
+.install-progress-track i.is-counting {
+  transform: scaleX(1);
+  transition: transform 2600ms linear;
+}
+.install-terminal-progress button {
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid #38424d;
+  border-radius: 8px;
+  background: transparent;
+  color: #aeb6bf;
+  cursor: pointer;
+}
+.install-terminal-progress button:hover {
+  background: #1b222a;
+  color: #fff;
+}
+.play-glyph,
+[data-paused] .pause-glyph {
+  display: none;
+}
+[data-paused] .play-glyph {
+  display: inline-flex;
+}
+@keyframes terminal-cursor {
+  50% {
+    opacity: 0;
+  }
 }
 .component-list {
   margin: 36px 0 0;
@@ -698,11 +918,55 @@ footer a:hover { color: var(--text); }
     grid-column: 2;
     grid-row: 1 / span 2;
   }
-  .command-list > div,
   .component-list > div {
     grid-template-columns: 1fr;
     gap: 8px;
     padding: 18px 0;
+  }
+  .install-tool-tabs {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .install-tool-tab {
+    min-height: 72px;
+    justify-content: flex-start;
+    padding-inline: 16px;
+    border-bottom: 1px solid var(--border-strong);
+  }
+  .install-tool-tab:nth-child(2n) {
+    border-right: 0;
+  }
+  .install-tool-tab:last-child,
+  .install-tool-tab:nth-last-child(2):nth-child(odd) {
+    border-bottom: 0;
+  }
+  .install-terminal-bar {
+    grid-template-columns: 1fr auto;
+    padding-inline: 16px;
+  }
+  .install-terminal-title {
+    display: none;
+  }
+  .install-terminal-body {
+    min-height: 250px;
+    padding: 34px 20px 30px;
+  }
+  .install-command-line {
+    align-items: flex-start;
+    gap: 10px;
+  }
+  .install-command-line code {
+    font-size: 14px;
+  }
+  .typing-cursor {
+    width: 8px;
+    height: 19px;
+    margin-top: 2px;
+  }
+  .install-output {
+    font-size: 13px;
+  }
+  .install-terminal-progress {
+    padding-left: 20px;
   }
   .skill-download {
     grid-template-columns: 1fr;


### PR DESCRIPTION
The static install list made four supported tools feel harder to scan and use than they should.

| before | after |
|---|---|
| ![before](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.7.1/animated-install-terminal-before.jpg) | ![after](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.7.1/animated-install-terminal-after.jpg) |

- types each command, shows its result, then advances automatically
- keeps manual tabs, pause, copy, and marketplace guidance in reach
- moves LiveKit into Voice Agents and removes generated filler