### PR TITLE
Fix frozen plugin install demo and site accessibility issues

### DIFF
--- a/site/src/components/ContentPage.astro
+++ b/site/src/components/ContentPage.astro
@@ -343,7 +343,7 @@ const initialInstallDemo = installDemoCommands[0]
             <div class="install-terminal-body">
               <div class="install-command-line">
                 <span class="install-prompt" aria-hidden="true">$</span>
-                <code data-install-command aria-label={initialInstallDemo.command}>{initialInstallDemo.command}</code>
+                <code data-install-command>{initialInstallDemo.command}</code>
                 <span class="typing-cursor" aria-hidden="true"></span>
               </div>
               <div class="install-output" aria-hidden="true">
@@ -394,7 +394,7 @@ const initialInstallDemo = installDemoCommands[0]
         <section class="content-section">
           <h2>Use the skill for the right task</h2>
           <p>{skill.description}</p>
-          <p>The skill belongs to the <a href={`/plugins/${skill.plugin}/`}><code>{skill.plugin}</code> plugin</a>. Install the full plugin for coding-agent commands, hooks, or related skills.</p>
+          <p>The skill belongs to the <a class="inline-link" href={`/plugins/${skill.plugin}/`}><code>{skill.plugin}</code> plugin</a>. Install the full plugin for coding-agent commands, hooks, or related skills.</p>
         </section>
       </div>
     )}
@@ -469,7 +469,7 @@ gemini extensions install --path ./plugins/simplify`}</code></pre>
           <p>Start a new session so the agent loads the plugin. Describe the task or name the skill in your prompt.</p>
           <pre class="code-sample"><code>{`Use the simplify skill to review my staged diff.
 Use the humanize skill to revise this README.`}</code></pre>
-          <p>Some plugins also add slash commands. Open the <a href="/plugins/">plugin catalog</a> to see each plugin’s components and install commands.</p>
+          <p>Some plugins also add slash commands. Open the <a class="inline-link" href="/plugins/">plugin catalog</a> to see each plugin’s components and install commands.</p>
         </section>
         <section class="content-section" id="web-skill-uploads">
           <h2>Choose and review a skill</h2>
@@ -521,7 +521,7 @@ Use the humanize skill to revise this README.`}</code></pre>
     const announcement = demo.querySelector<HTMLElement>("[data-install-announcement]")!
     const progress = demo.querySelector<HTMLElement>("[data-install-progress]")!
     const count = demo.querySelector<HTMLElement>("[data-install-count]")!
-    const copyButton = demo.querySelector<HTMLButtonElement>("[data-install-copy]")!
+    const copyButton = demo.querySelector<HTMLButtonElement>("[data-copy]")!
     const toggle = demo.querySelector<HTMLButtonElement>("[data-install-toggle]")!
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)")
     let current = 0
@@ -557,7 +557,6 @@ Use the humanize skill to revise this README.`}</code></pre>
       })
       panel.setAttribute("aria-labelledby", tab.id)
       title.textContent = tab.textContent?.trim() || "Terminal"
-      command.setAttribute("aria-label", fullCommand)
       copyButton.dataset.copy = fullCommand
       copyButton.setAttribute("aria-label", `Copy ${title.textContent} install command`)
       copyButton.classList.remove("is-copied")

--- a/site/src/components/Editor.astro
+++ b/site/src/components/Editor.astro
@@ -27,7 +27,7 @@ const initialFile = lines[0]
     <div class="tree-row root-row"><Icon name="folder" size={18} /><span>claude-codex-settings</span></div>
     {editorGroups.map((group) => (
       <>
-        <div class="tree-row folder-row"><span class="tree-caret">⌄</span><Icon name="folder" size={18} /><span>{group.name}</span></div>
+        <div class="tree-row folder-row"><span class="tree-caret" aria-hidden="true">⌄</span><Icon name="folder" size={18} /><span>{group.name}</span></div>
         {group.files.map((file) => (
           <button class:list={["tree-row", "tree-file", { "is-active": file.id === initialFile.id }]} type="button" data-file={file.id} title={file.path}>
             <Icon name="file" size={17} /><span>{file.label}</span>
@@ -61,6 +61,7 @@ const initialFile = lines[0]
         aria-labelledby={`tab-${file.id}`}
         data-panel={file.id}
         data-focus-line={file.focusLine}
+        tabindex="0"
         hidden={index !== 0}
       >
         <code>{file.lines.map((line, lineIndex) => <span class="code-line"><span class="line-number">{lineIndex + 1}</span><span>{line || " "}</span></span>)}</code>

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -19,7 +19,7 @@ const languageLocale = locales[locale].alternate
 
 <header class="site-header">
   <a class="brand" href={locales[locale].path}>{settings ? "Claude Settings" : "Agent Plugins"}</a>
-  <nav aria-label="Primary navigation">
+  <nav aria-label={copy.primaryNav}>
     {nav.map(([label, href]) => <a href={href}>{label}</a>)}
     <a href={repositoryUrl}>GitHub</a>
   </nav>

--- a/site/src/components/PluginDirectory.astro
+++ b/site/src/components/PluginDirectory.astro
@@ -17,7 +17,7 @@ const initialCommand = plugins[0].claudeCommand
   <label class="plugin-search">
     <Icon name="search" size={27} />
     <span class="sr-only">{copy.search}</span>
-    <input type="search" placeholder={copy.search} autocomplete="off" data-plugin-search />
+    <input type="search" name="q" placeholder={copy.search} autocomplete="off" data-plugin-search />
     <kbd>/</kbd>
   </label>
 
@@ -144,7 +144,7 @@ const initialCommand = plugins[0].claudeCommand
     })
 
     document.addEventListener("keydown", (event) => {
-      if (event.key === "/" && document.activeElement !== search) {
+      if (event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey && document.activeElement !== search) {
         event.preventDefault()
         search?.focus()
       }

--- a/site/src/components/SkillDownload.astro
+++ b/site/src/components/SkillDownload.astro
@@ -17,7 +17,7 @@ const detailUrl = skill.seo ? `/plugins/${skill.plugin}/skills/${skill.name}/` :
   <div class="skill-copy">
     <Heading>{detailUrl ? <a href={detailUrl}>{skill.name}</a> : skill.name}</Heading>
     <p>{skill.description}</p>
-    <div class="skill-labels" aria-label="Skill compatibility and package details">
+    <div class="skill-labels">
       <span>ChatGPT</span>
       <span>Claude.ai</span>
       <span>{skill.bundled.length ? `Includes ${skill.bundled.join(", ")}` : "Instructions only"}</span>

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -92,15 +92,19 @@ const structuredData = pageGraph.length
     <meta name="twitter:image" content={image} />
     <meta name="twitter:creator" content={author.xHandle} />
     <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
-    {googleAnalyticsId && <script async src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`} />}
     {googleAnalyticsId && (
-      <script is:inline set:html={`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${googleAnalyticsId}');`} />
+      <>
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
+        <script async src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`} />
+        <script is:inline set:html={`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag('js',new Date());gtag('config','${googleAnalyticsId}');`} />
+      </>
     )}
   </head>
   <body>
+    <a class="skip-link" href="#main">{copy.skipToContent}</a>
     <div class="page-shell">
       <Header locale={locale} variant={variant} showLanguage={alternateEntries.length > 1} />
-      <main><slot /></main>
+      <main id="main"><slot /></main>
       <footer>
         <span>{copy.footer.credit} <a href={repositoryUrl} target="_blank" rel="noreferrer">claude-codex-settings</a></span>
         <div>
@@ -114,7 +118,9 @@ const structuredData = pageGraph.length
         </div>
       </footer>
     </div>
+    <span class="sr-only" aria-live="polite" data-copy-announcement data-copied={copy.copied}></span>
     <script>
+      const announcement = document.querySelector<HTMLElement>("[data-copy-announcement]")!
       document.addEventListener("click", async (event) => {
         const button = (event.target as Element).closest<HTMLElement>("[data-copy], [data-copy-command]")
         if (!button) return
@@ -123,9 +129,11 @@ const structuredData = pageGraph.length
         await navigator.clipboard.writeText(text)
         button.classList.add("is-copied")
         if (label) label.textContent = "Copied"
+        announcement.textContent = announcement.dataset.copied!
         window.setTimeout(() => {
           button.classList.remove("is-copied")
           if (label) label.textContent = "Copy command"
+          announcement.textContent = ""
         }, 1200)
       })
     </script>

--- a/site/src/lib/i18n.ts
+++ b/site/src/lib/i18n.ts
@@ -9,6 +9,9 @@ export const translations = {
   en: {
     languageLabel: "简体中文",
     stars: "stars",
+    skipToContent: "Skip to main content",
+    copied: "Copied to clipboard",
+    primaryNav: "Primary navigation",
     footer: {
       credit: "Developed using web development plugins from",
       sitemap: "Sitemap",
@@ -78,7 +81,7 @@ export const translations = {
         ],
       },
       directory: {
-        search: "Search plugins and skills",
+        search: "Search plugins and skills…",
         available: "Available plugins",
         columns: ["#", "Plugin", "Description", "Supported tools", "Link"],
         view: "View plugin",
@@ -106,6 +109,9 @@ export const translations = {
   "zh-CN": {
     languageLabel: "English",
     stars: "个星标",
+    skipToContent: "跳到主要内容",
+    copied: "已复制到剪贴板",
+    primaryNav: "主导航",
     footer: {
       credit: "使用以下仓库中的网页开发插件构建：",
       sitemap: "网站地图",
@@ -167,7 +173,7 @@ export const translations = {
         ],
       },
       directory: {
-        search: "搜索插件和技能",
+        search: "搜索插件和技能…",
         available: "可用插件",
         columns: ["#", "插件", "说明", "支持的工具", "链接"],
         view: "查看插件",

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -14,13 +14,17 @@
 * { box-sizing: border-box; }
 html { scroll-behavior: smooth; }
 body { margin: 0; min-width: 320px; }
+[id] { scroll-margin-top: 24px; }
 a { color: inherit; text-decoration: none; }
+a, button { touch-action: manipulation; }
 button,
 input {
   font: inherit;
 }
 button { color: inherit; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.skip-link { position: absolute; top: 8px; left: 8px; z-index: 10; padding: 12px 18px; border-radius: 10px; background: var(--accent); color: var(--accent-text); font-weight: 700; transform: translateY(-200%); }
+.skip-link:focus-visible { transform: none; }
 .page-shell { width: min(100%, var(--page)); margin: 0 auto; padding: 0 var(--gutter); }
 
 .site-header {
@@ -31,11 +35,11 @@ button { color: inherit; }
   border-bottom: 1px solid var(--border);
 }
 .brand { font-size: 26px; font-weight: 760; letter-spacing: -0.035em; justify-self: start; }
-.site-header nav { display: flex; align-items: center; gap: clamp(28px, 4vw, 64px); }
-.site-header nav a { font-size: 16px; color: var(--muted); transition: color 160ms ease; }
+.site-header nav { display: flex; align-self: stretch; align-items: center; gap: clamp(28px, 4vw, 64px); }
+.site-header nav a { display: inline-flex; align-items: center; align-self: stretch; font-size: 16px; color: var(--muted); transition: color 160ms ease; }
 .site-header nav a:hover { color: var(--text); }
 .header-cta { justify-self: end; }
-.star-count { display: inline-flex; align-items: center; gap: 5px; padding-left: 11px; margin-left: 1px; border-left: 1px solid currentColor; font-size: 15px; font-variant-numeric: tabular-nums; opacity: .85; }
+.star-count { display: inline-flex; align-items: center; gap: 5px; padding-left: 11px; margin-left: 1px; border-left: 1px solid currentColor; font-size: 15px; font-variant-numeric: tabular-nums; }
 
 .button {
   min-height: 52px;
@@ -75,6 +79,7 @@ p {
 h1,
 h2 {
   letter-spacing: -0.052em;
+  text-wrap: balance;
 }
 h1 { font-size: clamp(46px, 4.5vw, 70px); line-height: 1.03; margin-bottom: 26px; }
 h2 { font-size: clamp(36px, 3.7vw, 56px); line-height: 1.05; margin-bottom: 20px; }
@@ -88,7 +93,7 @@ p { color: var(--muted); line-height: 1.55; }
   --muted: #3e4855;
   --border: #dbe0e6;
   --border-strong: #cdd5df;
-  --accent: #f05236;
+  --accent: #d63a1c;
   --accent-text: #fff;
   --link: #0759e6;
   background: var(--background);
@@ -128,7 +133,7 @@ p { color: var(--muted); line-height: 1.55; }
 .file-tree > p { margin: 0 8px 16px; color: #626c78; font: 700 12px/1 var(--mono); text-transform: uppercase; letter-spacing: .08em; }
 .tree-row { width: 100%; min-height: 38px; display: flex; align-items: center; gap: 8px; padding: 0 8px; border: 0; border-radius: 9px; background: transparent; text-align: left; font-size: 13px; white-space: nowrap; }
 button.tree-row { cursor: pointer; }
-.tree-row.is-active { background: #f0f3f7; color: var(--accent); }
+.tree-row.is-active { background: #f0f3f7; font-weight: 700; }
 .folder-row { padding-left: 4px; }
 .tree-file { padding-left: 38px; }
 .tree-caret { width: 10px; font-size: 17px; color: #5d6670; }
@@ -143,7 +148,7 @@ button.tree-row { cursor: pointer; }
 .code-panel code { display: block; min-width: max-content; font: 13px/24px var(--mono); color: #17202a; }
 .code-line { display: grid; grid-template-columns: 48px 1fr; padding-right: 20px; white-space: pre; }
 .code-line:hover { background: #f7f9fb; }
-.line-number { color: #8b96a3; text-align: right; padding-right: 16px; user-select: none; }
+.line-number { color: #667382; text-align: right; padding-right: 16px; user-select: none; }
 .terminal { grid-area: terminal; border-top: 1px solid var(--border); padding: 12px 14px 14px; }
 .terminal-label { margin: 0 0 10px 2px; font: 700 12px/1 var(--mono); color: #626c78; text-transform: uppercase; letter-spacing: .06em; }
 .terminal-body { height: 82px; display: flex; align-items: center; gap: 12px; padding: 0 18px; border-radius: 10px; background: #0e1217; color: #f7f9fb; overflow: hidden; }
@@ -384,13 +389,13 @@ button.tree-row { cursor: pointer; }
 .component-list dt {
   color: var(--muted);
 }
-.install-terminal-section > p .inline-link {
+.inline-link {
   color: var(--link);
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 4px;
 }
-.install-terminal-section > p .inline-link:hover {
+.inline-link:hover {
   color: var(--accent);
 }
 .install-tool-tabs {
@@ -736,7 +741,7 @@ button.tree-row { cursor: pointer; }
   color: var(--text);
 }
 [data-site="plugins"] .site-header nav a:first-child { color: var(--text); position: relative; }
-[data-site="plugins"] .site-header nav a:first-child::after { content: ""; position: absolute; left: 0; right: 0; bottom: -35px; height: 3px; background: var(--accent); }
+[data-site="plugins"] .site-header nav a:first-child::after { content: ""; position: absolute; left: 0; right: 0; bottom: 0; height: 3px; background: var(--accent); }
 .plugins-hero { padding: 58px 0 74px; border-bottom: 1px solid var(--border); }
 .plugins-intro { text-align: center; margin-bottom: 30px; }
 .plugins-intro h1 { margin-bottom: 16px; }
@@ -792,7 +797,7 @@ button.tree-row { cursor: pointer; }
 .install-content { min-height: 330px; padding: 24px 22px 34px; }
 .install-content > p { max-width: 360px; }
 .command-block { margin: 22px 0; }
-.command-label { display: block; color: var(--muted); font: 600 11px var(--mono); letter-spacing: .05em; text-transform: uppercase; opacity: .62; }
+.command-label { display: block; color: var(--muted); font: 600 11px var(--mono); letter-spacing: .05em; text-transform: uppercase; }
 .command-line { display: flex; align-items: center; gap: 12px; margin: 9px 0 0; padding: 12px 12px 12px 16px; border: 1px solid var(--border); border-radius: 12px; background: #080c11; }
 .command-line code { min-width: 0; color: var(--accent); font: 11px/1.5 var(--mono); letter-spacing: -.025em; overflow-wrap: anywhere; }
 .install-note { font-size: 13px; }
@@ -807,8 +812,11 @@ footer a:hover { color: var(--text); }
 .social-link { display: inline-flex; color: var(--muted); transition: color 160ms ease; }
 
 @media (max-width: 1100px) {
-  .site-header { grid-template-columns: 1fr auto; }
-  .site-header nav { display: none; }
+  .site-header { height: auto; grid-template-columns: 1fr auto; grid-template-areas: "brand actions" "nav nav"; row-gap: 4px; padding-block: 14px; }
+  .brand { grid-area: brand; }
+  .header-actions { grid-area: actions; }
+  .site-header nav { grid-area: nav; gap: clamp(18px, 5vw, 40px); overflow-x: auto; }
+  .site-header nav a { padding-block: 8px; font-size: 15px; white-space: nowrap; }
   .settings-hero { grid-template-columns: 1fr; padding-top: 70px; }
   .hero-copy { max-width: 780px; }
   .editor { height: 620px; }
@@ -830,7 +838,6 @@ footer a:hover { color: var(--text); }
 
 @media (max-width: 760px) {
   :root { --gutter: 20px; --radius: 15px; }
-  .site-header { height: 76px; }
   .brand { font-size: 21px; }
   .header-cta { min-height: 44px; padding: 0 14px; }
   .cta-label { display: none; }
@@ -988,5 +995,7 @@ footer a:hover { color: var(--text); }
   *::before,
   *::after {
     transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }


### PR DESCRIPTION
A web-interface-guidelines review of both site variants found one broken feature and a set of accessibility gaps, all verified end to end in the browser on desktop and mobile for both variants plus zh-cn.

- The install terminal demo on every plugin page was frozen: the script queried `[data-install-copy]`, an attribute no element has, and crashed before the first frame. Now wired to the existing `[data-copy]` button.
- Primary navigation was `display: none` below 1100px with no replacement, so the header now wraps it onto a second row on small screens (before/after below).
- Contrast failures fixed by darkening the settings accent from `#f05236` to `#d63a1c` and dropping low-opacity text tweaks: axe-core WCAG AA audits now report 0 violations on all 6 page types checked.
- Added a skip-to-content link, a localized aria-live announcement for copy buttons, and localized the nav label (the previous hardcoded English showed on zh-cn pages).
- Smaller fixes: `/` search shortcut no longer swallows Cmd+/, search input got a `name` and `…` placeholder, reduced-motion now also stops keyframe animations, headings use `text-wrap: balance`, and the plugins nav underline lost its `-35px` magic offset.

Mobile before/after, settings and plugins:

| Before | After |
| --- | --- |
| ![before settings](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.7.1/before-settings-mobile.png) | ![after settings](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.7.1/after-settings-mobile.png) |
| ![before plugins](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.7.1/before-plugins-mobile.png) | ![after plugins](https://github.com/fcakyon/claude-codex-settings/releases/download/v2.7.1/after-plugins-mobile.png) |
